### PR TITLE
v4.2.10 rev12

### DIFF
--- a/source/Grabacr07.KanColleViewer/KanColleViewer.csproj
+++ b/source/Grabacr07.KanColleViewer/KanColleViewer.csproj
@@ -135,6 +135,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime.Remoting" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\LivetCask.1.3.1.0\lib\net45\System.Windows.Interactivity.dll</HintPath>
       <Private>True</Private>
@@ -209,6 +210,7 @@
     <Compile Include="Models\Migration\_KanColleClientSettings.cs" />
     <Compile Include="ViewModels\AkashiTimerViewModel.cs" />
     <Compile Include="ViewModels\Catalogs\CalculatorViewModel.cs" />
+    <Compile Include="ViewModels\Catalogs\DictionaryViewModel.cs" />
     <Compile Include="ViewModels\Catalogs\ExpeditionsCatalogWindowViewModel.cs" />
     <Compile Include="ViewModels\Catalogs\NeedNdockShipCatalogWindowViewModel.cs" />
     <Compile Include="ViewModels\Catalogs\NotePadViewModel.cs" />
@@ -293,6 +295,9 @@
     </Compile>
     <Compile Include="Views\Catalogs\Calculator.xaml.cs">
       <DependentUpon>Calculator.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Views\Catalogs\DictionaryWindow.xaml.cs">
+      <DependentUpon>DictionaryWindow.xaml</DependentUpon>
     </Compile>
     <Compile Include="Views\Catalogs\ExpeditionsCatalogWindow.xaml.cs">
       <DependentUpon>ExpeditionsCatalogWindow.xaml</DependentUpon>
@@ -468,6 +473,10 @@
     <Page Include="Views\Catalogs\Calculator.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Views\Catalogs\DictionaryWindow.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Views\Catalogs\ExpeditionsCatalogWindow.xaml">
       <Generator>MSBuild:Compile</Generator>

--- a/source/Grabacr07.KanColleViewer/Models/GCWorker.cs
+++ b/source/Grabacr07.KanColleViewer/Models/GCWorker.cs
@@ -12,17 +12,26 @@ namespace Grabacr07.KanColleViewer.Models
 		[DllImport("kernel32.dll", EntryPoint = "SetProcessWorkingSetSize", SetLastError = true, CallingConvention = CallingConvention.StdCall)]
 		private static extern bool SetProcessWorkingSetSize(IntPtr proc, int min, int max);
 
+		public enum GCType
+		{
+			GCAll,
+			GCOptimized
+		}
+
 		private bool GCWorking { get; set; } = false;
 		private Thread GCThread { get; }
 
 		private int GCCount => KanColleSettings.MemoryOptimizePeriod;
 
-		private static bool GCRequested { get; set; } = false;
-		private static int GCGen { get; set; } = -1;
-		public static void GCRequest(int gen = -1)
+		private static bool _GCRequested { get; set; } = false;
+		private static int _GCGen { get; set; } = -1;
+		private static GCType _GCType { get; set; } = GCType.GCOptimized;
+
+		public static void GCRequest(int gen = -1, GCType type = GCType.GCOptimized)
 		{
-			GCWorker.GCRequested = true;
-			GCWorker.GCGen = gen;
+			GCWorker._GCRequested = true;
+			GCWorker._GCGen = gen;
+			GCWorker._GCType = type;
 		}
 
 		public GCWorker()
@@ -36,10 +45,10 @@ namespace Grabacr07.KanColleViewer.Models
 					if (!GCWorking) break;
 
 					cnt--;
-					if (cnt == 0 || GCWorker.GCRequested)
+					if (cnt == 0 || GCWorker._GCRequested)
 					{
 						cnt = GCCount;
-						this.Collect(GCWorker.GCGen);
+						this.Collect(GCWorker._GCGen, GCWorker._GCType);
 					}
 				}
 			});
@@ -50,15 +59,15 @@ namespace Grabacr07.KanColleViewer.Models
 			GCThread.Start();
 		}
 
-		private void Collect(int gen = -1)
+		private void Collect(int gen = -1, GCType type = GCType.GCOptimized)
 		{
 			if (gen == -1) gen = GC.MaxGeneration;
 
 			// GC 가 Request 되었다면 예외적으로 수행
-			if (!KanColleSettings.UseMemoryOptimize && !GCWorker.GCRequested) return;
-			GCWorker.GCRequested = false;
+			if (!KanColleSettings.UseMemoryOptimize && !GCWorker._GCRequested) return;
+			GCWorker._GCRequested = false;
 
-			GC.Collect(gen, GCCollectionMode.Optimized);
+			GC.Collect(gen, type == GCType.GCOptimized ? GCCollectionMode.Optimized : GCCollectionMode.Forced);
 			GC.WaitForPendingFinalizers();
 
 			if (Environment.OSVersion.Platform == PlatformID.Win32NT)

--- a/source/Grabacr07.KanColleViewer/Models/ShipCondition.cs
+++ b/source/Grabacr07.KanColleViewer/Models/ShipCondition.cs
@@ -23,7 +23,7 @@ namespace Grabacr07.KanColleViewer.Models
 				{
 					this._Remaining = value;
 					this.RaisePropertyChanged();
-					this.RaisePropertyChanged("ConditionText");
+					this.RaisePropertyChanged(nameof(this.ConditionText));
 				}
 			}
 		}

--- a/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
@@ -15,4 +15,4 @@ using System.Windows;
 	ResourceDictionaryLocation.None,
 	ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("4.2.10.11")]
+[assembly: AssemblyVersion("4.2.10.12")]

--- a/source/Grabacr07.KanColleViewer/ViewModels/Catalogs/DictionaryViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/Catalogs/DictionaryViewModel.cs
@@ -94,6 +94,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 		}
 	}
 
+	#region For Ship Dictionary Tab
 	public class DictionaryShipViewModel : TabItemViewModel
 	{
 		public override string Name
@@ -124,22 +125,46 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 		{
 			this.ShipList = KanColleClient.Current.Master.Ships
 				.OrderBy(x => x.Value.Id)
-				.Select(x => new ShipItemViewModel(x.Value))
+				.Select(x => new ShipItemViewModel(this, x.Value))
 				.ToArray();
 		}
 	}
 
 	public class ShipItemViewModel : TabItemViewModel
 	{
+		private DictionaryShipViewModel Parent { get; }
+
 		public override string Name
 		{
 			get { return _Name; }
 			protected set { throw new NotImplementedException(); }
 		}
 		public string Id => this._Id;
+		public string ShipType => this._ShipType;
+
+		#region Level
+		private int _Level { get; set; } = 1;
+		public int Level
+		{
+			get { return _Level; }
+			set
+			{
+				if (this._Level != value)
+				{
+					this._Level = value;
+					this.RaisePropertyChanged();
+					this.RaisePropertyChanged(nameof(this.Marriaged));
+					this.UpdateAllValues();
+				}
+			}
+		}
+		#endregion
+
+		public bool Marriaged => this.Level > 99;
 
 		private string _Name { get; set; }
 		private string _Id { get; set; }
+		private string _ShipType { get; set; }
 
 		public KanColleWrapper.Models.ShipInfo Ship { get; }
 
@@ -150,13 +175,74 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 			);
 
 		#region Status
+		public int MarriageHP
+		{
+			get
+			{
+				var id = this.Ship?.Id ?? -1;
+				if (id <= 0) return 0;
+
+				switch (id)
+				{
+					case 171: // Bismarck
+						return 6;
+					case 172: // Bismarck改
+						return 5;
+					case 173: // Bismarck zwei
+					case 178: // Bismarck drei
+						return 3;
+
+					case 131: // 大和
+						return 5;
+					case 143: // 武蔵
+						return 4;
+
+					case 441: // Italia
+					case 442: // Roma
+						return 6;
+
+					case 352: // 速吸改
+						return 2;
+				}
+
+				if (this.HP >= 91) // 91 ~
+					return 9;
+				else if (this.HP >= 70) // 70 ~ 90
+					return 8;
+				else if (this.HP >= 50) // 50 ~ 69
+					return 7;
+				else if (this.HP >= 40) // 40 ~ 49
+					return 6;
+				else if (this.HP >= 30) // 30 ~ 39
+					return 5;
+				else if (this.HP >= 8) // 8 ~ 29
+					return 4;
+				else if (this.HP >= 6) // 6 ~ 7 (まるゆ)
+					return 3;
+
+				return 0;
+			}
+		}
+		public int MarriageHPResult
+			=> this.Marriaged ? this.MarriageHP : 0;
+
 		public int HP => this.Ship?.RawData.api_taik?[0] ?? -1;
+		public int CurHP => this.HP == -1 ? -1
+			: this.HP + (this.Marriaged ? this.MarriageHP : 0);
 
 		public int MinArmor => this.Ship?.RawData.api_souk?[0] ?? -1;
 		public int MaxArmor => this.Ship?.RawData.api_souk?[1] ?? -1;
+		public int CurArmor => this.Level == 1 ? this.MinArmor
+			: this.Level == 99 ? (int)Math.Floor(0.4 * (this.MaxArmor - this.MinArmor)) + this.MinArmor
+			: this.MinArmor == -1 || this.MaxArmor == -1 ? -1
+			: (int)Math.Floor((double)(this.MaxArmor - this.MinArmor) * this.Level / 99 * 0.4 + this.MinArmor);
 
 		public int MinEvasion => DictionaryViewModel.shipInfos.FirstOrDefault(x => x.id == (this.Ship?.Id ?? 0))?.stat.evasion ?? -1;
 		public int MaxEvasion => DictionaryViewModel.shipInfos.FirstOrDefault(x => x.id == (this.Ship?.Id ?? 0))?.stat.evasion_max ?? -1;
+		public int CurEvasion => this.Level == 1 ? this.MinEvasion
+			: this.Level == 99 ? this.MaxEvasion
+			: this.MinEvasion == -1 || this.MaxEvasion == -1 ? -1
+			: (int)Math.Floor((double)(this.MaxEvasion - this.MinEvasion) * this.Level / 99 + this.MinEvasion);
 
 		public int TotalCarry => this.Ship?.RawData.api_maxeq?.Sum() ?? -1;
 
@@ -164,15 +250,31 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 
 		public int MinFire => this.Ship?.RawData.api_houg?[0] ?? -1;
 		public int MaxFire => this.Ship?.RawData.api_houg?[1] ?? -1;
+		public int CurFire => this.Level == 1 ? this.MinFire
+			: this.Level == 99 ? (int)Math.Floor(0.4 * (this.MaxFire - this.MinFire)) + this.MinFire
+			: this.MinFire == -1 || this.MaxFire == -1 ? -1
+			: (int)Math.Floor((double)(this.MaxFire - this.MinFire) * this.Level / 99 * 0.4 + this.MinFire);
 
 		public int MinTorpedo => this.Ship?.RawData.api_raig?[0] ?? -1;
 		public int MaxTorpedo => this.Ship?.RawData.api_raig?[1] ?? -1;
+		public int CurTorpedo => this.Level == 1 ? this.MinTorpedo
+			: this.Level == 99 ? (int)Math.Floor(0.4 * (this.MaxTorpedo - this.MinTorpedo)) + this.MinTorpedo
+			: this.MinTorpedo == -1 || this.MaxTorpedo == -1 ? -1
+			: (int)Math.Floor((double)(this.MaxTorpedo - this.MinTorpedo) * this.Level / 99 * 0.4 + this.MinTorpedo);
 
 		public int MinAA => this.Ship?.RawData.api_taik?[0] ?? -1;
 		public int MaxAA => this.Ship?.RawData.api_taik?[1] ?? -1;
+		public int CurAA => this.Level == 1 ? this.MinAA
+			: this.Level == 99 ? (int)Math.Floor(0.4 * (this.MaxAA - this.MinAA)) + this.MinAA
+			: this.MinAA == -1 || this.MaxAA == -1 ? -1
+			: (int)Math.Floor((double)(this.MaxAA - this.MinAA) * this.Level / 99 * 0.4 + this.MinAA);
 
 		public int MinASW => DictionaryViewModel.shipInfos.FirstOrDefault(x => x.id == (this.Ship?.Id ?? 0))?.stat.asw ?? -1;
 		public int MaxASW => DictionaryViewModel.shipInfos.FirstOrDefault(x => x.id == (this.Ship?.Id ?? 0))?.stat.asw_max ?? -1;
+		public int CurASW => this.Level == 1 ? this.MinASW
+			: this.Level == 99 ? this.MaxASW
+			: this.MinASW == -1 || this.MaxASW == -1 ? -1
+			: (int)Math.Floor((double)(this.MaxASW - this.MinASW) * this.Level / 99 + this.MinASW);
 
 		///////////////////
 
@@ -195,14 +297,74 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 
 		public int MinLOS => DictionaryViewModel.shipInfos.FirstOrDefault(x => x.id == (this.Ship?.Id ?? 0))?.stat.los ?? -1;
 		public int MaxLOS => DictionaryViewModel.shipInfos.FirstOrDefault(x => x.id == (this.Ship?.Id ?? 0))?.stat.los_max ?? -1;
+		public int CurLOS => this.Level == 1 ? this.MinLOS
+			: this.Level == 99 ? this.MaxLOS
+			: this.MinLOS == -1 || this.MaxLOS == -1 ? -1
+			: (int)Math.Floor((double)(this.MaxLOS - this.MinLOS) * this.Level / 99 + this.MinLOS);
 
 		public int MinLuck => this.Ship?.RawData.api_luck?[0] ?? -1;
 		public int MaxLuck => this.Ship?.RawData.api_luck?[1] ?? -1;
+		public int CurLuck => this.MinLuck == -1 ? -1
+			: this.MinLuck + (this.Marriaged ? 3 : 0);
 
 		///////////////////
 
 		public int MaxFuel => this.Ship?.RawData.api_fuel_max ?? -1;
 		public int MaxAmmo => this.Ship?.RawData.api_bull_max ?? -1;
+
+		public string CurMaxFuel => this.Marriaged
+			? Math.Floor(this.MaxFuel * 0.85) + " (-15%)"
+			: this.MaxFuel.ToString();
+		public string CurMaxAmmo => this.Marriaged
+			? Math.Floor(this.MaxAmmo * 0.85) + " (-15%)"
+			: this.MaxAmmo.ToString();
+
+		private void UpdateAllValues()
+		{
+			this.RaisePropertyChanged(nameof(this.MarriageHP));
+			this.RaisePropertyChanged(nameof(this.MarriageHPResult));
+
+			this.RaisePropertyChanged(nameof(this.HP));
+			this.RaisePropertyChanged(nameof(this.CurHP));
+
+			this.RaisePropertyChanged(nameof(this.MinArmor));
+			this.RaisePropertyChanged(nameof(this.MaxArmor));
+			this.RaisePropertyChanged(nameof(this.CurArmor));
+
+			this.RaisePropertyChanged(nameof(this.MinEvasion));
+			this.RaisePropertyChanged(nameof(this.MaxEvasion));
+			this.RaisePropertyChanged(nameof(this.CurEvasion));
+
+			this.RaisePropertyChanged(nameof(this.MinFire));
+			this.RaisePropertyChanged(nameof(this.MaxFire));
+			this.RaisePropertyChanged(nameof(this.CurFire));
+
+			this.RaisePropertyChanged(nameof(this.MinTorpedo));
+			this.RaisePropertyChanged(nameof(this.MaxTorpedo));
+			this.RaisePropertyChanged(nameof(this.CurTorpedo));
+
+			this.RaisePropertyChanged(nameof(this.MinAA));
+			this.RaisePropertyChanged(nameof(this.MaxAA));
+			this.RaisePropertyChanged(nameof(this.CurAA));
+
+			this.RaisePropertyChanged(nameof(this.MinASW));
+			this.RaisePropertyChanged(nameof(this.MaxASW));
+			this.RaisePropertyChanged(nameof(this.CurASW));
+
+			this.RaisePropertyChanged(nameof(this.MinLOS));
+			this.RaisePropertyChanged(nameof(this.MaxLOS));
+			this.RaisePropertyChanged(nameof(this.CurLOS));
+
+			this.RaisePropertyChanged(nameof(this.MinLuck));
+			this.RaisePropertyChanged(nameof(this.MaxLuck));
+			this.RaisePropertyChanged(nameof(this.CurLuck));
+
+			this.RaisePropertyChanged(nameof(this.MaxFuel));
+			this.RaisePropertyChanged(nameof(this.CurMaxFuel));
+
+			this.RaisePropertyChanged(nameof(this.MaxAmmo));
+			this.RaisePropertyChanged(nameof(this.CurMaxAmmo));
+		}
 		#endregion
 
 		// Equipment
@@ -232,18 +394,17 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 					})
 					.Select((x, z) => {
 						int id;
-						if (!int.TryParse(x, out id)) return new SlotInfo(null, false, 0);
-
+						if (!int.TryParse(x, out id)) return new SlotInfo(SlotItemInfo.Dummy, true, this.Ship?.Slots[z] ?? -1);
 						var master = KanColleClient.Current.Master;
 						var item = master.SlotItems.FirstOrDefault(y => y.Value.Id == id).Value;
-						if (item == null) return new SlotInfo(null, false, 0);
+						if (item == null) return new SlotInfo(SlotItemInfo.Dummy, true, this.Ship?.Slots[z] ?? -1);
 
 						return new SlotInfo(item, true, this.Ship?.Slots[z] ?? -1);
 					})
 					.ToList();
 
 				while (list.Count < (this.Ship?.SlotCount ?? 0))
-					list.Add(new SlotInfo(null, true, this.Ship?.Slots[list.Count] ?? -1));
+					list.Add(new SlotInfo(SlotItemInfo.Dummy, true, this.Ship?.Slots[list.Count] ?? -1));
 
 				while (list.Count < 4) list.Add(new SlotInfo(null, false, 0));
 
@@ -263,11 +424,58 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 		public int DestroyBauxite => this.Ship?.RawData.api_broken?[3] ?? 0;
 		#endregion
 
-		public ShipItemViewModel(KanColleWrapper.Models.ShipInfo ShipData)
+		#region Upgrade Information
+		public IEnumerable<UpgradeInfo> Upgrades { get; set; }
+		#endregion
+
+		public ShipItemViewModel(DictionaryShipViewModel parent, KanColleWrapper.Models.ShipInfo ShipData)
 		{
+			this.Parent = parent;
+
 			this.Ship = ShipData;
 			this._Name = this.Ship?.Name ?? "???";
 			this._Id = this.Ship?.Id.ToString() ?? "???";
+			this._ShipType = this.Ship?.ShipType.Name ?? "???";
+
+			if (this.Ship == null) this.Upgrades = new UpgradeInfo[0];
+			else
+			{
+				// Find root
+				var master = KanColleClient.Current.Master;
+				var root = this.Ship;
+
+				while (master.Ships.Any(x => x.Value.RawData.api_aftershipid == root.Id.ToString()))
+					root = master.Ships.FirstOrDefault(x => x.Value.RawData.api_aftershipid == root.Id.ToString()).Value;
+
+				List<UpgradeInfo> list = new List<UpgradeInfo>();
+				var reqLv = 1;
+
+				while (!list.Any(x => x.Id == root.Id))
+				{
+					bool NeedPaper, NeedCatapult;
+					NeedPaper = master.RawData.api_mst_shipupgrade
+						.FirstOrDefault(x => x.api_id == root.Id)
+						?.api_drawing_count > 0;
+					NeedCatapult = master.RawData.api_mst_shipupgrade
+						.FirstOrDefault(x => x.api_id == root.Id)
+						?.api_catapult_count > 0;
+
+					list.Add(new UpgradeInfo(this, root, reqLv, NeedPaper, NeedCatapult));
+					if (!root.RemodelingExists) break;
+
+					int after;
+					if (!int.TryParse(root.RawData.api_aftershipid, out after)) break;
+					if (after == 0) break;
+
+					reqLv = root.NextRemodelingLevel ?? 1;
+					root = master.Ships.FirstOrDefault(x => x.Value.Id == after).Value;
+				}
+				this.Upgrades = list.ToArray();
+			}
+		}
+		public void SetShip(int ShipId)
+		{
+			this.Parent.SelectedShip = this.Parent.ShipList.FirstOrDefault(x => x.Ship?.Id == ShipId) ?? this;
 		}
 	}
 	public class SlotInfo
