### PR TITLE
v4.2.10 rev13

### DIFF
--- a/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
@@ -15,4 +15,4 @@ using System.Windows;
 	ResourceDictionaryLocation.None,
 	ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("4.2.10.12")]
+[assembly: AssemblyVersion("4.2.10.13")]

--- a/source/Grabacr07.KanColleViewer/Views/Contents/Overview.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Contents/Overview.xaml
@@ -383,49 +383,49 @@
 							<metro2:CallMethodButton Content="함선목록"
 												 Padding="10,4"
 												 MinWidth="70"
-												 Margin="4,2"
+												 Margin="2"
 												 MethodName="ShowShipCatalog" />
 							<metro2:CallMethodButton Content="개수공창"
 												 Padding="10,4"
 												 MinWidth="70"
-												 Margin="4,2"
+												 Margin="2"
 												 MethodName="ShowRemodelWindow" />
 							<metro2:CallMethodButton Content="계산기"
 												 ToolTip="각종 수치 계산기입니다. 목표 경험치, 연습전 경험치, 기항대 계산기"
 												 Padding="10,4"
 												 MinWidth="70"
-												 Margin="4,2"
+												 Margin="2"
 												 MethodName="Calculator" />
 							<metro2:CallMethodButton Content="원정목록"
 												 Padding="10,4"
 												 MinWidth="70"
-												 Margin="4,2"
+												 Margin="2"
 												 MethodName="ExpeditionsCatalogWindow" />
 							<metro2:CallMethodButton Content="사전열람"
 												 Padding="10,4"
 												 MinWidth="70"
-												 Margin="4,2"
+												 Margin="2"
 												 MethodName="ShowDictionary"/>
 
 							<metro2:CallMethodButton Content="장비목록"
 												 Padding="10,4"
 												 MinWidth="70"
-												 Margin="4,2"
+												 Margin="2"
 												 MethodName="ShowSlotItemCatalog" />
 							<metro2:CallMethodButton Content="수리목록" 
 												 Padding="10,4"
 												 MinWidth="70"
-												 Margin="4,2"
+												 Margin="2"
 												 MethodName="ShowNdockShipCatalog"/>
 							<metro2:CallMethodButton Content="메모장" 
 												 Padding="10,4"
 												 MinWidth="70"
-												 Margin="4,2"
+												 Margin="2"
 												 MethodName="ShowNotePad"/>
 							<metro2:CallMethodButton Content="기록열람"
 												 Padding="10,4"
 												 MinWidth="70"
-												 Margin="4,2"
+												 Margin="2"
 												 MethodName="ShowLogViewer"/>
 						</UniformGrid>
 					</ScrollViewer>
@@ -543,25 +543,13 @@
 					Grid.RowSpan="3">
 				<ScrollViewer VerticalScrollBarVisibility="Disabled"
 								  HorizontalScrollBarVisibility="Auto">
-					<Grid>
-						<Grid.RowDefinitions>
-							<RowDefinition Height="Auto"/>
-							<RowDefinition Height="Auto"/>
-							<RowDefinition Height="Auto"/>
-							<RowDefinition Height="Auto"/>
-							<RowDefinition Height="Auto"/>
-							<RowDefinition Height="Auto"/>
-							<RowDefinition Height="Auto"/>
-							<RowDefinition Height="Auto"/>
-						</Grid.RowDefinitions>
-
+					<StackPanel Orientation="Vertical">
 						<metro2:CallMethodButton Content="함선목록"
 												 Padding="10,4"
 												 MinWidth="70"
 												 Margin="2,4"
 												 MethodName="ShowShipCatalog" />
 						<metro2:CallMethodButton Content="장비목록"
-												 Grid.Row="1"
 												 Padding="10,4"
 												 MinWidth="70"
 												 Margin="2,0,2,4"
@@ -569,13 +557,11 @@
 						<metro2:CallMethodButton Content="원정목록"
 												 Padding="10,4"
 												 MinWidth="70"
-												 Grid.Row="2"
 												 Margin="2,0,2,4"
 												 MethodName="ExpeditionsCatalogWindow" />
 						<metro2:CallMethodButton Content="계산기"
 												 ToolTip="각종 수치 계산기입니다. 목표 경험치, 연습전 경험치, 기항대 계산기"
 												 Padding="10,4"
-												 Grid.Row="3"
 												 MinWidth="70"
 												 Margin="2,0,2,4"
 												 MethodName="Calculator" />
@@ -583,16 +569,13 @@
 												 Padding="10,4"
 												 MinWidth="70"
 												 Margin="2,0,2,4"
-												 Grid.Row="4"
 												 MethodName="ShowRemodelWindow" />
-						<metro2:CallMethodButton Content="수리목록" 
-												 Grid.Row="5"
+						<metro2:CallMethodButton Content="수리목록"
 												 Padding="10,4"
 												 Margin="2,0,2,4"
 												 MinWidth="70"
 												 MethodName="ShowNdockShipCatalog"/>
-						<metro2:CallMethodButton Content="메모장" 
-												 Grid.Row="6"
+						<metro2:CallMethodButton Content="메모장"
 												 Padding="10,4"
 												 Margin="2,0,2,4"
 												 MinWidth="70"
@@ -601,14 +584,13 @@
 												 Padding="10,4"
 												 MinWidth="70"
 												 Margin="2,0,2,4"
-												 Grid.Row="7"
 												 MethodName="ShowLogViewer"/>
 						<metro2:CallMethodButton Content="사전열람"
 												 Padding="10,4"
 												 MinWidth="70"
-												 Margin="4,2"
+												 Margin="2,0,2,4"
 												 MethodName="ShowDictionary"/>
-					</Grid>
+					</StackPanel>
 				</ScrollViewer>
 			</Border>
 			<Grid Grid.Column="2" Grid.Row="1">


### PR DESCRIPTION
### ↯ 다운로드
- GitHub [다운로드](https://github.com/CirnoV/KanColleViewer/releases/download/v4.2.10r13/KanColleViewer-KR.4.2.10.r13.zip)
- MEGA [다운로드](https://mega.nz/#!ykwiXCyR!dYh7xuND5d_MKohxPAk1updEnD_HWxp6b388EIJ2xJg)

### 🔗 외부 링크
- VirusTotal [검사 결과](https://virustotal.com/ko/file/60244d2114655e347fc8ba3312fa721b4d6435816e99fab798775b96ef53e32d/analysis/1495509011/)
- OpenDB Project Website ([http://swaytwig.com/opendb/](http://swaytwig.com/opendb/))
- 업데이트 페이지 [http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html](http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html)

질문 및 건의사항은 [wolfgangkurzdev@gmail.com](mailto:wolfgangkurzdev@gmail.com) 으로 메일 부탁드립니다.
뷰어 사용중 오류가 발생하는 경우, error.log 혹은 battleinfo_error.log 를 첨부해주시면 해결에 도움이 됩니다.

----

### 💬 공통
- 종합 탭의 버튼들 레이아웃을 약간 수정했습니다.
- 뷰어를 세로 레이아웃으로 사용할 때 "**함선목록**" 버튼이 "**사전열람**" 버튼에 덮어씌워지는 문제를 수정했습니다.

### 💬 BattleInfo 플러그인
- 각종 계산 문제를 수정했습니다.
  * 연습전에서 대파가 발생한 경우 알림을 표시하던 문제를 수정했습니다.
  * 연습전에서 함선이 다메콘을 가지고 있는 경우, 굉침 처리시 다메콘이 사용된 것으로 처리되는 문제를 수정했습니다.