@@ -283,6 +491,45 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 			this.Carry = Carry;
 		}
 	}
+	public class UpgradeInfo
+	{
+		private ShipItemViewModel Parent { get; }
+
+		public int Id { get; }
+		public int RequiredLevel { get; }
+		public string Name { get; }
+		public string Requires { get; }
+
+		public string BadgeImage =>
+			string.Format(
+				"http://wolfgangkurz.github.io/KanColleAssets/ships/{0}/1.png",
+				DictionaryViewModel.shipGraphics.FirstOrDefault(x => x.api_id == this.Id)?.api_filename ?? "none"
+			);
+
+		public UpgradeInfo(ShipItemViewModel parent, KanColleWrapper.Models.ShipInfo ShipData, int Level, bool NeedPaper = false, bool NeedCatapult = false)
+		{
+			this.Parent = parent;
+
+			if (ShipData == null) return;
+
+			this.Id = ShipData.Id;
+			this.RequiredLevel = Level;
+			this.Name = ShipData?.Name ?? "???";
+
+			this.Requires = string.Join(
+				", ",
+				new string[]
+				{
+					NeedPaper ? "개장설계도" : "",
+					NeedCatapult ? "캐터펄트" : ""
+				}.Where(x => x.Length > 0).ToArray()
+			);
+		}
+
+		public void SetShip(int ShipId)
+			=> this.Parent.SetShip(ShipId);
+	}
+	#endregion
 
 	#region Raw Models
 	// ReSharper disable InconsistentNaming

--- a/source/Grabacr07.KanColleViewer/ViewModels/Catalogs/DictionaryViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/Catalogs/DictionaryViewModel.cs
@@ -1,0 +1,311 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Net.Http;
+using System.Text;
+using System.IO;
+using System.Runtime.Serialization.Json;
+using System.Threading;
+using Livet.EventListeners;
+using MetroTrilithon.Mvvm;
+
+using Grabacr07.KanColleViewer.Models;
+
+using Grabacr07.KanColleWrapper.Models.Raw;
+using Grabacr07.KanColleWrapper.Models;
+using Grabacr07.KanColleWrapper;
+
+namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
+{
+	public class DictionaryViewModel : WindowViewModel
+	{
+		internal static IEnumerable<kcsapi_mst_shipgraph> shipGraphics
+			=> KanColleClient.Current.Master.RawData?.api_mst_shipgraph ?? new kcsapi_mst_shipgraph[0];
+
+		internal static IEnumerable<ships_nedb> shipInfos { get; private set; }
+			= new ships_nedb[0];
+
+		static DictionaryViewModel()
+		{
+			new Thread(async () =>
+			{
+				using (var client = new HttpClient())
+				{
+					try
+					{
+						var response = await client.GetAsync("https://raw.githubusercontent.com/Diablohu/WhoCallsTheFleet/master/app-db/ships.nedb");
+						if (!response.IsSuccessStatusCode) return;
+
+						var json = await response.Content.ReadAsStringAsync();
+						var lines = json.Split(new char[] { '\r', '\n' }).Where(x => x.Length > 0);
+
+						List<ships_nedb> infoList = new List<ships_nedb>();
+
+						foreach (var line in lines)
+						{
+							var bytes = Encoding.UTF8.GetBytes(line);
+
+							DataContractJsonSerializerSettings settings = new DataContractJsonSerializerSettings();
+							settings.UseSimpleDictionaryFormat = true;
+
+							var serializer = new DataContractJsonSerializer(typeof(ships_nedb), settings);
+							using (var stream = new MemoryStream(bytes))
+							{
+								var rawResult = serializer.ReadObject(stream) as ships_nedb;
+								infoList.Add(rawResult);
+							}
+						}
+
+						shipInfos = infoList.ToArray();
+					}
+					catch (HttpRequestException) { return; }
+				}
+			}).Start();
+		}
+
+
+		public IList<TabItemViewModel> TabItems { get; set; } = new TabItemViewModel[0]; // Empty List
+
+		private TabItemViewModel _SelectedItem = null;
+		public TabItemViewModel SelectedItem
+		{
+			get { return this._SelectedItem; }
+			set
+			{
+				if (this._SelectedItem != value)
+				{
+					this._SelectedItem = value;
+					this.RaisePropertyChanged();
+				}
+			}
+		}
+
+		public DictionaryViewModel()
+		{
+			this.Title = "데이터 사전";
+
+			this.TabItems = new List<TabItemViewModel>
+			{
+				new DictionaryShipViewModel().AddTo(this),
+			};
+			this.SelectedItem = this.TabItems.FirstOrDefault();
+		}
+	}
+
+	public class DictionaryShipViewModel : TabItemViewModel
+	{
+		public override string Name
+		{
+			get { return "칸무스"; }
+			protected set { throw new NotImplementedException(); }
+		}
+
+		#region Tab (List)
+		public IList<ShipItemViewModel> ShipList { get; set; }
+
+		private ShipItemViewModel _SelectedShip;
+		public ShipItemViewModel SelectedShip
+		{
+			get { return this._SelectedShip; }
+			set
+			{
+				if (this._SelectedShip != value)
+				{
+					this._SelectedShip = value;
+					this.RaisePropertyChanged();
+				}
+			}
+		}
+		#endregion
+
+		public DictionaryShipViewModel()
+		{
+			this.ShipList = KanColleClient.Current.Master.Ships
+				.OrderBy(x => x.Value.Id)
+				.Select(x => new ShipItemViewModel(x.Value))
+				.ToArray();
+		}
+	}
+
+	public class ShipItemViewModel : TabItemViewModel
+	{
+		public override string Name
+		{
+			get { return _Name; }
+			protected set { throw new NotImplementedException(); }
+		}
+		public string Id => this._Id;
+
+		private string _Name { get; set; }
+		private string _Id { get; set; }
+
+		public KanColleWrapper.Models.ShipInfo Ship { get; }
+
+		public string BadgeImage =>
+			string.Format(
+				"http://wolfgangkurz.github.io/KanColleAssets/ships/{0}/1.png",
+				DictionaryViewModel.shipGraphics.FirstOrDefault(x => x.api_id == (this.Ship?.Id ?? 0))?.api_filename ?? "none"
+			);
+
+		#region Status
+		public int HP => this.Ship?.RawData.api_taik?[0] ?? -1;
+
+		public int MinArmor => this.Ship?.RawData.api_souk?[0] ?? -1;
+		public int MaxArmor => this.Ship?.RawData.api_souk?[1] ?? -1;
+
+		public int MinEvasion => DictionaryViewModel.shipInfos.FirstOrDefault(x => x.id == (this.Ship?.Id ?? 0))?.stat.evasion ?? -1;
+		public int MaxEvasion => DictionaryViewModel.shipInfos.FirstOrDefault(x => x.id == (this.Ship?.Id ?? 0))?.stat.evasion_max ?? -1;
+
+		public int TotalCarry => this.Ship?.RawData.api_maxeq?.Sum() ?? -1;
+
+		///////////////////
+
+		public int MinFire => this.Ship?.RawData.api_houg?[0] ?? -1;
+		public int MaxFire => this.Ship?.RawData.api_houg?[1] ?? -1;
+
+		public int MinTorpedo => this.Ship?.RawData.api_raig?[0] ?? -1;
+		public int MaxTorpedo => this.Ship?.RawData.api_raig?[1] ?? -1;
+
+		public int MinAA => this.Ship?.RawData.api_taik?[0] ?? -1;
+		public int MaxAA => this.Ship?.RawData.api_taik?[1] ?? -1;
+
+		public int MinASW => DictionaryViewModel.shipInfos.FirstOrDefault(x => x.id == (this.Ship?.Id ?? 0))?.stat.asw ?? -1;
+		public int MaxASW => DictionaryViewModel.shipInfos.FirstOrDefault(x => x.id == (this.Ship?.Id ?? 0))?.stat.asw_max ?? -1;
+
+		///////////////////
+
+		public ShipSpeed Speed => ShipSpeedConverter.FromInt32(this.Ship?.RawData.api_soku ?? 0);
+		public string SpeedText
+			=> this.Speed == ShipSpeed.Immovable ? "육상기지"
+				: this.Speed == ShipSpeed.Slow ? "저속"
+				: this.Speed == ShipSpeed.Fast ? "고속"
+				: this.Speed == ShipSpeed.Faster ? "고속+"
+				: this.Speed == ShipSpeed.Fastest ? "초고속"
+				: "???";
+
+		public int Range => this.Ship?.RawData.api_leng ?? -1;
+		public string RangeText
+			=> this.Range == 1 ? "단거리"
+				: this.Range == 2 ? "중거리"
+				: this.Range == 3 ? "장거리"
+				: this.Range == 4 ? "최장거리"
+				: "???";
+
+		public int MinLOS => DictionaryViewModel.shipInfos.FirstOrDefault(x => x.id == (this.Ship?.Id ?? 0))?.stat.los ?? -1;
+		public int MaxLOS => DictionaryViewModel.shipInfos.FirstOrDefault(x => x.id == (this.Ship?.Id ?? 0))?.stat.los_max ?? -1;
+
+		public int MinLuck => this.Ship?.RawData.api_luck?[0] ?? -1;
+		public int MaxLuck => this.Ship?.RawData.api_luck?[1] ?? -1;
+
+		///////////////////
+
+		public int MaxFuel => this.Ship?.RawData.api_fuel_max ?? -1;
+		public int MaxAmmo => this.Ship?.RawData.api_bull_max ?? -1;
+		#endregion
+
+		// Equipment
+		public IList<SlotInfo> Slots
+		{
+			get
+			{
+				var list = new List<SlotInfo>();
+
+				var info = DictionaryViewModel.shipInfos.FirstOrDefault(x => x.id == (this.Ship?.Id ?? 0));
+				if (info == null)
+				{
+					while (list.Count < (this.Ship?.SlotCount ?? 0))
+						list.Add(new SlotInfo(null, true, this.Ship?.Slots?[list.Count] ?? -1));
+
+					while (list.Count < 4) list.Add(new SlotInfo(null, false, 0));
+
+					return list;
+				}
+
+				list = info.equip
+					.Where(x =>
+					{
+						int id;
+						if (x == null || x.Length == 0) return false;
+						return int.TryParse(x, out id);
+					})
+					.Select((x, z) => {
+						int id;
+						if (!int.TryParse(x, out id)) return new SlotInfo(null, false, 0);
+
+						var master = KanColleClient.Current.Master;
+						var item = master.SlotItems.FirstOrDefault(y => y.Value.Id == id).Value;
+						if (item == null) return new SlotInfo(null, false, 0);
+
+						return new SlotInfo(item, true, this.Ship?.Slots[z] ?? -1);
+					})
+					.ToList();
+
+				while (list.Count < (this.Ship?.SlotCount ?? 0))
+					list.Add(new SlotInfo(null, true, this.Ship?.Slots[list.Count] ?? -1));
+
+				while (list.Count < 4) list.Add(new SlotInfo(null, false, 0));
+
+				return list;
+			}
+		}
+
+		#region Modernize & Destroy
+		public int ModernizeFire => this.Ship?.RawData.api_powup?[0] ?? 0;
+		public int ModernizeTorpedo => this.Ship?.RawData.api_powup?[1] ?? 0;
+		public int ModernizeAA => this.Ship?.RawData.api_powup?[2] ?? 0;
+		public int ModernizeArmor => this.Ship?.RawData.api_powup?[3] ?? 0;
+
+		public int DestroyFuel => this.Ship?.RawData.api_broken?[0] ?? 0;
+		public int DestroyAmmo => this.Ship?.RawData.api_broken?[1] ?? 0;
+		public int DestroySteel => this.Ship?.RawData.api_broken?[2] ?? 0;
+		public int DestroyBauxite => this.Ship?.RawData.api_broken?[3] ?? 0;
+		#endregion
+
+		public ShipItemViewModel(KanColleWrapper.Models.ShipInfo ShipData)
+		{
+			this.Ship = ShipData;
+			this._Name = this.Ship?.Name ?? "???";
+			this._Id = this.Ship?.Id.ToString() ?? "???";
+		}
+	}
+	public class SlotInfo
+	{
+		public SlotItemInfo Info { get; set; }
+		public bool Available { get; set; }
+		public int Carry { get; set; }
+
+		public SlotInfo(SlotItemInfo Info, bool Available, int Carry)
+		{
+			this.Info = Info;
+			this.Available = Available;
+			this.Carry = Carry;
+		}
+	}
+
+	#region Raw Models
+	// ReSharper disable InconsistentNaming
+	public class ships_nedb
+	{
+		public int id { get; set; }
+		public int no { get; set; }
+
+		public ships_nedb_stat stat { get; set; }
+		public int[] slot { get; set; }
+		public string[] equip { get; set; }
+	}
+	public class ships_nedb_stat
+	{
+		public int evasion { get; set; }
+		public int evasion_max { get; set; }
+
+		public int asw { get; set; }
+		public int asw_max { get; set; }
+
+		public int los { get; set; }
+		public int los_max { get; set; }
+	}
+	// ReSharper restore InconsistentNaming
+	#endregion
+}

--- a/source/Grabacr07.KanColleViewer/ViewModels/Contents/Fleets/CombinedFleetViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/Contents/Fleets/CombinedFleetViewModel.cs
@@ -25,13 +25,9 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents.Fleets
 		/// 艦隊に所属している艦娘のコレクションを取得します。
 		/// </summary>
 		public FleetViewModel[] Fleets
-		{
-			get
-			{
-				FleetViewModel[] temps = this.Source.Fleets.Select(x => new FleetViewModel(x)).ToArray();
-				return temps;
-			}
-		}
+			=> this.Source.Fleets
+				.Select(x => new FleetViewModel(x))
+				.ToArray();
 
 		#region 보급량
 
@@ -87,13 +83,13 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents.Fleets
 					this.RaisePropertyChanged(nameof(this.QuickStateView))
 				},
 				{ nameof(fleet.State.UsedFuel), (sender,args) =>
-					this.RaisePropertyChanged("UsedFuel")
+					this.RaisePropertyChanged(nameof(this.UsedFuel))
 				},
 				{ nameof(fleet.State.UsedBull), (sender,args) =>
-					this.RaisePropertyChanged("UsedAmmo")
+					this.RaisePropertyChanged(nameof(this.UsedAmmo))
 				},
 				{ nameof(fleet.State.UsedBauxite), (sender,args) =>
-					this.RaisePropertyChanged("UsedBauxite")
+					this.RaisePropertyChanged(nameof(this.UsedBauxite))
 				}
 			});
 

--- a/source/Grabacr07.KanColleViewer/ViewModels/Contents/Fleets/FleetViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/Contents/Fleets/FleetViewModel.cs
@@ -361,6 +361,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents.Fleets
 		public FleetViewModel(Fleet fleet)
 		{
 			this.Source = fleet;
+			this.ShipTypeTable = MakeShipTypeTable(this.Source.Ships);
 
 			if (this.Source.Id > 1)
 			{
@@ -484,7 +485,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents.Fleets
 			if (fleet.Count() <= 0) return false;
 			if (Mission < 1) return false;
 			bool Chk = true;
-			if (this.ShipTypeTable.Count <= 0) Chk = false;
+			if (this.ShipTypeTable?.Count <= 0) Chk = false;
 			if (Mission < 1) return false;
 			this.ShipTypeTable = this.ChangeSpecialType(this.ShipTypeTable, Mission);
 
@@ -577,7 +578,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents.Fleets
 		}
 		private Dictionary<int, int> ChangeSpecialType(Dictionary<int, int> list, int MissionNum)
 		{
-			Dictionary<int, int> templist = new Dictionary<int, int>(list);
+			Dictionary<int, int> templist = new Dictionary<int, int>(list ?? new Dictionary<int, int>());
 			bool Checker = true;
 			int SpecialCount = 1;
 			while (Checker)

--- a/source/Grabacr07.KanColleViewer/ViewModels/Contents/Fleets/FleetViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/Contents/Fleets/FleetViewModel.cs
@@ -21,7 +21,9 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents.Fleets
 
 		public int Id => this.Source.Id;
 
-		public string Name => string.IsNullOrEmpty(this.Source.Name.Trim()) ? "(제 " + this.Source.Id + " 함대)" : this.Source.Name;
+		public string Name => string.IsNullOrEmpty(this.Source.Name.Trim())
+			? "(제 " + this.Source.Id + " 함대)"
+			: this.Source.Name;
 
 		#region string
 		private string _ShipTypeString;
@@ -143,7 +145,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents.Fleets
 				// 같은 값을 넣는 것으로 원정 성공 여부 등을 재계산해야함
 
 				this._ExpeditionId = value;
-				this.IsPassed = this.CompareExpeditionData(value, this.Ships);
+				this.IsPassed = this.CompareExpeditionData(value, this.Source.Ships);
 
 				this.IsPossible = !this.IsPassed
 					? ExpeditionPossible.NotAccepted
@@ -295,8 +297,8 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents.Fleets
 			{
 				this._GreatChance = value;
 				this.RaisePropertyChanged();
-				this.RaisePropertyChanged("CanGreatSuccess");
-				this.RaisePropertyChanged("GreateChanceText");
+				this.RaisePropertyChanged(nameof(this.CanGreatSuccess));
+				this.RaisePropertyChanged(nameof(this.GreatChanceText));
 			}
 		}
 		public bool CanGreatSuccess => this.GreatChance > 0;
@@ -306,8 +308,8 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents.Fleets
 
 		#region 보급량
 
-		public int UsedFuel => this.Ships.Select(x => x.Ship.UsedFuel).Sum(x => x);
-		public int UsedAmmo => this.Ships.Select(x => x.Ship.UsedBull).Sum(x => x);
+		public int UsedFuel => this.Ships.Sum(x => x.Ship.UsedFuel);
+		public int UsedAmmo => this.Ships.Sum(x => x.Ship.UsedBull);
 		public int UsedBauxite => this.Ships.Sum(x => x.Ship.Slots.Sum(y => y.Lost * 5));
 
 		#endregion
@@ -319,13 +321,13 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents.Fleets
 		{
 			get
 			{
-				ShipViewModel[] temps = this.Source.Ships.Select(x => new ShipViewModel(x)).ToArray();
-				this.ShipTypeTable = MakeShipTypeTable(temps);
+				this.ShipTypeTable = MakeShipTypeTable(this.Source.Ships);
+				this.IsPassed = CompareExpeditionData(this.ExpeditionId, this.Source.Ships);
 
-				this.IsPassed = CompareExpeditionData(this.ExpeditionId, temps);
-				return temps;
+				return this.Source.Ships.Select(x => new ShipViewModel(x)).ToArray();
 			}
 		}
+
 		public List<int> ResultList { get; set; }
 		private Dictionary<int, int> ShipTypeTable { get; set; }
 
@@ -360,8 +362,6 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents.Fleets
 		{
 			this.Source = fleet;
 
-			this.IsFirstFleet = Visibility.Collapsed;
-
 			if (this.Source.Id > 1)
 			{
 				IsFirstFleet = Visibility.Visible;
@@ -376,7 +376,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents.Fleets
 			this.CompositeDisposable.Add(new PropertyChangedEventListener(fleet)
 			{
 				(sender, args) => this.RaisePropertyChanged(args.PropertyName),
-				{ nameof(fleet.ShipsUpdated), (sender,args)=>this.ExpeditionId = this.ExpeditionId }
+				{ nameof(fleet.ShipsUpdated), (sender,args) => this.ExpeditionId = this.ExpeditionId }
 			});
 
 			fleet.State.Updated += (sender, args) => this.ExpeditionId = this.ExpeditionId; // 편성 변경?
@@ -404,16 +404,16 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents.Fleets
 				{ nameof(fleet.State.Situation), (sender, args) => this.RaisePropertyChanged(nameof(this.IsInSortie)) },
 				{  nameof(fleet.State.UsedFuel), (sender,args) =>
 					{
-						this.RaisePropertyChanged("UsedFuel");
-						this.RaisePropertyChanged("UsedAmmo");
-						this.RaisePropertyChanged("UsedBauxite");
+						this.RaisePropertyChanged(nameof(this.UsedFuel));
+						this.RaisePropertyChanged(nameof(this.UsedAmmo));
+						this.RaisePropertyChanged(nameof(this.UsedBauxite));
 					}
 				},
 				{  nameof(fleet.State.UsedBull), (sender,args) =>
 					{
-						this.RaisePropertyChanged("UsedFuel");
-						this.RaisePropertyChanged("UsedAmmo");
-						this.RaisePropertyChanged("UsedBauxite");
+						this.RaisePropertyChanged(nameof(this.UsedFuel));
+						this.RaisePropertyChanged(nameof(this.UsedAmmo));
+						this.RaisePropertyChanged(nameof(this.UsedBauxite));
 					}
 				}
 			});
@@ -425,7 +425,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents.Fleets
 		/// <param name="MissonNum"></param>
 		/// <param name="ResourceType">0=연료 1=탄</param>
 		/// <returns></returns>
-		private int LossResource(ShipViewModel[] fleet, int MissionNum, int ResourceType = 0)
+		private int LossResource(Ship[] fleet, int MissionNum, int ResourceType = 0)
 		{
 			double total = 0;
 
@@ -433,26 +433,27 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents.Fleets
 			if (ResourceType == 1) losstype = "ArmoLoss";
 
 			var percent = KanColleClient.Current.Translations.GetExpeditionData(losstype, MissionNum);
-			if (percent == string.Empty) return -1;
+			if (string.IsNullOrEmpty(percent)) return -1;
 
 			double LossPercent = (double)Convert.ToInt32(percent) / 100d;
 
-			for (int i = 0; i < fleet.Count(); i++)
+			total = fleet.Sum(x =>
 			{
-				double temp = 0;
-				if (ResourceType == 1) temp = Convert.ToInt32(Math.Truncate((double)fleet[i].Ship.Bull.Maximum * LossPercent));
-				else temp = Convert.ToInt32(Math.Truncate((double)fleet[i].Ship.Fuel.Maximum * LossPercent));
+				if (ResourceType == 1)
+					return (int)Math.Floor((double)x.Bull.Maximum * LossPercent);
+				else
+					return (int)Math.Floor((double)x.Fuel.Maximum * LossPercent);
+			});
 
-				total += temp;
-			}
-
-			if (ResourceType == 1) this.vArmo = Visibility.Visible;
-			else this.vFuel = Visibility.Visible;
+			if (ResourceType == 1)
+				this.vArmo = Visibility.Visible;
+			else
+				this.vFuel = Visibility.Visible;
 
 			this.vResource = Visibility.Visible;
-			return Convert.ToInt32(total);
+			return (int)total;
 		}
-		private bool DrumCount(int Mission, ShipViewModel[] fleet)
+		private bool DrumCount(int Mission, Ship[] fleet)
 		{
 			bool result = false;
 			var NeedDrumRaw = KanColleClient.Current.Translations.GetExpeditionData("DrumCount", Mission);
@@ -462,31 +463,14 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents.Fleets
 			int nHasDrumShip = Convert.ToInt32(sNeedDrumRaw[1]);
 			this.nDrum = "총" + sNeedDrumRaw[0] + "개, " + "장착칸무스 최소 " + sNeedDrumRaw[1] + "척";
 			this.vDrum = Visibility.Visible;
-			int rTotalDrum = 0;
-			int rHasDrumShip = 0;
-			bool shipCheck = false;
 
-			for (int i = 0; i < fleet.Count(); i++)
-			{
-				for (int j = 0; j < fleet[i].Ship.Slots.Count(); j++)
-				{
-					if (fleet[i].Ship.Slots[j].Equipped && fleet[i].Ship.Slots[j].Item.Info.CategoryId == 30)
-					{
-						rTotalDrum++;
-						if (!shipCheck)
-						{
-							rHasDrumShip++;
-							shipCheck = true;
-						}
-					}
-				}
-				shipCheck = false;
-			}
+			int rHasDrumShip = fleet.Count(x => x.Slots.Any(y => y.Equipped && y.Item.Info.CategoryId == 30));
+			int rTotalDrum = fleet.Sum(x => x.Slots.Count(y => y.Equipped && y.Item.Info.CategoryId == 30));
+
 			if (rTotalDrum >= nTotalDrum && rHasDrumShip >= nHasDrumShip) result = true;
-
 			return result;
 		}
-		private bool CompareExpeditionData(int Mission, ShipViewModel[] fleet)
+		private bool CompareExpeditionData(int Mission, Ship[] fleet)
 		{
 			this.vFlag = Visibility.Collapsed;
 			this.vFlagType = Visibility.Collapsed;
@@ -524,21 +508,21 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents.Fleets
 			if (FLv != string.Empty && FLv != "-")
 			{
 				int lv = Convert.ToInt32(FLv);
-				if (fleet[0] != null && fleet[0].Ship.Level < lv) Chk = false;
+				if (fleet[0] != null && fleet[0].Level < lv) Chk = false;
 				this.FlagLv = ("Lv" + lv);
 				this.vFlag = Visibility.Visible;
 			}
 			if (TotalLevel != string.Empty)
 			{
 				int totallv = Convert.ToInt32(TotalLevel);
-				if (fleet.Sum(x => x.Ship.Level) < totallv) Chk = false;
+				if (fleet.Sum(x => x.Level) < totallv) Chk = false;
 				this.TotalLv = ("Lv" + totallv);
 				this.vTotal = Visibility.Visible;
 			}
 			if (FlagShipType != string.Empty)
 			{
 				int flagship = Convert.ToInt32(FlagShipType);
-				if (fleet[0].Ship.Info.ShipType.Id != flagship) Chk = false;
+				if (fleet[0].Info.ShipType.Id != flagship) Chk = false;
 				this.FlagType = (KanColleClient.Current.Translations.GetTranslation("", TranslationType.ShipTypes, false, null, flagship));
 				this.vFlagType = Visibility.Visible;
 			}
@@ -583,29 +567,13 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents.Fleets
 			return Chk;
 		}
 		#region Make & Replace List
-		private Dictionary<int, int> MakeShipTypeTable(ShipViewModel[] source)
+		private Dictionary<int, int> MakeShipTypeTable(Ship[] source)
 		{
 			if (source.Count() <= 0) return new Dictionary<int, int>();
-			Dictionary<int, int> temp = new Dictionary<int, int>();
-			List<int> rawList = new List<int>();
-			List<int> DistinctList = new List<int>();
 
-			foreach (var ship in source)
-			{
-				int ID = ship.Ship.Info.ShipType.Id;
-				rawList.Add(ID);
-			}
-			for (int i = 0; i < rawList.Count; i++)
-			{
-				if (DistinctList.Contains(rawList[i]))
-					continue;
-				DistinctList.Add(rawList[i]);
-			}
-			for (int i = 0; i < DistinctList.Count; i++)
-			{
-				temp.Add(DistinctList[i], rawList.Where(x => x == DistinctList[i]).Count());
-			}
-			return temp;
+			var rawList = source.Select(x => x.Info.ShipType.Id);
+			return rawList.Distinct()
+				.ToDictionary(x => x, x => rawList.Count(y => y == x));
 		}
 		private Dictionary<int, int> ChangeSpecialType(Dictionary<int, int> list, int MissionNum)
 		{

--- a/source/Grabacr07.KanColleViewer/ViewModels/Contents/Fleets/FleetsViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/Contents/Fleets/FleetsViewModel.cs
@@ -136,6 +136,8 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents.Fleets
 
 		#endregion
 
+		private bool prevCombined { get; set; }
+
 		public FleetsViewModel()
 		{
 			this.Fleets2 = new ItemViewModel[0];
@@ -157,6 +159,8 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents.Fleets
 			KanColleSettings.MergeCombinedFleet.ValueChanged += (s, e) => this.UpdateFleets();
 			this.ShowLostAirplane = KanColleSettings.ShowLostAirplane;
 			this.ShowAirplaneAlways = KanColleSettings.ShowAirplaneAlways;
+
+			prevCombined = KanColleClient.Current.Homeport.Organization.Combined;
 		}
 
 		public void ShowPresetWindow()
@@ -211,9 +215,11 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents.Fleets
 			if (!this.Fleets2.Any(x => x == this.SelectedFleet))
 				this.SelectedFleet = this.Fleets2.FirstOrDefault();
 
-			// 연합 함대인 경우 메모리 정리...
-			if (KanColleClient.Current.Homeport.Organization.Combined)
-				GCWorker.GCRequest();
+			// 연합 함대 해제 혹은 설정인 경우 메모리 정리...
+			if (KanColleClient.Current.Homeport.Organization.Combined || prevCombined)
+				GCWorker.GCRequest(-1, GCWorker.GCType.GCAll);
+
+			prevCombined = KanColleClient.Current.Homeport.Organization.Combined;
 		}
 
 		private CombinedFleetViewModel combinedFleetInstance;
@@ -232,25 +238,34 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents.Fleets
 			{
 				if (KanColleSettings.AutoFleetSelectWhenShipsChanged)
 				{
-					// 연합함대에 포함된 함대인지 체크
 					var first = this.Fleets2.FirstOrDefault();
+
+					// 첫번째가 연합함대
 					if (first.GetType() == typeof(CombinedFleetViewModel))
 					{
-						if((first as CombinedFleetViewModel).Source.Fleets.Any(x => x == fleet))
+						// 연합함대에 포함
+						if ((first as CombinedFleetViewModel).Source.Fleets.Any(x => x == fleet))
 							this.SelectedFleet = first;
+						else
+							this.SelectedFleet = vm;
 					}
 					else this.SelectedFleet = vm;
 				}
 			}, false).AddTo(this.fleetListeners);
+
 			fleet.Subscribe(nameof(Fleet.IsInSortie), () => {
 				if (KanColleSettings.AutoFleetSelectWhenSortie)
 				{
-					// 연합함대에 포함된 함대인지 체크
 					var first = this.Fleets2.FirstOrDefault();
+
+					// 첫번째가 연합함대
 					if (first.GetType() == typeof(CombinedFleetViewModel))
 					{
+						// 연합함대에 포함
 						if ((first as CombinedFleetViewModel).Source.Fleets.Any(x => x == fleet))
 							this.SelectedFleet = first;
+						else
+							this.SelectedFleet = vm;
 					}
 					else this.SelectedFleet = vm;
 				}

--- a/source/Grabacr07.KanColleViewer/ViewModels/Contents/Fleets/FleetsViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/Contents/Fleets/FleetsViewModel.cs
@@ -172,7 +172,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents.Fleets
 		}
 
 
-		private void UpdateFleets()
+		private async void UpdateFleets()
 		{
 			this.fleetListeners?.Dispose();
 			this.fleetListeners = new MultipleDisposable();
@@ -206,22 +206,21 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents.Fleets
 			this.Fleets2 = result.ToArray();
 
 			// SelectedFleet 이 무시되는 현상. 이유는 불명.
-			new System.Threading.Thread(() =>
-			{
-				System.Threading.Thread.Sleep(200);
+			await Task.Delay(200);
 
-				if (!this.Fleets2.Any(x => x == this.SelectedFleet))
-					this.SelectedFleet = this.Fleets2.FirstOrDefault();
-			}).Start();
+			if (!this.Fleets2.Any(x => x == this.SelectedFleet))
+				this.SelectedFleet = this.Fleets2.FirstOrDefault();
+
+			// 연합 함대인 경우 메모리 정리...
+			if (KanColleClient.Current.Homeport.Organization.Combined)
+				GCWorker.GCRequest();
 		}
 
 		private CombinedFleetViewModel combinedFleetInstance;
 		private CombinedFleetViewModel MakeCombinedFleetViewModel(CombinedFleet fleet)
 		{
 			if (combinedFleetInstance == null || combinedFleetInstance.Source != fleet)
-			{
 				combinedFleetInstance = new CombinedFleetViewModel(fleet);
-			}
 
 			return combinedFleetInstance;
 		}

--- a/source/Grabacr07.KanColleViewer/ViewModels/Contents/OverviewViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/Contents/OverviewViewModel.cs
@@ -129,6 +129,11 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents
 			var catalog = new CalculatorViewModel();
 			WindowService.Current.MainWindow.Transition(catalog, typeof(Calculator));
 		}
+		public void ShowDictionary()
+		{
+			var catalog = new DictionaryViewModel();
+			WindowService.Current.MainWindow.Transition(catalog, typeof(DictionaryWindow));
+		}
 		public void ExpeditionsCatalogWindow()
 		{
 			var catalog = new ExpeditionsCatalogWindowViewModel();

--- a/source/Grabacr07.KanColleViewer/ViewModels/Contents/ShipViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/Contents/ShipViewModel.cs
@@ -17,6 +17,8 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents
 		{
 			this.Ship = ship;
 			this.Condition = new ShipCondition(ship);
+
+			this.CompositeDisposable.Add(this.Condition);
 		}
 	}
 }

--- a/source/Grabacr07.KanColleViewer/ViewModels/Settings/OptimizeSettingsViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/Settings/OptimizeSettingsViewModel.cs
@@ -22,7 +22,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Settings
 
 		public void RequestGC()
 		{
-			GCWorker.GCRequest();
+			GCWorker.GCRequest(-1, GCWorker.GCType.GCAll);
 		}
 	}
 }

--- a/source/Grabacr07.KanColleViewer/Views/Catalogs/DictionaryWindow.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Catalogs/DictionaryWindow.xaml
@@ -515,7 +515,7 @@
 														<Setter Property="Text" Value="{Binding TotalCarry, Mode=OneWay}" />
 														<Style.Triggers>
 															<DataTrigger Binding="{Binding TotalCarry, Mode=OneWay}" Value="0">
-																<Setter Property="Text" Value="-" />
+																<Setter Property="Text" Value="" />
 															</DataTrigger>
 															<DataTrigger Binding="{Binding TotalCarry, Mode=OneWay}" Value="-1">
 																<Setter Property="Text" Value="???" />
@@ -979,7 +979,7 @@
 																		<Setter Property="Text" Value="{Binding Carry, Mode=OneWay}" />
 																		<Style.Triggers>
 																			<DataTrigger Binding="{Binding Available, Mode=OneWay}" Value="False">
-																				<Setter Property="Text" Value="-" />
+																				<Setter Property="Text" Value="" />
 																			</DataTrigger>
 																			<DataTrigger Binding="{Binding Carry, Mode=OneWay}" Value="-1">
 																				<Setter Property="Text" Value="?" />
@@ -1376,6 +1376,774 @@
 												</DataTemplate>
 											</ItemsControl.ItemTemplate>
 										</ItemsControl>
+									</StackPanel>
+								</StackPanel>
+							</ScrollViewer>
+						</Grid>
+					</DataTemplate>
+
+					<DataTemplate DataType="{x:Type viewModels:DictionaryEquipmentViewModel}">
+						<Grid>
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition Width="Auto" />
+								<ColumnDefinition Width="*" />
+							</Grid.ColumnDefinitions>
+
+							<ScrollViewer VerticalScrollBarVisibility="Auto"
+										  Margin="0,0,2,0">
+								<ListBox Background="{DynamicResource ActiveBackgroundBrushKey}"
+										 ItemsSource="{Binding EquipmentList}"
+										 SelectedValue="{Binding SelectedEquipment}"
+										 SelectionMode="Single"
+										 Grid.IsSharedSizeScope="True"
+										 ScrollViewer.IsDeferredScrollingEnabled="True"
+										 VirtualizingStackPanel.IsVirtualizing="True"
+										 VirtualizingStackPanel.VirtualizationMode="Recycling">
+									<ListBox.ItemContainerStyle>
+										<Style TargetType="{x:Type ListBoxItem}">
+											<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+											<Setter Property="IsSelected" Value="{Binding IsSelected, Mode=OneWay}" />
+											<Setter Property="Template">
+												<Setter.Value>
+													<ControlTemplate TargetType="{x:Type ListBoxItem}">
+														<Border Background="{TemplateBinding Background}">
+															<ContentPresenter />
+														</Border>
+													</ControlTemplate>
+												</Setter.Value>
+											</Setter>
+											<Setter Property="FocusVisualStyle" Value="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" />
+											<Style.Triggers>
+												<Trigger Property="IsMouseOver" Value="True">
+													<Setter Property="Background" Value="{DynamicResource AccentHighlightBrushKey}" />
+													<Setter Property="Foreground" Value="{DynamicResource AccentForegroundBrushKey}" />
+												</Trigger>
+												<Trigger Property="IsSelected" Value="True">
+													<Setter Property="Background" Value="{DynamicResource AccentBrushKey}" />
+													<Setter Property="Foreground" Value="{DynamicResource AccentForegroundBrushKey}" />
+												</Trigger>
+											</Style.Triggers>
+										</Style>
+									</ListBox.ItemContainerStyle>
+									<ListBox.ItemTemplate>
+										<DataTemplate DataType="{x:Type metro_controls:ITabItem}">
+											<Grid Margin="3">
+												<Grid.ColumnDefinitions>
+													<ColumnDefinition Width="Auto" SharedSizeGroup="IdType" />
+													<ColumnDefinition Width="*" />
+												</Grid.ColumnDefinitions>
+												<Grid.RowDefinitions>
+													<RowDefinition Height="Auto" />
+													<RowDefinition Height="Auto" />
+												</Grid.RowDefinitions>
+
+												<TextBlock Grid.Column="0"
+														   Grid.Row="0"
+														   Margin="3,0"
+														   VerticalAlignment="Bottom"
+														   Style="{StaticResource DetailTextStyleKey}"
+														   FontSize="8"
+														   Text="{Binding Id, Mode=OneWay, StringFormat={}No.{0}}" />
+												<TextBlock Grid.Column="0"
+														   Grid.Row="1"
+														   Margin="3,0"
+														   VerticalAlignment="Top"
+														   Style="{StaticResource EmphaticTextStyleKey}"
+														   FontSize="10"
+														   Text="{Binding ItemType, Mode=OneWay}" />
+
+												<TextBlock Grid.Column="1"
+														   Grid.RowSpan="2"
+														   Margin="5,1,3,1"
+														   Style="{StaticResource EmphaticTextStyleKey}"
+														   FontSize="14"
+														   VerticalAlignment="Center"
+														   TextTrimming="CharacterEllipsis"
+														   Text="{Binding Name, Mode=OneWay}" />
+											</Grid>
+										</DataTemplate>
+									</ListBox.ItemTemplate>
+									<ListBox.ItemsPanel>
+										<ItemsPanelTemplate>
+											<VirtualizingStackPanel />
+										</ItemsPanelTemplate>
+									</ListBox.ItemsPanel>
+									<ListBox.Template>
+										<ControlTemplate TargetType="{x:Type ListBox}">
+											<StackPanel>
+												<StackPanel IsItemsHost="True" />
+											</StackPanel>
+										</ControlTemplate>
+									</ListBox.Template>
+								</ListBox>
+							</ScrollViewer>
+
+							<ScrollViewer Grid.Column="1"
+										  VerticalScrollBarVisibility="Auto">
+								<StackPanel Orientation="Vertical"
+											Margin="0,0,0,10"
+											DataContext="{Binding SelectedEquipment, Mode=OneWay}">
+									<StackPanel.Style>
+										<Style TargetType="{x:Type StackPanel}">
+											<Style.Triggers>
+												<DataTrigger Binding="{Binding}" Value="{x:Null}">
+													<Setter Property="Visibility" Value="Collapsed" />
+												</DataTrigger>
+											</Style.Triggers>
+										</Style>
+									</StackPanel.Style>
+
+									<Grid Background="{DynamicResource ActiveBackgroundBrushKey}"
+										  MinHeight="40">
+										<Grid.ColumnDefinitions>
+											<ColumnDefinition Width="Auto" />
+											<ColumnDefinition Width="*" />
+											<ColumnDefinition Width="Auto" />
+										</Grid.ColumnDefinitions>
+
+										<TextBlock Margin="15,0,0,0"
+												   VerticalAlignment="Center"
+												   TextWrapping="NoWrap"
+												   Style="{StaticResource EmphaticTextStyleKey}"
+												   Text="{Binding Equipment.Name, Mode=OneWay}" />
+										<TextBlock Margin="8,2,0,1"
+												   Grid.Column="1"
+												   VerticalAlignment="Center"
+												   Style="{StaticResource DefaultTextStyleKey}"
+												   Text="{Binding Equipment.Id, Mode=OneWay, StringFormat={}No.{0}}" />
+										<TextBlock Margin="0,2,15,1"
+												   Grid.Column="2"
+												   VerticalAlignment="Center"
+												   Style="{StaticResource DefaultTextStyleKey}"
+												   Text="{Binding Equipment.TypeName, Mode=OneWay}" />
+									</Grid>
+
+									<Image Margin="10"
+										   Width="140"
+										   Height="140"
+										   HorizontalAlignment="Center"
+										   Source="{Binding CardImage, Mode=OneWay}" />
+
+									<StackPanel Orientation="Vertical"
+												Margin="8,10,0,0">
+										<TextBlock Foreground="White"
+												   VerticalAlignment="Center"
+												   Text="스테이터스" />
+
+										<Grid Margin="8,5,0,0">
+											<Grid.ColumnDefinitions>
+												<ColumnDefinition Width="Auto" />
+												<ColumnDefinition Width="Auto" />
+												<ColumnDefinition Width="*" />
+												<ColumnDefinition Width="Auto" />
+												<ColumnDefinition Width="Auto" />
+												<ColumnDefinition Width="*" />
+											</Grid.ColumnDefinitions>
+											<Grid.RowDefinitions>
+												<RowDefinition Height="Auto" />
+												<RowDefinition Height="Auto" />
+												<RowDefinition Height="Auto" />
+
+												<RowDefinition Height="Auto" />
+												<RowDefinition Height="Auto" />
+												<RowDefinition Height="Auto" />
+
+												<RowDefinition Height="Auto" />
+												<RowDefinition Height="Auto" />
+												<RowDefinition Height="Auto" />
+
+												<RowDefinition Height="Auto" />
+												<RowDefinition Height="Auto" />
+											</Grid.RowDefinitions>
+
+											<Image Grid.Column="0"
+												   Grid.Row="0"
+												   Width="18"
+												   Height="18"
+												   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/hp.png" />
+											<TextBlock Grid.Column="1"
+													   Grid.Row="0"
+													   Margin="4,0,10,0"
+													   Foreground="#f2f2f2"
+													   Text="내구" />
+											<TextBlock Grid.Column="2"
+													   Grid.Row="0"
+													   Foreground="#5cccf8">
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Setter Property="Text" Value="{Binding HP, Mode=OneWay}" />
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding HP, Mode=OneWay}" Value="0">
+																<Setter Property="Text" Value="" />
+															</DataTrigger>
+															<DataTrigger Binding="{Binding HP, Mode=OneWay}" Value="-1">
+																<Setter Property="Text" Value="???" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+
+											<Image Grid.Column="3"
+												   Grid.Row="0"
+												   Width="18"
+												   Height="18"
+												   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/armor.png" />
+											<TextBlock Grid.Column="4"
+													   Grid.Row="0"
+													   Margin="4,0,6,0"
+													   Foreground="#f2f2f2"
+													   Text="장갑" />
+											<TextBlock Grid.Column="5"
+													   Grid.Row="0"
+													   Foreground="#5cccf8">
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Setter Property="Text" Value="{Binding Armor, Mode=OneWay}" />
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding Armor, Mode=OneWay}" Value="0">
+																<Setter Property="Text" Value="" />
+															</DataTrigger>
+															<DataTrigger Binding="{Binding Armor, Mode=OneWay}" Value="-1">
+																<Setter Property="Text" Value="???" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+
+											<Image Grid.Column="0"
+												   Grid.Row="1"
+												   Margin="0,4,0,0"
+												   Width="18"
+												   Height="18"
+												   Source="{Binding EvasionIcon, Mode=OneWay}" />
+											<TextBlock Grid.Column="1"
+													   Grid.Row="1"
+													   Margin="4,4,10,0"
+													   Foreground="#f2f2f2"
+													   Text="{Binding EvasionName, Mode=OneWay}" />
+											<TextBlock Grid.Column="2"
+													   Grid.Row="1"
+													   Margin="0,4,0,0"
+													   Foreground="#5cccf8">
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Setter Property="Text" Value="{Binding Evasion, Mode=OneWay}" />
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding Evasion, Mode=OneWay}" Value="0">
+																<Setter Property="Text" Value="" />
+															</DataTrigger>
+															<DataTrigger Binding="{Binding Evasion, Mode=OneWay}" Value="-1">
+																<Setter Property="Text" Value="???" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+
+											<Image Grid.Column="3"
+												   Grid.Row="1"
+												   Margin="0,4,0,0"
+												   Width="18"
+												   Height="18"
+												   Source="{Binding HitChanceIcon, Mode=OneWay}" />
+											<TextBlock Grid.Column="4"
+													   Grid.Row="1"
+													   Margin="4,4,10,0"
+													   Foreground="#f2f2f2"
+													   Text="{Binding HitChanceName, Mode=OneWay}" />
+											<TextBlock Grid.Column="5"
+													   Grid.Row="1"
+													   Margin="0,4,0,0"
+													   Foreground="#5cccf8">
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Setter Property="Text" Value="{Binding HitChance, Mode=OneWay}" />
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding HitChance, Mode=OneWay}" Value="0">
+																<Setter Property="Text" Value="" />
+															</DataTrigger>
+															<DataTrigger Binding="{Binding HitChance, Mode=OneWay}" Value="-1">
+																<Setter Property="Text" Value="???" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+
+											<Border Grid.ColumnSpan="6"
+													Grid.Row="2"
+													Margin="0,6"
+													Height="2"
+													Background="#44ffffff" />
+
+											<Image Grid.Column="0"
+												   Grid.Row="3"
+												   Width="18"
+												   Height="18"
+												   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/fire.png" />
+											<TextBlock Grid.Column="1"
+													   Grid.Row="3"
+													   Margin="4,0,10,0"
+													   Foreground="#f2f2f2"
+													   Text="화력" />
+											<TextBlock Grid.Column="2"
+													   Grid.Row="3"
+													   Foreground="#5cccf8">
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Setter Property="Text" Value="{Binding Fire, Mode=OneWay}" />
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding Fire, Mode=OneWay}" Value="0">
+																<Setter Property="Text" Value="" />
+															</DataTrigger>
+															<DataTrigger Binding="{Binding Fire, Mode=OneWay}" Value="-1">
+																<Setter Property="Text" Value="???" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+
+											<Image Grid.Column="3"
+												   Grid.Row="3"
+												   Width="18"
+												   Height="18"
+												   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/torpedo.png" />
+											<TextBlock Grid.Column="4"
+													   Grid.Row="3"
+													   Margin="4,0,6,0"
+													   Foreground="#f2f2f2"
+													   Text="뇌장" />
+											<TextBlock Grid.Column="5"
+													   Grid.Row="3"
+													   Foreground="#5cccf8">
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Setter Property="Text" Value="{Binding Torpedo, Mode=OneWay}" />
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding Torpedo, Mode=OneWay}" Value="0">
+																<Setter Property="Text" Value="" />
+															</DataTrigger>
+															<DataTrigger Binding="{Binding Torpedo, Mode=OneWay}" Value="-1">
+																<Setter Property="Text" Value="???" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+
+											<Image Grid.Column="0"
+												   Grid.Row="4"
+												   Margin="0,4,0,0"
+												   Width="18"
+												   Height="18"
+												   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/aa.png" />
+											<TextBlock Grid.Column="1"
+													   Grid.Row="4"
+													   Margin="4,4,10,0"
+													   Foreground="#f2f2f2"
+													   Text="대공" />
+											<TextBlock Grid.Column="2"
+													   Grid.Row="4"
+													   Margin="0,4,0,0"
+													   Foreground="#5cccf8">
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Setter Property="Text" Value="{Binding AA, Mode=OneWay}" />
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding AA, Mode=OneWay}" Value="0">
+																<Setter Property="Text" Value="" />
+															</DataTrigger>
+															<DataTrigger Binding="{Binding AA, Mode=OneWay}" Value="-1">
+																<Setter Property="Text" Value="???" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+
+											<Image Grid.Column="3"
+												   Grid.Row="4"
+												   Margin="0,4,0,0"
+												   Width="18"
+												   Height="18"
+												   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/asw.png" />
+											<TextBlock Grid.Column="4"
+													   Grid.Row="4"
+													   Margin="4,4,10,0"
+													   Foreground="#f2f2f2"
+													   Text="대잠" />
+											<TextBlock Grid.Column="5"
+													   Grid.Row="4"
+													   Margin="0,4,0,0"
+													   Foreground="#5cccf8">
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Setter Property="Text" Value="{Binding ASW, Mode=OneWay}" />
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding ASW, Mode=OneWay}" Value="0">
+																<Setter Property="Text" Value="" />
+															</DataTrigger>
+															<DataTrigger Binding="{Binding ASW, Mode=OneWay}" Value="-1">
+																<Setter Property="Text" Value="???" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+
+											<Border Grid.ColumnSpan="6"
+													Grid.Row="5"
+													Margin="0,6"
+													Height="2"
+													Background="#44ffffff" />
+
+											<Image Grid.Column="0"
+												   Grid.Row="6"
+												   Width="18"
+												   Height="18"
+												   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/bomb.png" />
+											<TextBlock Grid.Column="1"
+													   Grid.Row="6"
+													   Margin="4,0,10,0"
+													   Foreground="#f2f2f2"
+													   Text="폭장" />
+											<TextBlock Grid.Column="2"
+													   Grid.Row="6"
+													   Foreground="#5cccf8">
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Setter Property="Text" Value="{Binding Bombing, Mode=OneWay}" />
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding Bombing, Mode=OneWay}" Value="0">
+																<Setter Property="Text" Value="" />
+															</DataTrigger>
+															<DataTrigger Binding="{Binding Bombing, Mode=OneWay}" Value="-1">
+																<Setter Property="Text" Value="???" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+
+											<Image Grid.Column="3"
+												   Grid.Row="6"
+												   Width="18"
+												   Height="18"
+												   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/torpedo.png" />
+											<TextBlock Grid.Column="4"
+													   Grid.Row="6"
+													   Margin="4,0,6,0"
+													   Foreground="#f2f2f2"
+													   Text="뇌장 (항공)" />
+											<TextBlock Grid.Column="5"
+													   Grid.Row="6"
+													   Foreground="#5cccf8">
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Setter Property="Text" Value="{Binding TorpedoAircraft, Mode=OneWay}" />
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding TorpedoAircraft, Mode=OneWay}" Value="0">
+																<Setter Property="Text" Value="" />
+															</DataTrigger>
+															<DataTrigger Binding="{Binding TorpedoAircraft, Mode=OneWay}" Value="-1">
+																<Setter Property="Text" Value="???" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+
+											<Image Grid.Column="0"
+												   Grid.Row="7"
+												   Margin="0,4,0,0"
+												   Width="18"
+												   Height="18"
+												   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/bauxite.png" />
+											<TextBlock Grid.Column="1"
+													   Grid.Row="7"
+													   Margin="4,4,10,0"
+													   Foreground="#f2f2f2"
+													   Text="배치 비용" />
+											<TextBlock Grid.Column="2"
+													   Grid.Row="7"
+													   Margin="0,4,0,0"
+													   Foreground="#5cccf8">
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Setter Property="Text" Value="{Binding AircraftCost, Mode=OneWay}" />
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding AircraftCost, Mode=OneWay}" Value="0">
+																<Setter Property="Text" Value="" />
+															</DataTrigger>
+															<DataTrigger Binding="{Binding AircraftCost, Mode=OneWay}" Value="-1">
+																<Setter Property="Text" Value="???" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+
+											<Image Grid.Column="3"
+												   Grid.Row="7"
+												   Margin="0,4,0,0"
+												   Width="18"
+												   Height="18"
+												   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/carry.png" />
+											<TextBlock Grid.Column="4"
+													   Grid.Row="7"
+													   Margin="4,4,10,0"
+													   Foreground="#f2f2f2"
+													   Text="항속거리" />
+											<TextBlock Grid.Column="5"
+													   Grid.Row="7"
+													   Margin="0,4,0,0"
+													   Foreground="#5cccf8">
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Setter Property="Text" Value="{Binding AircraftDistance, Mode=OneWay}" />
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding AircraftDistance, Mode=OneWay}" Value="0">
+																<Setter Property="Text" Value="" />
+															</DataTrigger>
+															<DataTrigger Binding="{Binding AircraftDistance, Mode=OneWay}" Value="-1">
+																<Setter Property="Text" Value="???" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+
+											<Border Grid.ColumnSpan="6"
+													Grid.Row="8"
+													Margin="0,6"
+													Height="2"
+													Background="#44ffffff" />
+
+											<Image Grid.Column="0"
+												   Grid.Row="9"
+												   Width="18"
+												   Height="18"
+												   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/speed.png" />
+											<TextBlock Grid.Column="1"
+													   Grid.Row="9"
+													   Margin="4,0,10,0"
+													   Foreground="#f2f2f2"
+													   Text="속력" />
+											<TextBlock Grid.Column="2"
+													   Grid.Row="9"
+													   Foreground="#5cccf8"
+													   Text="{Binding SpeedText, Mode=OneWay}" />
+
+											<Image Grid.Column="3"
+												   Grid.Row="9"
+												   Width="18"
+												   Height="18"
+												   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/range.png" />
+											<TextBlock Grid.Column="4"
+													   Grid.Row="9"
+													   Margin="4,0,6,0"
+													   Foreground="#f2f2f2"
+													   Text="사거리" />
+											<TextBlock Grid.Column="5"
+													   Grid.Row="9"
+													   Foreground="#5cccf8"
+													   Text="{Binding RangeText, Mode=OneWay}" />
+
+											<Image Grid.Column="0"
+												   Grid.Row="10"
+												   Margin="0,4,0,0"
+												   Width="18"
+												   Height="18"
+												   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/los.png" />
+											<TextBlock Grid.Column="1"
+													   Grid.Row="10"
+													   Margin="4,4,10,0"
+													   Foreground="#f2f2f2"
+													   Text="색적" />
+											<TextBlock Grid.Column="2"
+													   Grid.Row="10"
+													   Margin="0,4,0,0"
+													   Foreground="#5cccf8">
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Setter Property="Text" Value="{Binding LOS, Mode=OneWay}" />
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding LOS, Mode=OneWay}" Value="0">
+																<Setter Property="Text" Value="" />
+															</DataTrigger>
+															<DataTrigger Binding="{Binding LOS, Mode=OneWay}" Value="-1">
+																<Setter Property="Text" Value="???" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+
+											<Image Grid.Column="3"
+												   Grid.Row="10"
+												   Margin="0,4,0,0"
+												   Width="18"
+												   Height="18"
+												   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/luck.png" />
+											<TextBlock Grid.Column="4"
+													   Grid.Row="10"
+													   Margin="4,4,10,0"
+													   Foreground="#f2f2f2"
+													   Text="운" />
+											<TextBlock Grid.Column="5"
+													   Grid.Row="10"
+													   Margin="0,4,0,0"
+													   Foreground="#5cccf8">
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Setter Property="Text" Value="{Binding Luck, Mode=OneWay}" />
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding Luck, Mode=OneWay}" Value="0">
+																<Setter Property="Text" Value="" />
+															</DataTrigger>
+															<DataTrigger Binding="{Binding Luck, Mode=OneWay}" Value="-1">
+																<Setter Property="Text" Value="???" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+										</Grid>
+									</StackPanel>
+
+									<StackPanel Orientation="Vertical"
+												Margin="8,20,0,0">
+										<TextBlock Foreground="White"
+												   Text="폐기" />
+
+										<Grid>
+											<Grid.ColumnDefinitions>
+												<ColumnDefinition Width="Auto" />
+												<ColumnDefinition Width="Auto" />
+												<ColumnDefinition Width="Auto" />
+												<ColumnDefinition Width="Auto" />
+											</Grid.ColumnDefinitions>
+
+											<StackPanel Orientation="Horizontal"
+													Margin="4,3"
+													Grid.Column="0">
+												<Image Width="18"
+													   Height="18"
+													   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/fuel.png" />
+												<TextBlock Margin="3,0,15,0"
+														   Foreground="#5cccf8"
+														   Text="{Binding DestroyFuel, Mode=OneWay, StringFormat={}+{0}}">
+													<TextBlock.Style>
+														<Style TargetType="{x:Type TextBlock}">
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding DestroyFuel, Mode=OneWay}" Value="0">
+																	<Setter Property="Visibility" Value="Hidden" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</TextBlock.Style>
+												</TextBlock>
+												<StackPanel.Style>
+													<Style TargetType="{x:Type StackPanel}">
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding DestroyFuel, Mode=OneWay}" Value="0">
+																<Setter Property="Opacity" Value="0.33" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</StackPanel.Style>
+											</StackPanel>
+											<StackPanel Orientation="Horizontal"
+													Margin="4,3"
+													Grid.Column="1">
+												<Image Width="18"
+													   Height="18"
+													   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/ammo.png" />
+												<TextBlock Margin="3,0,15,0"
+														   Foreground="#5cccf8"
+														   Text="{Binding DestroyAmmo, Mode=OneWay, StringFormat={}+{0}}">
+													<TextBlock.Style>
+														<Style TargetType="{x:Type TextBlock}">
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding DestroyAmmo, Mode=OneWay}" Value="0">
+																	<Setter Property="Visibility" Value="Hidden" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</TextBlock.Style>
+												</TextBlock>
+												<StackPanel.Style>
+													<Style TargetType="{x:Type StackPanel}">
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding DestroyAmmo, Mode=OneWay}" Value="0">
+																<Setter Property="Opacity" Value="0.33" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</StackPanel.Style>
+											</StackPanel>
+											<StackPanel Orientation="Horizontal"
+													Margin="4,3"
+													Grid.Column="2">
+												<Image Width="18"
+													   Height="18"
+													   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/steel.png" />
+												<TextBlock Margin="3,0,15,0"
+														   Foreground="#5cccf8"
+														   Text="{Binding DestroySteel, Mode=OneWay, StringFormat={}+{0}}">
+													<TextBlock.Style>
+														<Style TargetType="{x:Type TextBlock}">
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding DestroySteel, Mode=OneWay}" Value="0">
+																	<Setter Property="Visibility" Value="Hidden" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</TextBlock.Style>
+												</TextBlock>
+												<StackPanel.Style>
+													<Style TargetType="{x:Type StackPanel}">
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding DestroySteel, Mode=OneWay}" Value="0">
+																<Setter Property="Opacity" Value="0.33" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</StackPanel.Style>
+											</StackPanel>
+											<StackPanel Orientation="Horizontal"
+													Margin="4,3"
+													Grid.Column="3">
+												<Image Width="18"
+													   Height="18"
+													   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/bauxite.png" />
+												<TextBlock Margin="3,0,15,0"
+														   Foreground="#5cccf8"
+														   Text="{Binding DestroyBauxite, Mode=OneWay, StringFormat={}+{0}}">
+													<TextBlock.Style>
+														<Style TargetType="{x:Type TextBlock}">
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding DestroyBauxite, Mode=OneWay}" Value="0">
+																	<Setter Property="Visibility" Value="Hidden" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</TextBlock.Style>
+												</TextBlock>
+												<StackPanel.Style>
+													<Style TargetType="{x:Type StackPanel}">
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding DestroyBauxite, Mode=OneWay}" Value="0">
+																<Setter Property="Opacity" Value="0.33" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</StackPanel.Style>
+											</StackPanel>
+										</Grid>
 									</StackPanel>
 								</StackPanel>
 							</ScrollViewer>

--- a/source/Grabacr07.KanColleViewer/Views/Catalogs/DictionaryWindow.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Catalogs/DictionaryWindow.xaml
@@ -1,0 +1,1000 @@
+﻿<metro:MetroWindow x:Class="Grabacr07.KanColleViewer.Views.Catalogs.DictionaryWindow"
+				   x:Name="GlowMetroWindow"
+				   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+				   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+				   xmlns:s="clr-namespace:System;assembly=mscorlib"
+				   xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
+				   xmlns:ei="http://schemas.microsoft.com/expression/2010/interactions"
+				   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+				   xmlns:ed="http://schemas.microsoft.com/expression/2010/drawing"
+				   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+				   xmlns:livet="http://schemas.livet-mvvm.net/2011/wpf"
+				   xmlns:metro="http://schemes.grabacr.net/winfx/2014/controls"
+				   xmlns:metro_controls="clr-namespace:MetroRadiance.UI.Controls;assembly=MetroRadiance"
+				   xmlns:controls="clr-namespace:Grabacr07.KanColleViewer.Views.Controls"
+				   xmlns:metro2="http://schemes.grabacr.net/winfx/2015/personal/controls"
+				   xmlns:properties="clr-namespace:Grabacr07.KanColleViewer.Properties"
+				   xmlns:views="clr-namespace:Grabacr07.KanColleViewer.Views"
+				   xmlns:viewModels="clr-namespace:Grabacr07.KanColleViewer.ViewModels.Catalogs"
+				   xmlns:kcvc="http://schemes.grabacr.net/winfx/2015/kancolleviewer/controls"
+				   xmlns:kcvi="http://schemes.grabacr.net/winfx/2015/kancolleviewer/interactivity"
+				   xmlns:kcvv="http://schemes.grabacr.net/winfx/2015/kancolleviewer/converters"
+				   xmlns:vm="clr-namespace:Grabacr07.KanColleViewer.ViewModels"
+				   xmlns:behaviors="clr-namespace:Grabacr07.KanColleViewer.Views.Behaviors"
+				   mc:Ignorable="d"
+				   d:DataContext="{d:DesignInstance viewModels:DictionaryViewModel}"
+				   Title="{Binding Title}"
+				   Width="640"
+				   Height="480"
+				   FontSize="12"
+				   Background="{DynamicResource ThemeBrushKey}"
+				   Foreground="{DynamicResource ActiveForegroundBrushKey}"
+				   IsRestoringWindowPlacement="True"
+				   SnapsToDevicePixels="True"
+				   TextOptions.TextFormattingMode="Display">
+	<Window.Resources>
+		<ResourceDictionary>
+			<BooleanToVisibilityConverter x:Key="BooleanToVisibility" />
+		</ResourceDictionary>
+	</Window.Resources>
+
+	<i:Interaction.Triggers>
+		<i:EventTrigger EventName="ContentRendered">
+			<livet:LivetCallMethodAction MethodTarget="{Binding}"
+										 MethodName="Initialize" />
+		</i:EventTrigger>
+
+		<i:EventTrigger EventName="Closed">
+			<livet:DataContextDisposeAction />
+		</i:EventTrigger>
+
+		<livet:InteractionMessageTrigger Messenger="{Binding Messenger}"
+										 MessageKey="Window.Location">
+			<behaviors:SetWindowLocationAction />
+		</livet:InteractionMessageTrigger>
+		<livet:InteractionMessageTrigger Messenger="{Binding Messenger, Mode=OneWay}"
+										 MessageKey="Window.Activate">
+			<livet:WindowInteractionMessageAction InvokeActionOnlyWhenWindowIsActive="False" />
+		</livet:InteractionMessageTrigger>
+	</i:Interaction.Triggers>
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+
+		<!-- #region Caption area -->
+		<DockPanel metro:MetroWindow.IsCaptionBar="True">
+			<Border DockPanel.Dock="Bottom"
+					Height="4" />
+			<kcvc:AppIcon Width="36"
+						  Height="36"
+						  Background="Transparent"
+						  AnchorVisibility="Collapsed"
+						  BandVisibility="Collapsed" />
+
+			<StackPanel DockPanel.Dock="Right"
+						Orientation="Horizontal"
+						VerticalAlignment="Top"
+						WindowChrome.IsHitTestVisibleInChrome="True">
+				<metro:SystemButtons />
+			</StackPanel>
+
+			<TextBlock Text="{Binding Title}"
+					   Style="{DynamicResource CaptionTextStyleKey}"
+					   Margin="2,0,8,0" />
+		</DockPanel>
+		<!-- #endregion -->
+
+		<Grid Grid.Row="2">
+			<Grid.RowDefinitions>
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="*" />
+			</Grid.RowDefinitions>
+			<metro:HorizontalTabView Background="{DynamicResource ActiveBackgroundBrushKey}"
+									 ItemsSource="{Binding TabItems}"
+									 SelectedValue="{Binding SelectedItem}" />
+
+			<Grid Grid.Row="1"
+				  Margin="0,2,0,0">
+				<ItemsControl ItemsSource="{Binding TabItems}">
+					<ItemsControl.ItemsPanel>
+						<ItemsPanelTemplate>
+							<Grid />
+						</ItemsPanelTemplate>
+					</ItemsControl.ItemsPanel>
+					<ItemsControl.ItemTemplate>
+						<DataTemplate DataType="{x:Type vm:TabItemViewModel}">
+							<ContentControl Content="{Binding}"
+											Visibility="{Binding IsSelected, Converter={StaticResource BooleanToVisibility}}" />
+						</DataTemplate>
+					</ItemsControl.ItemTemplate>
+				</ItemsControl>
+
+				<Grid.Resources>
+					<DataTemplate DataType="{x:Type viewModels:DictionaryShipViewModel}">
+						<Grid>
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition Width="Auto" />
+								<ColumnDefinition Width="*" />
+							</Grid.ColumnDefinitions>
+
+							<ScrollViewer VerticalScrollBarVisibility="Auto"
+										  Margin="0,0,2,0">
+								<ListBox Background="{DynamicResource ActiveBackgroundBrushKey}"
+										 ItemsSource="{Binding ShipList}"
+										 SelectedValue="{Binding SelectedShip}"
+										 SelectionMode="Single"
+										 ScrollViewer.IsDeferredScrollingEnabled="True"
+										 VirtualizingStackPanel.IsVirtualizing="True"
+										 VirtualizingStackPanel.VirtualizationMode="Recycling">
+									<ListBox.ItemContainerStyle>
+										<Style TargetType="{x:Type ListBoxItem}">
+											<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+											<Setter Property="Height" Value="22" />
+											<Setter Property="IsSelected" Value="{Binding IsSelected, Mode=OneWay}" />
+											<Setter Property="Template">
+												<Setter.Value>
+													<ControlTemplate TargetType="{x:Type ListBoxItem}">
+														<Border Background="{TemplateBinding Background}">
+															<ContentPresenter />
+														</Border>
+													</ControlTemplate>
+												</Setter.Value>
+											</Setter>
+											<Setter Property="FocusVisualStyle" Value="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" />
+											<Style.Triggers>
+												<Trigger Property="IsMouseOver" Value="True">
+													<Setter Property="Background" Value="{DynamicResource AccentHighlightBrushKey}" />
+													<Setter Property="Foreground" Value="{DynamicResource AccentForegroundBrushKey}" />
+												</Trigger>
+												<Trigger Property="IsSelected" Value="True">
+													<Setter Property="Background" Value="{DynamicResource AccentBrushKey}" />
+													<Setter Property="Foreground" Value="{DynamicResource AccentForegroundBrushKey}" />
+												</Trigger>
+											</Style.Triggers>
+										</Style>
+									</ListBox.ItemContainerStyle>
+									<ListBox.ItemTemplate>
+										<DataTemplate DataType="{x:Type metro_controls:ITabItem}">
+											<TextBlock Margin="5,0"
+													   FontSize="13"
+													   VerticalAlignment="Center"
+													   TextTrimming="CharacterEllipsis">
+												<Run Text="{Binding Id, Mode=OneWay, StringFormat={}No.{0}}" FontSize="10" />
+												<Run Text="{Binding Name, Mode=OneWay}" />
+											</TextBlock>
+										</DataTemplate>
+									</ListBox.ItemTemplate>
+									<ListBox.ItemsPanel>
+										<ItemsPanelTemplate>
+											<VirtualizingStackPanel />
+										</ItemsPanelTemplate>
+									</ListBox.ItemsPanel>
+									<ListBox.Template>
+										<ControlTemplate TargetType="{x:Type ListBox}">
+											<StackPanel>
+												<StackPanel IsItemsHost="True" />
+											</StackPanel>
+										</ControlTemplate>
+									</ListBox.Template>
+								</ListBox>
+							</ScrollViewer>
+
+							<ScrollViewer Grid.Column="1"
+										  VerticalScrollBarVisibility="Auto">
+								<StackPanel Orientation="Vertical"
+											DataContext="{Binding SelectedShip, Mode=OneWay}">
+									<StackPanel.Style>
+										<Style TargetType="{x:Type StackPanel}">
+											<Style.Triggers>
+												<DataTrigger Binding="{Binding}" Value="{x:Null}">
+													<Setter Property="Visibility" Value="Collapsed" />
+												</DataTrigger>
+											</Style.Triggers>
+										</Style>
+									</StackPanel.Style>
+
+									<Grid Background="{DynamicResource ActiveBackgroundBrushKey}">
+										<Grid.ColumnDefinitions>
+											<ColumnDefinition Width="Auto" />
+											<ColumnDefinition Width="*" />
+											<ColumnDefinition Width="*" />
+											<ColumnDefinition Width="Auto" />
+										</Grid.ColumnDefinitions>
+
+										<TextBlock Margin="15,0,0,0"
+												   VerticalAlignment="Center"
+												   TextWrapping="NoWrap"
+												   Style="{StaticResource EmphaticTextStyleKey}"
+												   Text="{Binding Ship.Name, Mode=OneWay}" />
+										<TextBlock Margin="8,2,0,1"
+												   Grid.Column="1"
+												   VerticalAlignment="Center"
+												   Style="{StaticResource DefaultTextStyleKey}"
+												   Text="{Binding Ship.Id, Mode=OneWay, StringFormat={}No.{0}}" />
+										<TextBlock Margin="0,2,8,1"
+												   Grid.Column="2"
+												   VerticalAlignment="Center"
+												   TextAlignment="Right"
+												   Style="{StaticResource DefaultTextStyleKey}"
+												   Text="{Binding Ship.ShipType.Name, Mode=OneWay}" />
+
+										<Image Grid.Column="3"
+											   Width="160"
+											   Height="40"
+											   Source="{Binding BadgeImage, Mode=OneWay}" />
+									</Grid>
+
+									<StackPanel Orientation="Vertical"
+												Margin="8,10,0,0">
+										<TextBlock Foreground="White"
+												   Text="스테이터스" />
+										<Grid Margin="8,5,0,0">
+											<Grid.ColumnDefinitions>
+												<ColumnDefinition Width="Auto" />
+												<ColumnDefinition Width="Auto" />
+												<ColumnDefinition Width="*" />
+												<ColumnDefinition Width="Auto" />
+												<ColumnDefinition Width="Auto" />
+												<ColumnDefinition Width="*" />
+											</Grid.ColumnDefinitions>
+											<Grid.RowDefinitions>
+												<RowDefinition Height="Auto" />
+												<RowDefinition Height="Auto" />
+												<RowDefinition Height="Auto" />
+
+												<RowDefinition Height="Auto" />
+												<RowDefinition Height="Auto" />
+												<RowDefinition Height="Auto" />
+
+												<RowDefinition Height="Auto" />
+												<RowDefinition Height="Auto" />
+
+												<RowDefinition Height="Auto" />
+												<RowDefinition Height="Auto" />
+											</Grid.RowDefinitions>
+
+											<Image Grid.Column="0"
+												   Grid.Row="0"
+												   Width="18"
+												   Height="18"
+												   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/hp.png" />
+											<TextBlock Grid.Column="1"
+													   Grid.Row="0"
+													   Margin="4,0,10,0"
+													   Foreground="#f2f2f2"
+													   Text="내구" />
+											<TextBlock Grid.Column="2"
+													   Grid.Row="0"
+													   Foreground="#5cccf8">
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Setter Property="Text" Value="{Binding HP, Mode=OneWay}" />
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding HP, Mode=OneWay}" Value="-1">
+																<Setter Property="Text" Value="???" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+
+											<Image Grid.Column="3"
+												   Grid.Row="0"
+												   Width="18"
+												   Height="18"
+												   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/armor.png" />
+											<TextBlock Grid.Column="4"
+													   Grid.Row="0"
+													   Margin="4,0,6,0"
+													   Foreground="#f2f2f2"
+													   Text="장갑" />
+											<TextBlock Grid.Column="5"
+													   Grid.Row="0"
+													   Foreground="#5cccf8">
+												<Run>
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding MinArmor, Mode=OneWay}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding MinArmor, Mode=OneWay}" Value="-1">
+																	<Setter Property="Text" Value="???" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+												<Run Text="＞" />
+												<Run>
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding MaxArmor, Mode=OneWay}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding MaxArmor, Mode=OneWay}" Value="-1">
+																	<Setter Property="Text" Value="???" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+											</TextBlock>
+
+											<Image Grid.Column="0"
+												   Grid.Row="1"
+												   Margin="0,4,0,0"
+												   Width="18"
+												   Height="18"
+												   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/evasion.png" />
+											<TextBlock Grid.Column="1"
+													   Grid.Row="1"
+													   Margin="4,4,10,0"
+													   Foreground="#f2f2f2"
+													   Text="회피" />
+											<TextBlock Grid.Column="2"
+													   Grid.Row="1"
+													   Margin="0,4,0,0"
+													   Foreground="#5cccf8">
+												<Run>
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding MinEvasion, Mode=OneWay}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding MinEvasion, Mode=OneWay}" Value="-1">
+																	<Setter Property="Text" Value="???" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+												<Run Text="＞" />
+												<Run>
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding MaxEvasion, Mode=OneWay}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding MaxEvasion, Mode=OneWay}" Value="-1">
+																	<Setter Property="Text" Value="???" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+											</TextBlock>
+
+											<Image Grid.Column="3"
+												   Grid.Row="1"
+												   Margin="0,4,0,0"
+												   Width="18"
+												   Height="18"
+												   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/carry.png" />
+											<TextBlock Grid.Column="4"
+													   Grid.Row="1"
+													   Margin="4,4,10,0"
+													   Foreground="#f2f2f2"
+													   Text="탑재량" />
+											<TextBlock Grid.Column="5"
+													   Grid.Row="1"
+													   Margin="0,4,0,0"
+													   Foreground="#5cccf8">
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Setter Property="Text" Value="{Binding TotalCarry, Mode=OneWay}" />
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding TotalCarry, Mode=OneWay}" Value="0">
+																<Setter Property="Text" Value="-" />
+															</DataTrigger>
+															<DataTrigger Binding="{Binding TotalCarry, Mode=OneWay}" Value="-1">
+																<Setter Property="Text" Value="???" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+
+											<Border Grid.ColumnSpan="6"
+													Grid.Row="2"
+													Margin="0,6"
+													Height="2"
+													Background="#44ffffff" />
+
+											<Image Grid.Column="0"
+												   Grid.Row="3"
+												   Width="18"
+												   Height="18"
+												   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/fire.png" />
+											<TextBlock Grid.Column="1"
+													   Grid.Row="3"
+													   Margin="4,0,10,0"
+													   Foreground="#f2f2f2"
+													   Text="화력" />
+											<TextBlock Grid.Column="2"
+													   Grid.Row="3"
+													   Foreground="#5cccf8">
+												<Run>
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding MinFire, Mode=OneWay}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding MinFire, Mode=OneWay}" Value="-1">
+																	<Setter Property="Text" Value="???" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+												<Run Text="＞" />
+												<Run>
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding MaxFire, Mode=OneWay}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding MaxFire, Mode=OneWay}" Value="-1">
+																	<Setter Property="Text" Value="???" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+											</TextBlock>
+
+											<Image Grid.Column="3"
+												   Grid.Row="3"
+												   Width="18"
+												   Height="18"
+												   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/torpedo.png" />
+											<TextBlock Grid.Column="4"
+													   Grid.Row="3"
+													   Margin="4,0,6,0"
+													   Foreground="#f2f2f2"
+													   Text="뇌장" />
+											<TextBlock Grid.Column="5"
+													   Grid.Row="3"
+													   Foreground="#5cccf8">
+												<Run>
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding MinTorpedo, Mode=OneWay}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding MinTorpedo, Mode=OneWay}" Value="-1">
+																	<Setter Property="Text" Value="???" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+												<Run Text="＞" />
+												<Run>
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding MaxTorpedo, Mode=OneWay}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding MaxTorpedo, Mode=OneWay}" Value="-1">
+																	<Setter Property="Text" Value="???" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+											</TextBlock>
+
+											<Image Grid.Column="0"
+												   Grid.Row="4"
+												   Margin="0,4,0,0"
+												   Width="18"
+												   Height="18"
+												   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/aa.png" />
+											<TextBlock Grid.Column="1"
+													   Grid.Row="4"
+													   Margin="4,4,10,0"
+													   Foreground="#f2f2f2"
+													   Text="대공" />
+											<TextBlock Grid.Column="2"
+													   Grid.Row="4"
+													   Margin="0,4,0,0"
+													   Foreground="#5cccf8">
+												<Run>
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding MinAA, Mode=OneWay}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding MinAA, Mode=OneWay}" Value="-1">
+																	<Setter Property="Text" Value="???" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+												<Run Text="＞" />
+												<Run>
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding MaxAA, Mode=OneWay}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding MaxAA, Mode=OneWay}" Value="-1">
+																	<Setter Property="Text" Value="???" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+											</TextBlock>
+
+											<Image Grid.Column="3"
+												   Grid.Row="4"
+												   Margin="0,4,0,0"
+												   Width="18"
+												   Height="18"
+												   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/asw.png" />
+											<TextBlock Grid.Column="4"
+													   Grid.Row="4"
+													   Margin="4,4,10,0"
+													   Foreground="#f2f2f2"
+													   Text="대잠" />
+											<TextBlock Grid.Column="5"
+													   Grid.Row="4"
+													   Margin="0,4,0,0"
+													   Foreground="#5cccf8">
+												<Run>
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding MinASW, Mode=OneWay}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding MinASW, Mode=OneWay}" Value="-1">
+																	<Setter Property="Text" Value="???" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+												<Run Text="＞" />
+												<Run>
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding MaxASW, Mode=OneWay}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding MaxASW, Mode=OneWay}" Value="-1">
+																	<Setter Property="Text" Value="???" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+											</TextBlock>
+
+											<Border Grid.ColumnSpan="6"
+													Grid.Row="5"
+													Margin="0,6"
+													Height="2"
+													Background="#44ffffff" />
+
+											<Image Grid.Column="0"
+												   Grid.Row="6"
+												   Width="18"
+												   Height="18"
+												   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/speed.png" />
+											<TextBlock Grid.Column="1"
+													   Grid.Row="6"
+													   Margin="4,0,10,0"
+													   Foreground="#f2f2f2"
+													   Text="속력" />
+											<TextBlock Grid.Column="2"
+													   Grid.Row="6"
+													   Foreground="#5cccf8"
+													   Text="{Binding SpeedText, Mode=OneWay}" />
+
+											<Image Grid.Column="3"
+												   Grid.Row="6"
+												   Width="18"
+												   Height="18"
+												   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/range.png" />
+											<TextBlock Grid.Column="4"
+													   Grid.Row="6"
+													   Margin="4,0,6,0"
+													   Foreground="#f2f2f2"
+													   Text="사거리" />
+											<TextBlock Grid.Column="5"
+													   Grid.Row="6"
+													   Foreground="#5cccf8"
+													   Text="{Binding RangeText, Mode=OneWay}" />
+
+											<Image Grid.Column="0"
+												   Grid.Row="7"
+												   Margin="0,4,0,0"
+												   Width="18"
+												   Height="18"
+												   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/los.png" />
+											<TextBlock Grid.Column="1"
+													   Grid.Row="7"
+													   Margin="4,4,10,0"
+													   Foreground="#f2f2f2"
+													   Text="색적" />
+											<TextBlock Grid.Column="2"
+													   Grid.Row="7"
+													   Margin="0,4,0,0"
+													   Foreground="#5cccf8">
+												<Run>
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding MinLOS, Mode=OneWay}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding MinLOS, Mode=OneWay}" Value="-1">
+																	<Setter Property="Text" Value="???" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+												<Run Text="＞" />
+												<Run>
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding MaxLOS, Mode=OneWay}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding MaxLOS, Mode=OneWay}" Value="-1">
+																	<Setter Property="Text" Value="???" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+											</TextBlock>
+
+											<Image Grid.Column="3"
+												   Grid.Row="7"
+												   Margin="0,4,0,0"
+												   Width="18"
+												   Height="18"
+												   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/luck.png" />
+											<TextBlock Grid.Column="4"
+													   Grid.Row="7"
+													   Margin="4,4,10,0"
+													   Foreground="#f2f2f2"
+													   Text="운" />
+											<TextBlock Grid.Column="5"
+													   Grid.Row="7"
+													   Margin="0,4,0,0"
+													   Foreground="#5cccf8">
+												<Run>
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding MinLuck, Mode=OneWay}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding MinLuck, Mode=OneWay}" Value="-1">
+																	<Setter Property="Text" Value="???" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+												<Run Text="(max" />
+												<Run>
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding MaxLuck, Mode=OneWay}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding MaxLuck, Mode=OneWay}" Value="-1">
+																	<Setter Property="Text" Value="???" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run><Run Text=")" />
+											</TextBlock>
+
+											<Border Grid.ColumnSpan="6"
+													Grid.Row="8"
+													Margin="0,6"
+													Height="2"
+													Background="#44ff7878" />
+
+											<Image Grid.Column="0"
+												   Grid.Row="9"
+												   Margin="0,4,0,0"
+												   Width="18"
+												   Height="18"
+												   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/fuel.png" />
+											<TextBlock Grid.Column="1"
+													   Grid.Row="9"
+													   Margin="4,4,10,0"
+													   Foreground="#f2f2f2"
+													   Text="연료" />
+											<TextBlock Grid.Column="2"
+													   Grid.Row="9"
+													   Margin="0,4,0,0"
+													   Foreground="#ff7878">
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Setter Property="Text" Value="{Binding MaxFuel, Mode=OneWay}" />
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding MaxFuel, Mode=OneWay}" Value="-1">
+																<Setter Property="Text" Value="???" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+
+											<Image Grid.Column="3"
+												   Grid.Row="9"
+												   Margin="0,4,0,0"
+												   Width="18"
+												   Height="18"
+												   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/ammo.png" />
+											<TextBlock Grid.Column="4"
+													   Grid.Row="9"
+													   Margin="4,4,10,0"
+													   Foreground="#f2f2f2"
+													   Text="탄약" />
+											<TextBlock Grid.Column="5"
+													   Grid.Row="9"
+													   Margin="0,4,0,0"
+													   Foreground="#ff7878">
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Setter Property="Text" Value="{Binding MaxAmmo, Mode=OneWay}" />
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding MaxAmmo, Mode=OneWay}" Value="-1">
+																<Setter Property="Text" Value="???" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+
+										</Grid>
+									</StackPanel>
+
+									<StackPanel Orientation="Vertical"
+												Margin="8,20,0,0">
+										<TextBlock Foreground="White"
+												   Text="초기장비 및 탑재량" />
+										<ItemsControl ItemsSource="{Binding Slots, Mode=OneWay}">
+											<ItemsControl.ItemTemplate>
+												<DataTemplate>
+													<StackPanel Orientation="Vertical">
+														<Grid Margin="8,5,0,0">
+															<Grid.ColumnDefinitions>
+																<ColumnDefinition Width="Auto" />
+																<ColumnDefinition Width="Auto" />
+																<ColumnDefinition Width="*" />
+															</Grid.ColumnDefinitions>
+
+															<TextBlock Margin="0,0,6,0"
+																	   Padding="1,1"
+																	   Width="24"
+																	   TextAlignment="Center"
+																	   Background="#30000000"
+																	   Foreground="#5cccf8">
+																<TextBlock.Style>
+																	<Style TargetType="{x:Type TextBlock}">
+																		<Setter Property="Text" Value="{Binding Carry, Mode=OneWay}" />
+																		<Style.Triggers>
+																			<DataTrigger Binding="{Binding Available, Mode=OneWay}" Value="False">
+																				<Setter Property="Text" Value="-" />
+																			</DataTrigger>
+																			<DataTrigger Binding="{Binding Carry, Mode=OneWay}" Value="-1">
+																				<Setter Property="Text" Value="?" />
+																			</DataTrigger>
+																		</Style.Triggers>
+																	</Style>
+																</TextBlock.Style>
+															</TextBlock>
+
+															<kcvc:SlotItemIcon Grid.Column="1"
+																				   Type="{Binding Info.IconType, Mode=OneWay}"
+																				   Width="18"
+																				   Height="18">
+																<kcvc:SlotItemIcon.Style>
+																	<Style TargetType="{x:Type kcvc:SlotItemIcon}">
+																		<Style.Triggers>
+																			<DataTrigger Binding="{Binding Available, Mode=OneWay}" Value="False">
+																				<Setter Property="Visibility" Value="Collapsed" />
+																			</DataTrigger>
+																		</Style.Triggers>
+																	</Style>
+																</kcvc:SlotItemIcon.Style>
+															</kcvc:SlotItemIcon>
+
+															<TextBlock Grid.Column="2"
+																	   Margin="4,0,0,0">
+																<TextBlock.Style>
+																	<Style TargetType="{x:Type TextBlock}">
+																		<Setter Property="Text" Value="{Binding Info.Name, Mode=OneWay}" />
+																		<Setter Property="Foreground" Value="#f0f0f0" />
+
+																		<Style.Triggers>
+																			<DataTrigger Binding="{Binding Info.Name, Mode=OneWay}" Value="{x:Null}">
+																				<Setter Property="Text" Value="알 수 없는 장비입니다." />
+																				<Setter Property="Foreground" Value="#c2f0f0f0" />
+																			</DataTrigger>
+																			<DataTrigger Binding="{Binding Available, Mode=OneWay}" Value="False">
+																				<Setter Property="Text" Value="존재하지 않는 슬롯입니다." />
+																				<Setter Property="Foreground" Value="#58f0f0f0" />
+																				<Setter Property="TextAlignment" Value="Center" />
+																			</DataTrigger>
+																		</Style.Triggers>
+																	</Style>
+																</TextBlock.Style>
+															</TextBlock>
+														</Grid>
+														<Border Height="1"
+																Margin="5,5,5,0"
+																Background="#20ffffff" />
+													</StackPanel>
+												</DataTemplate>
+											</ItemsControl.ItemTemplate>
+										</ItemsControl>
+									</StackPanel>
+
+									<StackPanel Orientation="Vertical"
+												Margin="8,20,0,0">
+										<TextBlock Foreground="White"
+												   Text="근대화개수 / 해체" />
+										<StackPanel Margin="8,5,0,0"
+													Orientation="Horizontal">
+											<StackPanel Orientation="Horizontal">
+												<Image Width="18"
+													   Height="18"
+													   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/fire.png" />
+												<TextBlock Margin="3,0,15,0"
+														   Foreground="#5cccf8"
+														   Text="{Binding ModernizeFire, Mode=OneWay, StringFormat={}+{0}}" />
+
+												<StackPanel.Style>
+													<Style TargetType="{x:Type StackPanel}">
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding ModernizeFire, Mode=OneWay}" Value="0">
+																<Setter Property="Visibility" Value="Collapsed" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</StackPanel.Style>
+											</StackPanel>
+
+											<StackPanel Orientation="Horizontal">
+												<Image Width="18"
+													   Height="18"
+													   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/torpedo.png" />
+												<TextBlock Margin="3,0,15,0"
+														   Foreground="#5cccf8"
+														   Text="{Binding ModernizeTorpedo, Mode=OneWay, StringFormat={}+{0}}" />
+
+												<StackPanel.Style>
+													<Style TargetType="{x:Type StackPanel}">
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding ModernizeTorpedo, Mode=OneWay}" Value="0">
+																<Setter Property="Visibility" Value="Collapsed" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</StackPanel.Style>
+											</StackPanel>
+
+											<StackPanel Orientation="Horizontal">
+												<Image Width="18"
+													   Height="18"
+													   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/aa.png" />
+												<TextBlock Margin="3,0,15,0"
+														   Foreground="#5cccf8"
+														   Text="{Binding ModernizeAA, Mode=OneWay, StringFormat={}+{0}}" />
+
+												<StackPanel.Style>
+													<Style TargetType="{x:Type StackPanel}">
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding ModernizeAA, Mode=OneWay}" Value="0">
+																<Setter Property="Visibility" Value="Collapsed" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</StackPanel.Style>
+											</StackPanel>
+
+											<StackPanel Orientation="Horizontal">
+												<Image Width="18"
+													   Height="18"
+													   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/armor.png" />
+												<TextBlock Margin="3,0,15,0"
+														   Foreground="#5cccf8"
+														   Text="{Binding ModernizeArmor, Mode=OneWay, StringFormat={}+{0}}" />
+
+												<StackPanel.Style>
+													<Style TargetType="{x:Type StackPanel}">
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding ModernizeArmor, Mode=OneWay}" Value="0">
+																<Setter Property="Visibility" Value="Collapsed" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</StackPanel.Style>
+											</StackPanel>
+										</StackPanel>
+										<StackPanel Margin="8,4,0,0"
+													Orientation="Horizontal">
+											<StackPanel Orientation="Horizontal">
+												<Image Width="18"
+													   Height="18"
+													   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/fuel.png" />
+												<TextBlock Margin="3,0,15,0"
+														   Foreground="#5cccf8"
+														   Text="{Binding DestroyFuel, Mode=OneWay, StringFormat={}+{0}}" />
+
+												<StackPanel.Style>
+													<Style TargetType="{x:Type StackPanel}">
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding DestroyFuel, Mode=OneWay}" Value="0">
+																<Setter Property="Visibility" Value="Collapsed" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</StackPanel.Style>
+											</StackPanel>
+
+											<StackPanel Orientation="Horizontal">
+												<Image Width="18"
+													   Height="18"
+													   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/ammo.png" />
+												<TextBlock Margin="3,0,15,0"
+														   Foreground="#5cccf8"
+														   Text="{Binding DestroyAmmo, Mode=OneWay, StringFormat={}+{0}}" />
+
+												<StackPanel.Style>
+													<Style TargetType="{x:Type StackPanel}">
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding DestroyAmmo, Mode=OneWay}" Value="0">
+																<Setter Property="Visibility" Value="Collapsed" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</StackPanel.Style>
+											</StackPanel>
+
+											<StackPanel Orientation="Horizontal">
+												<Image Width="18"
+													   Height="18"
+													   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/steel.png" />
+												<TextBlock Margin="3,0,15,0"
+														   Foreground="#5cccf8"
+														   Text="{Binding DestroySteel, Mode=OneWay, StringFormat={}+{0}}" />
+
+												<StackPanel.Style>
+													<Style TargetType="{x:Type StackPanel}">
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding DestroySteel, Mode=OneWay}" Value="0">
+																<Setter Property="Visibility" Value="Collapsed" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</StackPanel.Style>
+											</StackPanel>
+
+											<StackPanel Orientation="Horizontal">
+												<Image Width="18"
+													   Height="18"
+													   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/bauxite.png" />
+												<TextBlock Margin="3,0,15,0"
+														   Foreground="#5cccf8"
+														   Text="{Binding DestroyBauxite, Mode=OneWay, StringFormat={}+{0}}" />
+
+												<StackPanel.Style>
+													<Style TargetType="{x:Type StackPanel}">
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding DestroyBauxite, Mode=OneWay}" Value="0">
+																<Setter Property="Visibility" Value="Collapsed" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</StackPanel.Style>
+											</StackPanel>
+										</StackPanel>
+									</StackPanel>
+								</StackPanel>
+							</ScrollViewer>
+						</Grid>
+					</DataTemplate>
+				</Grid.Resources>
+			</Grid>
+		</Grid>
+	</Grid>
+</metro:MetroWindow>

--- a/source/Grabacr07.KanColleViewer/Views/Catalogs/DictionaryWindow.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Catalogs/DictionaryWindow.xaml
@@ -13,7 +13,6 @@
 				   xmlns:metro_controls="clr-namespace:MetroRadiance.UI.Controls;assembly=MetroRadiance"
 				   xmlns:controls="clr-namespace:Grabacr07.KanColleViewer.Views.Controls"
 				   xmlns:metro2="http://schemes.grabacr.net/winfx/2015/personal/controls"
-				   xmlns:properties="clr-namespace:Grabacr07.KanColleViewer.Properties"
 				   xmlns:views="clr-namespace:Grabacr07.KanColleViewer.Views"
 				   xmlns:viewModels="clr-namespace:Grabacr07.KanColleViewer.ViewModels.Catalogs"
 				   xmlns:kcvc="http://schemes.grabacr.net/winfx/2015/kancolleviewer/controls"
@@ -21,6 +20,8 @@
 				   xmlns:kcvv="http://schemes.grabacr.net/winfx/2015/kancolleviewer/converters"
 				   xmlns:vm="clr-namespace:Grabacr07.KanColleViewer.ViewModels"
 				   xmlns:behaviors="clr-namespace:Grabacr07.KanColleViewer.Views.Behaviors"
+				   xmlns:models="clr-namespace:Grabacr07.KanColleViewer.Models"
+				   xmlns:converters="clr-namespace:Grabacr07.KanColleViewer.Views.Converters"
 				   mc:Ignorable="d"
 				   d:DataContext="{d:DesignInstance viewModels:DictionaryViewModel}"
 				   Title="{Binding Title}"
@@ -34,7 +35,18 @@
 				   TextOptions.TextFormattingMode="Display">
 	<Window.Resources>
 		<ResourceDictionary>
+			<ObjectDataProvider xmlns:sys="clr-namespace:System;assembly=mscorlib"
+								xmlns:linq="clr-namespace:System.Linq;assembly=System.Core"
+								x:Key="EnumerableRange"
+								ObjectType="{x:Type linq:Enumerable}" MethodName="Range">
+				<ObjectDataProvider.MethodParameters>
+					<sys:Int32>1</sys:Int32>
+					<sys:Int32>155</sys:Int32>
+				</ObjectDataProvider.MethodParameters>
+			</ObjectDataProvider>
+
 			<BooleanToVisibilityConverter x:Key="BooleanToVisibility" />
+			<converters:RangeToBooleanConverter x:Key="RangeToBooleanConverter" />
 		</ResourceDictionary>
 	</Window.Resources>
 
@@ -126,13 +138,13 @@
 										 ItemsSource="{Binding ShipList}"
 										 SelectedValue="{Binding SelectedShip}"
 										 SelectionMode="Single"
+										 Grid.IsSharedSizeScope="True"
 										 ScrollViewer.IsDeferredScrollingEnabled="True"
 										 VirtualizingStackPanel.IsVirtualizing="True"
 										 VirtualizingStackPanel.VirtualizationMode="Recycling">
 									<ListBox.ItemContainerStyle>
 										<Style TargetType="{x:Type ListBoxItem}">
 											<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
-											<Setter Property="Height" Value="22" />
 											<Setter Property="IsSelected" Value="{Binding IsSelected, Mode=OneWay}" />
 											<Setter Property="Template">
 												<Setter.Value>
@@ -158,13 +170,40 @@
 									</ListBox.ItemContainerStyle>
 									<ListBox.ItemTemplate>
 										<DataTemplate DataType="{x:Type metro_controls:ITabItem}">
-											<TextBlock Margin="5,0"
-													   FontSize="13"
-													   VerticalAlignment="Center"
-													   TextTrimming="CharacterEllipsis">
-												<Run Text="{Binding Id, Mode=OneWay, StringFormat={}No.{0}}" FontSize="10" />
-												<Run Text="{Binding Name, Mode=OneWay}" />
-											</TextBlock>
+											<Grid Margin="3">
+												<Grid.ColumnDefinitions>
+													<ColumnDefinition Width="Auto" SharedSizeGroup="IdType" />
+													<ColumnDefinition Width="*" />
+												</Grid.ColumnDefinitions>
+												<Grid.RowDefinitions>
+													<RowDefinition Height="Auto" />
+													<RowDefinition Height="Auto" />
+												</Grid.RowDefinitions>
+
+												<TextBlock Grid.Column="0"
+														   Grid.Row="0"
+														   Margin="3,0"
+														   VerticalAlignment="Bottom"
+														   Style="{StaticResource DetailTextStyleKey}"
+														   FontSize="8"
+														   Text="{Binding Id, Mode=OneWay, StringFormat={}No.{0}}" />
+												<TextBlock Grid.Column="0"
+														   Grid.Row="1"
+														   Margin="3,0"
+														   VerticalAlignment="Top"
+														   Style="{StaticResource EmphaticTextStyleKey}"
+														   FontSize="10"
+														   Text="{Binding ShipType, Mode=OneWay}" />
+
+												<TextBlock Grid.Column="1"
+														   Grid.RowSpan="2"
+														   Margin="5,1,3,1"
+														   Style="{StaticResource EmphaticTextStyleKey}"
+														   FontSize="14"
+														   VerticalAlignment="Center"
+														   TextTrimming="CharacterEllipsis"
+														   Text="{Binding Name, Mode=OneWay}" />
+											</Grid>
 										</DataTemplate>
 									</ListBox.ItemTemplate>
 									<ListBox.ItemsPanel>
@@ -185,6 +224,7 @@
 							<ScrollViewer Grid.Column="1"
 										  VerticalScrollBarVisibility="Auto">
 								<StackPanel Orientation="Vertical"
+											Margin="0,0,0,10"
 											DataContext="{Binding SelectedShip, Mode=OneWay}">
 									<StackPanel.Style>
 										<Style TargetType="{x:Type StackPanel}">
@@ -229,8 +269,50 @@
 
 									<StackPanel Orientation="Vertical"
 												Margin="8,10,0,0">
-										<TextBlock Foreground="White"
-												   Text="스테이터스" />
+										<Grid>
+											<Grid.ColumnDefinitions>
+												<ColumnDefinition Width="*" />
+												<ColumnDefinition Width="Auto" />
+												<ColumnDefinition Width="Auto" />
+											</Grid.ColumnDefinitions>
+
+											<TextBlock Foreground="White"
+													   VerticalAlignment="Center"
+													   Text="스테이터스" />
+
+											<TextBlock Margin="0,0,4,0"
+													   Grid.Column="1"
+													   VerticalAlignment="Center"
+													   FontSize="12"
+													   Foreground="#FFF08020"
+													   Text="레벨:" />
+											<metro:PromptComboBox Grid.Column="2"
+																  Margin="8"
+																  VerticalAlignment="Center"
+																  ItemsSource="{Binding Source={StaticResource EnumerableRange}}"
+																  HorizontalAlignment="Left"
+																  SelectedValue="{Binding Level, Mode=TwoWay}"
+																  IsReadOnly="True"
+																  Prompt=""
+																  MinWidth="72">
+												<metro:PromptComboBox.ItemTemplate>
+													<DataTemplate>
+														<TextBlock Text="{Binding}">
+															<TextBlock.Style>
+																<Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource DefaultTextStyleKey}">
+																	<Style.Triggers>
+																		<DataTrigger Binding="{Binding Path=., Converter={StaticResource RangeToBooleanConverter}, ConverterParameter=100-999}" Value="True">
+																			<Setter Property="Foreground" Value="#FFFFC7D3" />
+																		</DataTrigger>
+																	</Style.Triggers>
+																</Style>
+															</TextBlock.Style>
+														</TextBlock>
+													</DataTemplate>
+												</metro:PromptComboBox.ItemTemplate>
+											</metro:PromptComboBox>
+										</Grid>
+
 										<Grid Margin="8,5,0,0">
 											<Grid.ColumnDefinitions>
 												<ColumnDefinition Width="Auto" />
@@ -269,16 +351,36 @@
 											<TextBlock Grid.Column="2"
 													   Grid.Row="0"
 													   Foreground="#5cccf8">
-												<TextBlock.Style>
-													<Style TargetType="{x:Type TextBlock}">
-														<Setter Property="Text" Value="{Binding HP, Mode=OneWay}" />
-														<Style.Triggers>
-															<DataTrigger Binding="{Binding HP, Mode=OneWay}" Value="-1">
-																<Setter Property="Text" Value="???" />
-															</DataTrigger>
-														</Style.Triggers>
-													</Style>
-												</TextBlock.Style>
+												<Run>
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding CurHP, Mode=OneWay}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding CurHP, Mode=OneWay}" Value="-1">
+																	<Setter Property="Text" Value="???" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+
+												<InlineUIContainer>
+													<TextBlock Foreground="#FFF08020">
+														<Run Text="  (" />
+														<Run Text="{Binding MarriageHPResult, Mode=OneWay, StringFormat={}+{0}}" />
+														<Run Text=")" />
+
+														<TextBlock.Style>
+															<Style TargetType="{x:Type TextBlock}">
+																<Style.Triggers>
+																	<DataTrigger Binding="{Binding MarriageHPResult, Mode=OneWay}" Value="0">
+																		<Setter Property="Visibility" Value="Collapsed" />
+																	</DataTrigger>
+																</Style.Triggers>
+															</Style>
+														</TextBlock.Style>
+													</TextBlock>
+												</InlineUIContainer>
 											</TextBlock>
 
 											<Image Grid.Column="3"
@@ -319,6 +421,21 @@
 														</Style>
 													</Run.Style>
 												</Run>
+
+												<Run Text="  (" Foreground="#FFF08020" />
+												<Run Foreground="#FFF08020">
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding CurArmor, Mode=OneWay}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding CurArmor, Mode=OneWay}" Value="-1">
+																	<Setter Property="Text" Value="???" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+												<Run Text=")" Foreground="#FFF08020" />
 											</TextBlock>
 
 											<Image Grid.Column="0"
@@ -361,6 +478,21 @@
 														</Style>
 													</Run.Style>
 												</Run>
+
+												<Run Text="  (" Foreground="#FFF08020" />
+												<Run Foreground="#FFF08020">
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding CurEvasion, Mode=OneWay}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding CurEvasion, Mode=OneWay}" Value="-1">
+																	<Setter Property="Text" Value="???" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+												<Run Text=")" Foreground="#FFF08020" />
 											</TextBlock>
 
 											<Image Grid.Column="3"
@@ -437,6 +569,21 @@
 														</Style>
 													</Run.Style>
 												</Run>
+
+												<Run Text="  (" Foreground="#FFF08020" />
+												<Run Foreground="#FFF08020">
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding CurFire, Mode=OneWay}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding CurFire, Mode=OneWay}" Value="-1">
+																	<Setter Property="Text" Value="???" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+												<Run Text=")" Foreground="#FFF08020" />
 											</TextBlock>
 
 											<Image Grid.Column="3"
@@ -477,6 +624,21 @@
 														</Style>
 													</Run.Style>
 												</Run>
+
+												<Run Text="  (" Foreground="#FFF08020" />
+												<Run Foreground="#FFF08020">
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding CurTorpedo, Mode=OneWay}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding CurTorpedo, Mode=OneWay}" Value="-1">
+																	<Setter Property="Text" Value="???" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+												<Run Text=")" Foreground="#FFF08020" />
 											</TextBlock>
 
 											<Image Grid.Column="0"
@@ -519,6 +681,21 @@
 														</Style>
 													</Run.Style>
 												</Run>
+
+												<Run Text="  (" Foreground="#FFF08020" />
+												<Run Foreground="#FFF08020">
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding CurAA, Mode=OneWay}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding CurAA, Mode=OneWay}" Value="-1">
+																	<Setter Property="Text" Value="???" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+												<Run Text=")" Foreground="#FFF08020" />
 											</TextBlock>
 
 											<Image Grid.Column="3"
@@ -561,6 +738,21 @@
 														</Style>
 													</Run.Style>
 												</Run>
+
+												<Run Text="  (" Foreground="#FFF08020" />
+												<Run Foreground="#FFF08020">
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding CurASW, Mode=OneWay}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding CurASW, Mode=OneWay}" Value="-1">
+																	<Setter Property="Text" Value="???" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+												<Run Text=")" Foreground="#FFF08020" />
 											</TextBlock>
 
 											<Border Grid.ColumnSpan="6"
@@ -639,6 +831,21 @@
 														</Style>
 													</Run.Style>
 												</Run>
+
+												<Run Text="  (" Foreground="#FFF08020" />
+												<Run Foreground="#FFF08020">
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding CurLOS, Mode=OneWay}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding CurLOS, Mode=OneWay}" Value="-1">
+																	<Setter Property="Text" Value="???" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+												<Run Text=")" Foreground="#FFF08020" />
 											</TextBlock>
 
 											<Image Grid.Column="3"
@@ -659,9 +866,9 @@
 												<Run>
 													<Run.Style>
 														<Style TargetType="{x:Type Run}">
-															<Setter Property="Text" Value="{Binding MinLuck, Mode=OneWay}" />
+															<Setter Property="Text" Value="{Binding CurLuck, Mode=OneWay}" />
 															<Style.Triggers>
-																<DataTrigger Binding="{Binding MinLuck, Mode=OneWay}" Value="-1">
+																<DataTrigger Binding="{Binding CurLuck, Mode=OneWay}" Value="-1">
 																	<Setter Property="Text" Value="???" />
 																</DataTrigger>
 															</Style.Triggers>
@@ -706,7 +913,7 @@
 													   Foreground="#ff7878">
 												<TextBlock.Style>
 													<Style TargetType="{x:Type TextBlock}">
-														<Setter Property="Text" Value="{Binding MaxFuel, Mode=OneWay}" />
+														<Setter Property="Text" Value="{Binding CurMaxFuel, Mode=OneWay}" />
 														<Style.Triggers>
 															<DataTrigger Binding="{Binding MaxFuel, Mode=OneWay}" Value="-1">
 																<Setter Property="Text" Value="???" />
@@ -733,7 +940,7 @@
 													   Foreground="#ff7878">
 												<TextBlock.Style>
 													<Style TargetType="{x:Type TextBlock}">
-														<Setter Property="Text" Value="{Binding MaxAmmo, Mode=OneWay}" />
+														<Setter Property="Text" Value="{Binding CurMaxAmmo, Mode=OneWay}" />
 														<Style.Triggers>
 															<DataTrigger Binding="{Binding MaxAmmo, Mode=OneWay}" Value="-1">
 																<Setter Property="Text" Value="???" />
@@ -789,6 +996,9 @@
 																<kcvc:SlotItemIcon.Style>
 																	<Style TargetType="{x:Type kcvc:SlotItemIcon}">
 																		<Style.Triggers>
+																			<DataTrigger Binding="{Binding Info.Id, Mode=OneWay}" Value="0">
+																				<Setter Property="Visibility" Value="Hidden" />
+																			</DataTrigger>
 																			<DataTrigger Binding="{Binding Available, Mode=OneWay}" Value="False">
 																				<Setter Property="Visibility" Value="Collapsed" />
 																			</DataTrigger>
@@ -805,9 +1015,13 @@
 																		<Setter Property="Foreground" Value="#f0f0f0" />
 
 																		<Style.Triggers>
-																			<DataTrigger Binding="{Binding Info.Name, Mode=OneWay}" Value="{x:Null}">
-																				<Setter Property="Text" Value="알 수 없는 장비입니다." />
+																			<DataTrigger Binding="{Binding Info.Id, Mode=OneWay}" Value="0">
+																				<Setter Property="Text" Value="비어있는 슬롯입니다." />
 																				<Setter Property="Foreground" Value="#c2f0f0f0" />
+																			</DataTrigger>
+																			<DataTrigger Binding="{Binding Info.Name, Mode=OneWay}" Value="{x:Null}">
+																				<Setter Property="Text" Value="알 수 없는 장비" />
+																				<Setter Property="Foreground" Value="#58f0f0f0" />
 																			</DataTrigger>
 																			<DataTrigger Binding="{Binding Available, Mode=OneWay}" Value="False">
 																				<Setter Property="Text" Value="존재하지 않는 슬롯입니다." />
@@ -832,162 +1046,336 @@
 												Margin="8,20,0,0">
 										<TextBlock Foreground="White"
 												   Text="근대화개수 / 해체" />
-										<StackPanel Margin="8,5,0,0"
-													Orientation="Horizontal">
-											<StackPanel Orientation="Horizontal">
+
+										<Grid>
+											<Grid.ColumnDefinitions>
+												<ColumnDefinition Width="Auto" />
+												<ColumnDefinition Width="Auto" />
+												<ColumnDefinition Width="Auto" />
+												<ColumnDefinition Width="Auto" />
+											</Grid.ColumnDefinitions>
+											<Grid.RowDefinitions>
+												<RowDefinition Height="Auto" />
+												<RowDefinition Height="Auto" />
+											</Grid.RowDefinitions>
+
+											<StackPanel Orientation="Horizontal"
+														Margin="4,3"
+														Grid.Column="0"
+														Grid.Row="0">
 												<Image Width="18"
 													   Height="18"
 													   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/fire.png" />
 												<TextBlock Margin="3,0,15,0"
 														   Foreground="#5cccf8"
-														   Text="{Binding ModernizeFire, Mode=OneWay, StringFormat={}+{0}}" />
-
+														   Text="{Binding ModernizeFire, Mode=OneWay, StringFormat={}+{0}}">
+													<TextBlock.Style>
+														<Style TargetType="{x:Type TextBlock}">
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding ModernizeFire, Mode=OneWay}" Value="0">
+																	<Setter Property="Visibility" Value="Hidden" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</TextBlock.Style>
+												</TextBlock>
 												<StackPanel.Style>
 													<Style TargetType="{x:Type StackPanel}">
 														<Style.Triggers>
 															<DataTrigger Binding="{Binding ModernizeFire, Mode=OneWay}" Value="0">
-																<Setter Property="Visibility" Value="Collapsed" />
+																<Setter Property="Opacity" Value="0.33" />
 															</DataTrigger>
 														</Style.Triggers>
 													</Style>
 												</StackPanel.Style>
 											</StackPanel>
-
-											<StackPanel Orientation="Horizontal">
+											<StackPanel Orientation="Horizontal"
+														Margin="4,3"
+														Grid.Column="1"
+														Grid.Row="0">
 												<Image Width="18"
 													   Height="18"
 													   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/torpedo.png" />
 												<TextBlock Margin="3,0,15,0"
 														   Foreground="#5cccf8"
-														   Text="{Binding ModernizeTorpedo, Mode=OneWay, StringFormat={}+{0}}" />
-
+														   Text="{Binding ModernizeTorpedo, Mode=OneWay, StringFormat={}+{0}}">
+													<TextBlock.Style>
+														<Style TargetType="{x:Type TextBlock}">
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding ModernizeTorpedo, Mode=OneWay}" Value="0">
+																	<Setter Property="Visibility" Value="Hidden" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</TextBlock.Style>
+												</TextBlock>
 												<StackPanel.Style>
 													<Style TargetType="{x:Type StackPanel}">
 														<Style.Triggers>
 															<DataTrigger Binding="{Binding ModernizeTorpedo, Mode=OneWay}" Value="0">
-																<Setter Property="Visibility" Value="Collapsed" />
+																<Setter Property="Opacity" Value="0.33" />
 															</DataTrigger>
 														</Style.Triggers>
 													</Style>
 												</StackPanel.Style>
 											</StackPanel>
-
-											<StackPanel Orientation="Horizontal">
+											<StackPanel Orientation="Horizontal"
+														Margin="4,3"
+														Grid.Column="2"
+														Grid.Row="0">
 												<Image Width="18"
 													   Height="18"
 													   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/aa.png" />
 												<TextBlock Margin="3,0,15,0"
 														   Foreground="#5cccf8"
-														   Text="{Binding ModernizeAA, Mode=OneWay, StringFormat={}+{0}}" />
-
+														   Text="{Binding ModernizeAA, Mode=OneWay, StringFormat={}+{0}}">
+													<TextBlock.Style>
+														<Style TargetType="{x:Type TextBlock}">
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding ModernizeAA, Mode=OneWay}" Value="0">
+																	<Setter Property="Visibility" Value="Hidden" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</TextBlock.Style>
+												</TextBlock>
 												<StackPanel.Style>
 													<Style TargetType="{x:Type StackPanel}">
 														<Style.Triggers>
 															<DataTrigger Binding="{Binding ModernizeAA, Mode=OneWay}" Value="0">
-																<Setter Property="Visibility" Value="Collapsed" />
+																<Setter Property="Opacity" Value="0.33" />
 															</DataTrigger>
 														</Style.Triggers>
 													</Style>
 												</StackPanel.Style>
 											</StackPanel>
-
-											<StackPanel Orientation="Horizontal">
+											<StackPanel Orientation="Horizontal"
+														Margin="4,3"
+														Grid.Column="3"
+														Grid.Row="0">
 												<Image Width="18"
 													   Height="18"
 													   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/armor.png" />
 												<TextBlock Margin="3,0,15,0"
 														   Foreground="#5cccf8"
-														   Text="{Binding ModernizeArmor, Mode=OneWay, StringFormat={}+{0}}" />
-
+														   Text="{Binding ModernizeArmor, Mode=OneWay, StringFormat={}+{0}}">
+													<TextBlock.Style>
+														<Style TargetType="{x:Type TextBlock}">
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding ModernizeArmor, Mode=OneWay}" Value="0">
+																	<Setter Property="Visibility" Value="Hidden" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</TextBlock.Style>
+												</TextBlock>
 												<StackPanel.Style>
 													<Style TargetType="{x:Type StackPanel}">
 														<Style.Triggers>
 															<DataTrigger Binding="{Binding ModernizeArmor, Mode=OneWay}" Value="0">
-																<Setter Property="Visibility" Value="Collapsed" />
+																<Setter Property="Opacity" Value="0.33" />
 															</DataTrigger>
 														</Style.Triggers>
 													</Style>
 												</StackPanel.Style>
 											</StackPanel>
-										</StackPanel>
-										<StackPanel Margin="8,4,0,0"
-													Orientation="Horizontal">
-											<StackPanel Orientation="Horizontal">
+
+											<StackPanel Orientation="Horizontal"
+													Margin="4,3"
+													Grid.Column="0"
+													Grid.Row="1">
 												<Image Width="18"
 													   Height="18"
 													   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/fuel.png" />
 												<TextBlock Margin="3,0,15,0"
 														   Foreground="#5cccf8"
-														   Text="{Binding DestroyFuel, Mode=OneWay, StringFormat={}+{0}}" />
-
+														   Text="{Binding DestroyFuel, Mode=OneWay, StringFormat={}+{0}}">
+													<TextBlock.Style>
+														<Style TargetType="{x:Type TextBlock}">
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding DestroyFuel, Mode=OneWay}" Value="0">
+																	<Setter Property="Visibility" Value="Hidden" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</TextBlock.Style>
+												</TextBlock>
 												<StackPanel.Style>
 													<Style TargetType="{x:Type StackPanel}">
 														<Style.Triggers>
 															<DataTrigger Binding="{Binding DestroyFuel, Mode=OneWay}" Value="0">
-																<Setter Property="Visibility" Value="Collapsed" />
+																<Setter Property="Opacity" Value="0.33" />
 															</DataTrigger>
 														</Style.Triggers>
 													</Style>
 												</StackPanel.Style>
 											</StackPanel>
-
-											<StackPanel Orientation="Horizontal">
+											<StackPanel Orientation="Horizontal"
+													Margin="4,3"
+													Grid.Column="1"
+													Grid.Row="1">
 												<Image Width="18"
 													   Height="18"
 													   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/ammo.png" />
 												<TextBlock Margin="3,0,15,0"
 														   Foreground="#5cccf8"
-														   Text="{Binding DestroyAmmo, Mode=OneWay, StringFormat={}+{0}}" />
-
+														   Text="{Binding DestroyAmmo, Mode=OneWay, StringFormat={}+{0}}">
+													<TextBlock.Style>
+														<Style TargetType="{x:Type TextBlock}">
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding DestroyAmmo, Mode=OneWay}" Value="0">
+																	<Setter Property="Visibility" Value="Hidden" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</TextBlock.Style>
+												</TextBlock>
 												<StackPanel.Style>
 													<Style TargetType="{x:Type StackPanel}">
 														<Style.Triggers>
 															<DataTrigger Binding="{Binding DestroyAmmo, Mode=OneWay}" Value="0">
-																<Setter Property="Visibility" Value="Collapsed" />
+																<Setter Property="Opacity" Value="0.33" />
 															</DataTrigger>
 														</Style.Triggers>
 													</Style>
 												</StackPanel.Style>
 											</StackPanel>
-
-											<StackPanel Orientation="Horizontal">
+											<StackPanel Orientation="Horizontal"
+													Margin="4,3"
+													Grid.Column="2"
+													Grid.Row="1">
 												<Image Width="18"
 													   Height="18"
 													   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/steel.png" />
 												<TextBlock Margin="3,0,15,0"
 														   Foreground="#5cccf8"
-														   Text="{Binding DestroySteel, Mode=OneWay, StringFormat={}+{0}}" />
-
+														   Text="{Binding DestroySteel, Mode=OneWay, StringFormat={}+{0}}">
+													<TextBlock.Style>
+														<Style TargetType="{x:Type TextBlock}">
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding DestroySteel, Mode=OneWay}" Value="0">
+																	<Setter Property="Visibility" Value="Hidden" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</TextBlock.Style>
+												</TextBlock>
 												<StackPanel.Style>
 													<Style TargetType="{x:Type StackPanel}">
 														<Style.Triggers>
 															<DataTrigger Binding="{Binding DestroySteel, Mode=OneWay}" Value="0">
-																<Setter Property="Visibility" Value="Collapsed" />
+																<Setter Property="Opacity" Value="0.33" />
 															</DataTrigger>
 														</Style.Triggers>
 													</Style>
 												</StackPanel.Style>
 											</StackPanel>
-
-											<StackPanel Orientation="Horizontal">
+											<StackPanel Orientation="Horizontal"
+													Margin="4,3"
+													Grid.Column="3"
+													Grid.Row="1">
 												<Image Width="18"
 													   Height="18"
 													   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/bauxite.png" />
 												<TextBlock Margin="3,0,15,0"
 														   Foreground="#5cccf8"
-														   Text="{Binding DestroyBauxite, Mode=OneWay, StringFormat={}+{0}}" />
-
+														   Text="{Binding DestroyBauxite, Mode=OneWay, StringFormat={}+{0}}">
+													<TextBlock.Style>
+														<Style TargetType="{x:Type TextBlock}">
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding DestroyBauxite, Mode=OneWay}" Value="0">
+																	<Setter Property="Visibility" Value="Hidden" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</TextBlock.Style>
+												</TextBlock>
 												<StackPanel.Style>
 													<Style TargetType="{x:Type StackPanel}">
 														<Style.Triggers>
 															<DataTrigger Binding="{Binding DestroyBauxite, Mode=OneWay}" Value="0">
-																<Setter Property="Visibility" Value="Collapsed" />
+																<Setter Property="Opacity" Value="0.33" />
 															</DataTrigger>
 														</Style.Triggers>
 													</Style>
 												</StackPanel.Style>
 											</StackPanel>
-										</StackPanel>
+										</Grid>
+									</StackPanel>
+
+									<StackPanel Orientation="Vertical"
+												Margin="8,20,0,0">
+										<TextBlock Foreground="White"
+												   Text="개장 정보" />
+
+										<ItemsControl ItemsSource="{Binding Upgrades, Mode=OneWay}">
+											<ItemsControl.ItemsPanel>
+												<ItemsPanelTemplate>
+													<WrapPanel Orientation="Horizontal" />
+												</ItemsPanelTemplate>
+											</ItemsControl.ItemsPanel>
+											<ItemsControl.ItemTemplate>
+												<DataTemplate>
+													<metro2:CallMethodButton Padding="4"
+																			 Margin="5,3"
+																			 MethodName="SetShip"
+																			 MethodParameter="{Binding Id, Mode=OneWay}">
+														<metro2:CallMethodButton.Content>
+															<Grid Width="160"
+																  Margin="5,3">
+																<Grid.ColumnDefinitions>
+																	<ColumnDefinition Width="*" />
+																	<ColumnDefinition Width="*" />
+																</Grid.ColumnDefinitions>
+																<Grid.RowDefinitions>
+																	<RowDefinition Height="Auto" />
+																	<RowDefinition Height="Auto" />
+																	<RowDefinition Height="Auto" />
+																</Grid.RowDefinitions>
+
+																<Image Grid.ColumnSpan="2"
+																	   Width="160"
+																	   Height="40"
+																	   Source="{Binding BadgeImage, Mode=OneWay}" />
+
+																<TextBlock Grid.Column="0"
+																		   Grid.Row="1"
+																		   Margin="0,3"
+																		   HorizontalAlignment="Left"
+																		   Text="{Binding Name, Mode=OneWay}"
+																		   FontSize="10"
+																		   TextWrapping="Wrap" />
+																<TextBlock Grid.Column="1"
+																		   Grid.Row="1"
+																		   Margin="0,3"
+																		   HorizontalAlignment="Right"
+																		   Text="{Binding RequiredLevel, Mode=OneWay,StringFormat={}Lv.{0}}"
+																		   FontSize="10"
+																		   TextWrapping="Wrap" />
+
+																<TextBlock Grid.Column="0"
+																		   Grid.ColumnSpan="2"
+																		   Grid.Row="2"
+																		   HorizontalAlignment="Center"
+																		   Text="{Binding Requires, Mode=OneWay}"
+																		   FontSize="10"
+																		   TextWrapping="Wrap">
+																	<TextBlock.Style>
+																		<Style TargetType="{x:Type TextBlock}">
+																			<Style.Triggers>
+																				<DataTrigger Binding="{Binding Requires, Mode=OneWay}" Value="">
+																					<Setter Property="Visibility" Value="Collapsed" />
+																				</DataTrigger>
+																			</Style.Triggers>
+																		</Style>
+																	</TextBlock.Style>
+																</TextBlock>
+															</Grid>
+														</metro2:CallMethodButton.Content>
+													</metro2:CallMethodButton>
+												</DataTemplate>
+											</ItemsControl.ItemTemplate>
+										</ItemsControl>
 									</StackPanel>
 								</StackPanel>
 							</ScrollViewer>

--- a/source/Grabacr07.KanColleViewer/Views/Catalogs/DictionaryWindow.xaml.cs
+++ b/source/Grabacr07.KanColleViewer/Views/Catalogs/DictionaryWindow.xaml.cs
@@ -1,0 +1,12 @@
+﻿namespace Grabacr07.KanColleViewer.Views.Catalogs
+{
+	partial class DictionaryWindow
+	{
+		public DictionaryWindow()
+		{
+			this.InitializeComponent();
+
+			Application.Instance.MainWindow.Closed += (sender, args) => this.Close();
+		}
+	}
+}

--- a/source/Grabacr07.KanColleViewer/Views/Contents/Overview.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Contents/Overview.xaml
@@ -379,79 +379,55 @@
 				<Border Visibility="{Binding Horizontal}">
 					<ScrollViewer VerticalScrollBarVisibility="Disabled"
 								  HorizontalScrollBarVisibility="Auto">
-						<Grid>
-							<Grid.RowDefinitions>
-								<RowDefinition Height="Auto"/>
-								<RowDefinition Height="Auto"/>
-							</Grid.RowDefinitions>
-							<Grid.ColumnDefinitions>
-								<ColumnDefinition Width="Auto"/>
-								<ColumnDefinition Width="Auto"/>
-								<ColumnDefinition Width="Auto"/>
-								<ColumnDefinition Width="Auto"/>
-								<ColumnDefinition Width="Auto"/>
-								<ColumnDefinition Width="Auto"/>
-							</Grid.ColumnDefinitions>
-
+						<UniformGrid Rows="2">
 							<metro2:CallMethodButton Content="함선목록"
-												 Grid.Column="2"
 												 Padding="10,4"
 												 MinWidth="70"
-												 Margin="7,0"
+												 Margin="4,2"
 												 MethodName="ShowShipCatalog" />
-
 							<metro2:CallMethodButton Content="개수공창"
-												 Grid.Column="3"
 												 Padding="10,4"
 												 MinWidth="70"
-												 Margin="0,0,7,0"
+												 Margin="4,2"
 												 MethodName="ShowRemodelWindow" />
-
 							<metro2:CallMethodButton Content="계산기"
-												 Grid.Column="4"
 												 ToolTip="각종 수치 계산기입니다. 목표 경험치, 연습전 경험치, 기항대 계산기"
 												 Padding="10,4"
 												 MinWidth="70"
-												 Margin="0,0,7,0"
+												 Margin="4,2"
 												 MethodName="Calculator" />
-
 							<metro2:CallMethodButton Content="원정목록"
-												 Grid.Column="5"
 												 Padding="10,4"
 												 MinWidth="70"
-												 Margin="0,0,7,0"
+												 Margin="4,2"
 												 MethodName="ExpeditionsCatalogWindow" />
+							<metro2:CallMethodButton Content="사전열람"
+												 Padding="10,4"
+												 MinWidth="70"
+												 Margin="4,2"
+												 MethodName="ShowDictionary"/>
 
 							<metro2:CallMethodButton Content="장비목록"
-												 Grid.Column="2"
-												 Grid.Row="1"
 												 Padding="10,4"
 												 MinWidth="70"
-												 Margin="7,3,7,0"
-												 MethodName="ShowSlotItemCatalog">
-							</metro2:CallMethodButton>
+												 Margin="4,2"
+												 MethodName="ShowSlotItemCatalog" />
 							<metro2:CallMethodButton Content="수리목록" 
-												 Grid.Column="3"
-												 Grid.Row="1"
 												 Padding="10,4"
 												 MinWidth="70"
-												 Margin="0,3,7,0"
+												 Margin="4,2"
 												 MethodName="ShowNdockShipCatalog"/>
 							<metro2:CallMethodButton Content="메모장" 
-												 Grid.Column="4"
-												 Grid.Row="1"
 												 Padding="10,4"
 												 MinWidth="70"
-												 Margin="0,3,7,0"
+												 Margin="4,2"
 												 MethodName="ShowNotePad"/>
 							<metro2:CallMethodButton Content="기록열람"
 												 Padding="10,4"
 												 MinWidth="70"
-												 Grid.Row="1"
-												 Grid.Column="5"
-												 Margin="0,3,7,0"
+												 Margin="4,2"
 												 MethodName="ShowLogViewer"/>
-						</Grid>
+						</UniformGrid>
 					</ScrollViewer>
 				</Border>
 				<Border VerticalAlignment="Top">
@@ -627,6 +603,11 @@
 												 Margin="2,0,2,4"
 												 Grid.Row="7"
 												 MethodName="ShowLogViewer"/>
+						<metro2:CallMethodButton Content="사전열람"
+												 Padding="10,4"
+												 MinWidth="70"
+												 Margin="4,2"
+												 MethodName="ShowDictionary"/>
 					</Grid>
 				</ScrollViewer>
 			</Border>

--- a/source/Grabacr07.KanColleWrapper/KanColleWrapper.csproj
+++ b/source/Grabacr07.KanColleWrapper/KanColleWrapper.csproj
@@ -153,6 +153,7 @@
     <Compile Include="Models\Raw\kcsapi_empty_result.cs" />
     <Compile Include="Models\Raw\kcsapi_mst_mapcell.cs" />
     <Compile Include="Models\Raw\kcsapi_mst_shipgraph.cs" />
+    <Compile Include="Models\Raw\kcsapi_mst_shipupgrade.cs" />
     <Compile Include="Models\Raw\kcsapi_practice_result.cs" />
     <Compile Include="Models\Raw\kcsapi_require_info.cs" />
     <Compile Include="Models\Raw\kcsapi_ship_deck.cs" />

--- a/source/Grabacr07.KanColleWrapper/KanColleWrapper.csproj
+++ b/source/Grabacr07.KanColleWrapper/KanColleWrapper.csproj
@@ -152,6 +152,7 @@
     <Compile Include="Models\Raw\kcsapi_data_support_info.cs" />
     <Compile Include="Models\Raw\kcsapi_empty_result.cs" />
     <Compile Include="Models\Raw\kcsapi_mst_mapcell.cs" />
+    <Compile Include="Models\Raw\kcsapi_mst_shipgraph.cs" />
     <Compile Include="Models\Raw\kcsapi_practice_result.cs" />
     <Compile Include="Models\Raw\kcsapi_require_info.cs" />
     <Compile Include="Models\Raw\kcsapi_ship_deck.cs" />

--- a/source/Grabacr07.KanColleWrapper/Master.cs
+++ b/source/Grabacr07.KanColleWrapper/Master.cs
@@ -13,6 +13,8 @@ namespace Grabacr07.KanColleWrapper
 	/// </summary>
 	public class Master
 	{
+		public kcsapi_start2 RawData { get; }
+
 		/// <summary>
 		/// すべての艦娘の定義を取得します。
 		/// </summary>
@@ -62,6 +64,8 @@ namespace Grabacr07.KanColleWrapper
 
 		internal Master(kcsapi_start2 start2)
 		{
+			this.RawData = start2;
+
 			this.ShipTypes = new MasterTable<ShipType>(start2.api_mst_stype.Select(x => new ShipType(x)));
 			this.Ships = new MasterTable<ShipInfo>(start2.api_mst_ship.Select(x => new ShipInfo(x)));
 			this.SlotItemEquipTypes = new MasterTable<SlotItemEquipType>(start2.api_mst_slotitem_equiptype.Select(x => new SlotItemEquipType(x)));

--- a/source/Grabacr07.KanColleWrapper/Models/CombinedFleet.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/CombinedFleet.cs
@@ -74,12 +74,14 @@ namespace Grabacr07.KanColleWrapper.Models
 					h => new EventHandler(h),
 					h => source.State.Updated += h,
 					h => source.State.Updated -= h,
-					(sender, args) => this.State.Update()));
+					(sender, args) => this.State.Update()
+				));
 				this.CompositeDisposable.Add(new WeakEventListener<EventHandler, EventArgs>(
 					h => new EventHandler(h),
 					h => source.State.Calculated += h,
 					h => source.State.Calculated -= h,
-					(sender, args) => this.State.Calculate()));
+					(sender, args) => this.State.Calculate()
+				));
 			}
 
 			this.UpdateName();

--- a/source/Grabacr07.KanColleWrapper/Models/Raw/kcsapi_mst_shipgraph.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/Raw/kcsapi_mst_shipgraph.cs
@@ -1,0 +1,11 @@
+﻿namespace Grabacr07.KanColleWrapper.Models.Raw
+{
+	// ReSharper disable InconsistentNaming
+	public class kcsapi_mst_shipgraph
+	{
+		public int api_id { get; set; }
+		public int api_sortno { get; set; }
+		public string api_filename { get; set; }
+	}
+	// ReSharper restore InconsistentNaming
+}

--- a/source/Grabacr07.KanColleWrapper/Models/Raw/kcsapi_mst_shipupgrade.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/Raw/kcsapi_mst_shipupgrade.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Grabacr07.KanColleWrapper.Models.Raw
+{
+	// ReSharper disable InconsistentNaming
+	public class kcsapi_mst_shipupgrade
+	{
+		public int api_id { get; set; }
+
+		public int api_current_ship_id { get; set; }
+		public int api_original_ship_id { get; set; }
+
+		public int api_upgrade_type { get; set; }
+		public int api_upgrade_level { get; set; }
+
+		public int api_drawing_count { get; set; }
+		public int api_catapult_count { get; set; }
+
+		public int api_sortno { get; set; }
+	}
+	// ReSharper restore InconsistentNaming
+}

--- a/source/Grabacr07.KanColleWrapper/Models/Raw/kcsapi_start2.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/Raw/kcsapi_start2.cs
@@ -10,6 +10,7 @@ namespace Grabacr07.KanColleWrapper.Models.Raw
 	{
 		public kcsapi_mst_ship[] api_mst_ship { get; set; }
 		public kcsapi_mst_shipgraph[] api_mst_shipgraph { get; set; }
+		public kcsapi_mst_shipupgrade[] api_mst_shipupgrade { get; set; }
 		public kcsapi_mst_slotitem_equiptype[] api_mst_slotitem_equiptype { get; set; }
 		public kcsapi_mst_stype[] api_mst_stype { get; set; }
 		public kcsapi_mst_slotitem[] api_mst_slotitem { get; set; }

--- a/source/Grabacr07.KanColleWrapper/Models/Raw/kcsapi_start2.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/Raw/kcsapi_start2.cs
@@ -9,6 +9,7 @@ namespace Grabacr07.KanColleWrapper.Models.Raw
 	public class kcsapi_start2
 	{
 		public kcsapi_mst_ship[] api_mst_ship { get; set; }
+		public kcsapi_mst_shipgraph[] api_mst_shipgraph { get; set; }
 		public kcsapi_mst_slotitem_equiptype[] api_mst_slotitem_equiptype { get; set; }
 		public kcsapi_mst_stype[] api_mst_stype { get; set; }
 		public kcsapi_mst_slotitem[] api_mst_slotitem { get; set; }

--- a/source/Grabacr07.KanColleWrapper/Organization.cs
+++ b/source/Grabacr07.KanColleWrapper/Organization.cs
@@ -134,7 +134,7 @@ namespace Grabacr07.KanColleWrapper
 			proxy.api_req_hokyu_charge.TryParse<kcsapi_charge>().Subscribe(x => this.Charge(x.Data));
 			proxy.api_req_kaisou_powerup.TryParse<kcsapi_powerup>().Subscribe(this.Powerup);
 			proxy.api_req_kaisou_slot_exchange_index.TryParse<kcsapi_slot_exchange_index>().Subscribe(this.ExchangeSlot);
-            proxy.api_req_kaisou_slot_deprive.TryParse<kcsapi_slot_deprive>().Subscribe(x => this.DepriveSlotItem(x.Data));
+			proxy.api_req_kaisou_slot_deprive.TryParse<kcsapi_slot_deprive>().Subscribe(x => this.DepriveSlotItem(x.Data));
 
 			proxy.api_req_kousyou_getship.TryParse<kcsapi_kdock_getship>().Subscribe(x => this.GetShip(x.Data));
 			proxy.api_req_kousyou_destroyship.TryParse<kcsapi_destroyship>().Subscribe(this.DestoryShip);
@@ -380,15 +380,15 @@ namespace Grabacr07.KanColleWrapper
 
 		#endregion
 
-        #region 改装 (DepriveSlotItem)
+		#region 改装 (DepriveSlotItem)
 
-        private void DepriveSlotItem(kcsapi_slot_deprive source)
-        {
-            this.Ships[source.api_ship_data.api_unset_ship.api_id]?.Update(source.api_ship_data.api_unset_ship);
-            this.Ships[source.api_ship_data.api_set_ship.api_id]?.Update(source.api_ship_data.api_set_ship);
-        }
+		private void DepriveSlotItem(kcsapi_slot_deprive source)
+		{
+			this.Ships[source.api_ship_data.api_unset_ship.api_id]?.Update(source.api_ship_data.api_unset_ship);
+			this.Ships[source.api_ship_data.api_set_ship.api_id]?.Update(source.api_ship_data.api_set_ship);
+		}
 
-        #endregion
+		#endregion
 
 		#region 工廠 (Get / Destroy)
 

--- a/source/KanColleViewer.sln
+++ b/source/KanColleViewer.sln
@@ -83,9 +83,6 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KanColleViewer.QuestTracker", "Grabacr07.KanColleViewer.QuestTracker\KanColleViewer.QuestTracker.csproj", "{039E4D88-DECD-494D-92D2-407C6403A010}"
 EndProject
 Global
-	GlobalSection(Performance) = preSolution
-		HasPerformanceSessions = true
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug|x86 = Debug|x86

--- a/source/KanColleViewer.sln
+++ b/source/KanColleViewer.sln
@@ -83,6 +83,9 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KanColleViewer.QuestTracker", "Grabacr07.KanColleViewer.QuestTracker\KanColleViewer.QuestTracker.csproj", "{039E4D88-DECD-494D-92D2-407C6403A010}"
 EndProject
 Global
+	GlobalSection(Performance) = preSolution
+		HasPerformanceSessions = true
+	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug|x86 = Debug|x86


### PR DESCRIPTION
### ↯ 다운로드
- GitHub [다운로드](https://github.com/CirnoV/KanColleViewer/releases/download/v4.2.10r12/KanColleViewer-KR.4.2.10.r12.zip)
- MEGA [다운로드](https://mega.nz/#!vowUTDCT!6-poOIRLtI2MijtsaS6UziVZtFCQJmIXAKEkh0VLlh0)

### 🔗 외부 링크
- VirusTotal [검사 결과](https://virustotal.com/ko/file/8e9326d6480aaea76c27c4d6270b12ec80238ce0f3e31490a97463f5ab3bac6d/analysis/1495480366/)
- OpenDB Project Website ([http://swaytwig.com/opendb/](http://swaytwig.com/opendb/))

질문 및 건의사항은 [wolfgangkurzdev@gmail.com](mailto:wolfgangkurzdev@gmail.com) 으로 메일 부탁드립니다.

----

### 💬 업데이트
- 업데이트 페이지를 갱신했습니다.
  * 이후 업데이트 내역은 [GitHub의 Pull requests](https://github.com/CirnoV/KanColleViewer/pulls)를 통해 관리됩니다.

### 💬 공통
- 메모리 정리 작동을 최적화했습니다.
  * 메모리 정리시에도 뷰어 및 게임이 멈추는 현상이 최소화되었습니다.
- 메모리 누수 문제를 수정했습니다.
  * 뷰어를 장시간 사용하거나, 연합함대를 사용할 때 메모리가 비정상적으로 높아지는 문제를 수정했습니다.
- 구동시 자원 등 각종 정보가 표시되지 않던 문제를 수정했습니다.
  * 하단의 "**💬 BattleInfo 플러그인**" 항목을 참조하세요.

### 💬 번역
- 신규 함선의 번역이 추가되었습니다.
  * 나가토改2
- 일부 장비의 번역이 갱신되었습니다.
  * 심해 30.5cm 삼연장포 → 심해 12inch 삼연장포
- 일부 퀘스트의 번역이 추가되었습니다.
  * 퀘스트 번역은 개발자가 플레이하면서 확인되는 퀘스트만 번역중입니다.

### 💬 데이터 사전
- 새로운 기능인 데이터 사전이 추가되었습니다.
  * 종합 탭의 "**사전열람**" 버튼으로 열람할 수 있습니다.
  * 칸무스/장비 리스트를 구성하는 동안 뷰어가 장시간 멈출 수 있습니다.
  * 일부 정보 (회피, 대잠, 색적, 초기장비) 정보는 [WhoCallsTheFleet](https://github.com/Diablohu/WhoCallsTheFleet/) 의 정보를 실시간으로 불러와서 사용합니다.
  * 데이터 사전에 사용된 모든 이미지는 [KanColleAssets](https://github.com/WolfgangKurz/KanColleAssets/) 의 정보를 실시간으로 불러와서 사용합니다.

### 💬 함대 탭
- 대잠 수치 도우미를 최적화했습니다.
  * 편성이나 장비가 변경될 때, 도우미가 뷰어를 멈추게 하는 문제를 수정했습니다.

### 💬 BattleInfo 플러그인
- 각종 계산 문제를 수정했습니다.
  * 연습전을 시작할 때 정보가 정리되지 않아 데미지 및 랭크 계산에 문제가 있던 점을 수정했습니다.
  * 단일 함대vs단일 함대 전투에서 야전시 데미지 및 랭크 계산에 문제가 있던 점을 수정했습니다.
  * 연합함대 vs 연합함대의 데미지 계산 문제를 수정했습니다.
  * 기동연합 및 수송연합과 수상연합의 데미지 계산을 분리하지 않아서 발생하던 문제였습니다.
- 기믹 발동 여부가 표시의 문제를 수정했습니다.
  * 해당 기능 구현이 잘못되어 이벤트가 진행중이지 않을 때 뷰어를 시작하면 모항 정보가 갱신되지 않는 문제가 수정되었습니다.
