### PR TITLE
v4.2.10 rev14

### DIFF
--- a/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
@@ -15,4 +15,4 @@ using System.Windows;
 	ResourceDictionaryLocation.None,
 	ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("4.2.10.13")]
+[assembly: AssemblyVersion("4.2.10.14")]

--- a/source/Grabacr07.KanColleViewer/ViewModels/Catalogs/DictionaryViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/Catalogs/DictionaryViewModel.cs
@@ -405,42 +405,60 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 			? Math.Floor(this.MaxAmmo * 0.85) + " (-15%)"
 			: this.MaxAmmo.ToString();
 
+		public TimeSpan? BuildTime => this.Ship != null
+			? TimeSpan.FromMinutes(this.Ship.RawData.api_buildtime)
+			: (TimeSpan?)null;
+		public string BuildTimeText =>
+			this.BuildTime != null
+			? $"{(int)this.BuildTime.Value.TotalHours:D2}:{this.BuildTime.Value.ToString(@"mm\:ss")}"
+			: "--:--:--";
+			
+
 		private void UpdateAllValues()
 		{
 			this.RaisePropertyChanged(nameof(this.MarriageHP));
 			this.RaisePropertyChanged(nameof(this.MarriageHPResult));
 
+			this.RaisePropertyChanged(nameof(this.AbyssalHP));
 			this.RaisePropertyChanged(nameof(this.HP));
 			this.RaisePropertyChanged(nameof(this.CurHP));
 
+			this.RaisePropertyChanged(nameof(this.AbyssalArmor));
 			this.RaisePropertyChanged(nameof(this.MinArmor));
 			this.RaisePropertyChanged(nameof(this.MaxArmor));
 			this.RaisePropertyChanged(nameof(this.CurArmor));
 
+			this.RaisePropertyChanged(nameof(this.AbyssalEvasion));
 			this.RaisePropertyChanged(nameof(this.MinEvasion));
 			this.RaisePropertyChanged(nameof(this.MaxEvasion));
 			this.RaisePropertyChanged(nameof(this.CurEvasion));
 
+			this.RaisePropertyChanged(nameof(this.AbyssalFire));
 			this.RaisePropertyChanged(nameof(this.MinFire));
 			this.RaisePropertyChanged(nameof(this.MaxFire));
 			this.RaisePropertyChanged(nameof(this.CurFire));
 
+			this.RaisePropertyChanged(nameof(this.AbyssalTorpedo));
 			this.RaisePropertyChanged(nameof(this.MinTorpedo));
 			this.RaisePropertyChanged(nameof(this.MaxTorpedo));
 			this.RaisePropertyChanged(nameof(this.CurTorpedo));
 
+			this.RaisePropertyChanged(nameof(this.AbyssalAA));
 			this.RaisePropertyChanged(nameof(this.MinAA));
 			this.RaisePropertyChanged(nameof(this.MaxAA));
 			this.RaisePropertyChanged(nameof(this.CurAA));
 
+			this.RaisePropertyChanged(nameof(this.AbyssalASW));
 			this.RaisePropertyChanged(nameof(this.MinASW));
 			this.RaisePropertyChanged(nameof(this.MaxASW));
 			this.RaisePropertyChanged(nameof(this.CurASW));
 
+			this.RaisePropertyChanged(nameof(this.AbyssalLOS));
 			this.RaisePropertyChanged(nameof(this.MinLOS));
 			this.RaisePropertyChanged(nameof(this.MaxLOS));
 			this.RaisePropertyChanged(nameof(this.CurLOS));
 
+			this.RaisePropertyChanged(nameof(this.AbyssalLuck));
 			this.RaisePropertyChanged(nameof(this.MinLuck));
 			this.RaisePropertyChanged(nameof(this.MaxLuck));
 			this.RaisePropertyChanged(nameof(this.CurLuck));
@@ -450,6 +468,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 
 			this.RaisePropertyChanged(nameof(this.MaxAmmo));
 			this.RaisePropertyChanged(nameof(this.CurMaxAmmo));
+			this.RaisePropertyChanged(nameof(this.BuildTimeText));
 		}
 		#endregion
 

--- a/source/Grabacr07.KanColleViewer/ViewModels/Catalogs/DictionaryViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/Catalogs/DictionaryViewModel.cs
@@ -24,13 +24,39 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 		internal static IEnumerable<kcsapi_mst_shipgraph> shipGraphics
 			=> KanColleClient.Current.Master.RawData?.api_mst_shipgraph ?? new kcsapi_mst_shipgraph[0];
 
-		internal static IEnumerable<ships_nedb> shipInfos { get; private set; }
-			= new ships_nedb[0];
+		internal static IEnumerable<ships_nedb> shipInfos { get; private set; } = new ships_nedb[0];
+		internal static IEnumerable<ships_abyssal_info> abyssalShipInfos { get; private set; } = new ships_abyssal_info[0];
 
 		static DictionaryViewModel()
 		{
 			new Thread(async () =>
 			{
+				#region Abyssal Informations
+				using (var client = new HttpClient())
+				{
+					try
+					{
+						var response = await client.GetAsync("https://wolfgangkurz.github.io/KanColleAssets/abyssal_table.json");
+						if (!response.IsSuccessStatusCode) return;
+
+						var json = await response.Content.ReadAsStringAsync();
+						var bytes = Encoding.UTF8.GetBytes(json);
+
+						DataContractJsonSerializerSettings settings = new DataContractJsonSerializerSettings();
+						settings.UseSimpleDictionaryFormat = true;
+
+						var serializer = new DataContractJsonSerializer(typeof(ships_abyssal_info[]), settings);
+						using (var stream = new MemoryStream(bytes))
+						{
+							var rawResult = serializer.ReadObject(stream) as ships_abyssal_info[];
+							abyssalShipInfos = rawResult;
+						}
+					}
+					catch (HttpRequestException) { return; }
+				}
+				#endregion
+
+				#region Ship datas (WhoCallsTheFleet)
 				using (var client = new HttpClient())
 				{
 					try
@@ -62,6 +88,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 					}
 					catch (HttpRequestException) { return; }
 				}
+				#endregion
 			}).Start();
 		}
 
@@ -125,14 +152,38 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 				}
 			}
 		}
+
+		private string _SearchText { get; set; }
+		public string SearchText
+		{
+			get { return this._SearchText; }
+			set
+			{
+				if (this._SearchText != value)
+				{
+					this._SearchText = value;
+					this.RaisePropertyChanged();
+
+					this.UpdateList();
+				}
+			}
+		}
 		#endregion
 
 		public DictionaryShipViewModel()
 		{
+			UpdateList();
+		}
+
+		private void UpdateList()
+		{
 			this.ShipList = KanColleClient.Current.Master.Ships
 				.OrderBy(x => x.Value.Id)
+				.Where(x => x.Value.Name.IndexOf(this.SearchText ?? "", StringComparison.CurrentCultureIgnoreCase) >= 0)
 				.Select(x => new ShipItemViewModel(this, x.Value))
 				.ToArray();
+
+			this.RaisePropertyChanged(nameof(this.ShipList));
 		}
 	}
 
@@ -166,7 +217,8 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 		}
 		#endregion
 
-		public bool Marriaged => this.Level > 99;
+		public bool IsAbyssal => (this.Ship?.Id ?? 0) > 1500;
+		public bool Marriaged => this.Level > 99 && (this.Ship?.Id ?? 0) <= 1500;
 
 		private string _Name { get; set; }
 		private string _Id { get; set; }
@@ -235,10 +287,12 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 		public int MarriageHPResult
 			=> this.Marriaged ? this.MarriageHP : 0;
 
+		public int AbyssalHP { get; set; }
 		public int HP => this.Ship?.RawData.api_taik?[0] ?? -1;
 		public int CurHP => this.HP == -1 ? -1
 			: this.HP + (this.Marriaged ? this.MarriageHP : 0);
 
+		public int AbyssalArmor { get; set; }
 		public int MinArmor => this.Ship?.RawData.api_souk?[0] ?? -1;
 		public int MaxArmor => this.Ship?.RawData.api_souk?[1] ?? -1;
 		public int CurArmor => this.Level == 1 ? this.MinArmor
@@ -246,6 +300,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 			: this.MinArmor == -1 || this.MaxArmor == -1 ? -1
 			: (int)Math.Floor((double)(this.MaxArmor - this.MinArmor) * this.Level / 99 * 0.4 + this.MinArmor);
 
+		public int AbyssalEvasion { get; set; }
 		public int MinEvasion => DictionaryViewModel.shipInfos.FirstOrDefault(x => x.id == (this.Ship?.Id ?? 0))?.stat.evasion ?? -1;
 		public int MaxEvasion => DictionaryViewModel.shipInfos.FirstOrDefault(x => x.id == (this.Ship?.Id ?? 0))?.stat.evasion_max ?? -1;
 		public int CurEvasion => this.Level == 1 ? this.MinEvasion
@@ -253,10 +308,12 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 			: this.MinEvasion == -1 || this.MaxEvasion == -1 ? -1
 			: (int)Math.Floor((double)(this.MaxEvasion - this.MinEvasion) * this.Level / 99 + this.MinEvasion);
 
+		public int AbyssalCarry { get; set; }
 		public int TotalCarry => this.Ship?.RawData.api_maxeq?.Sum() ?? -1;
 
 		///////////////////
 
+		public int AbyssalFire { get; set; }
 		public int MinFire => this.Ship?.RawData.api_houg?[0] ?? -1;
 		public int MaxFire => this.Ship?.RawData.api_houg?[1] ?? -1;
 		public int CurFire => this.Level == 1 ? this.MinFire
@@ -264,6 +321,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 			: this.MinFire == -1 || this.MaxFire == -1 ? -1
 			: (int)Math.Floor((double)(this.MaxFire - this.MinFire) * this.Level / 99 * 0.4 + this.MinFire);
 
+		public int AbyssalTorpedo { get; set; }
 		public int MinTorpedo => this.Ship?.RawData.api_raig?[0] ?? -1;
 		public int MaxTorpedo => this.Ship?.RawData.api_raig?[1] ?? -1;
 		public int CurTorpedo => this.Level == 1 ? this.MinTorpedo
@@ -271,6 +329,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 			: this.MinTorpedo == -1 || this.MaxTorpedo == -1 ? -1
 			: (int)Math.Floor((double)(this.MaxTorpedo - this.MinTorpedo) * this.Level / 99 * 0.4 + this.MinTorpedo);
 
+		public int AbyssalAA { get; set; }
 		public int MinAA => this.Ship?.RawData.api_taik?[0] ?? -1;
 		public int MaxAA => this.Ship?.RawData.api_taik?[1] ?? -1;
 		public int CurAA => this.Level == 1 ? this.MinAA
@@ -278,6 +337,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 			: this.MinAA == -1 || this.MaxAA == -1 ? -1
 			: (int)Math.Floor((double)(this.MaxAA - this.MinAA) * this.Level / 99 * 0.4 + this.MinAA);
 
+		public int AbyssalASW { get; set; }
 		public int MinASW => DictionaryViewModel.shipInfos.FirstOrDefault(x => x.id == (this.Ship?.Id ?? 0))?.stat.asw ?? -1;
 		public int MaxASW => DictionaryViewModel.shipInfos.FirstOrDefault(x => x.id == (this.Ship?.Id ?? 0))?.stat.asw_max ?? -1;
 		public int CurASW => this.Level == 1 ? this.MinASW
@@ -287,7 +347,15 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 
 		///////////////////
 
+		public ShipSpeed AbyssalSpeed { get; set; }
 		public ShipSpeed Speed => ShipSpeedConverter.FromInt32(this.Ship?.RawData.api_soku ?? 0);
+		public string AbyssalSpeedText
+			=> this.AbyssalSpeed == ShipSpeed.Immovable ? "육상기지"
+				: this.AbyssalSpeed == ShipSpeed.Slow ? "저속"
+				: this.AbyssalSpeed == ShipSpeed.Fast ? "고속"
+				: this.AbyssalSpeed == ShipSpeed.Faster ? "고속+"
+				: this.AbyssalSpeed == ShipSpeed.Fastest ? "초고속"
+				: "???";
 		public string SpeedText
 			=> this.Speed == ShipSpeed.Immovable ? "육상기지"
 				: this.Speed == ShipSpeed.Slow ? "저속"
@@ -296,14 +364,22 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 				: this.Speed == ShipSpeed.Fastest ? "초고속"
 				: "???";
 
+		public int AbyssalRange { get; set; }
 		public int Range => this.Ship?.RawData.api_leng ?? -1;
+		public string AbyssalRangeText
+			=> this.AbyssalRange == 1 ? "단거리"
+				: this.AbyssalRange == 2 ? "중거리"
+				: this.AbyssalRange == 3 ? "장거리"
+				: this.AbyssalRange == 4 ? "초장거리"
+				: "???";
 		public string RangeText
 			=> this.Range == 1 ? "단거리"
 				: this.Range == 2 ? "중거리"
 				: this.Range == 3 ? "장거리"
-				: this.Range == 4 ? "최장거리"
+				: this.Range == 4 ? "초장거리"
 				: "???";
 
+		public int AbyssalLOS { get; set; }
 		public int MinLOS => DictionaryViewModel.shipInfos.FirstOrDefault(x => x.id == (this.Ship?.Id ?? 0))?.stat.los ?? -1;
 		public int MaxLOS => DictionaryViewModel.shipInfos.FirstOrDefault(x => x.id == (this.Ship?.Id ?? 0))?.stat.los_max ?? -1;
 		public int CurLOS => this.Level == 1 ? this.MinLOS
@@ -311,6 +387,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 			: this.MinLOS == -1 || this.MaxLOS == -1 ? -1
 			: (int)Math.Floor((double)(this.MaxLOS - this.MinLOS) * this.Level / 99 + this.MinLOS);
 
+		public int AbyssalLuck { get; set; }
 		public int MinLuck => this.Ship?.RawData.api_luck?[0] ?? -1;
 		public int MaxLuck => this.Ship?.RawData.api_luck?[1] ?? -1;
 		public int CurLuck => this.MinLuck == -1 ? -1
@@ -381,42 +458,73 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 		{
 			get
 			{
+				var shipId = (this.Ship?.Id ?? 0);
+				var slotCount = this.Ship?.SlotCount ?? 0;
 				var list = new List<SlotInfo>();
 
-				var info = DictionaryViewModel.shipInfos.FirstOrDefault(x => x.id == (this.Ship?.Id ?? 0));
-				if (info == null)
+				if (shipId > 1500) // Is abyssal?
 				{
-					while (list.Count < (this.Ship?.SlotCount ?? 0))
-						list.Add(new SlotInfo(null, true, this.Ship?.Slots?[list.Count] ?? -1));
+					var info = DictionaryViewModel.abyssalShipInfos.FirstOrDefault(x => x.id == shipId);
+					if (info == null)
+					{
+						while (list.Count < slotCount)
+							list.Add(new SlotInfo(null, true, this.Ship?.Slots?[list.Count] ?? -1));
 
-					while (list.Count < 4) list.Add(new SlotInfo(null, false, 0));
+						while (list.Count < 4) list.Add(new SlotInfo(null, false, 0));
+						return list;
+					}
 
-					return list;
+					list = info.equips
+						.Where(x => x > 0)
+						.Select((x, z) =>
+						{
+							var master = KanColleClient.Current.Master;
+							var item = master.SlotItems.FirstOrDefault(y => y.Value.Id == x).Value;
+							if (item == null) return new SlotInfo(SlotItemInfo.Dummy, true, info.carrys[z]);
+
+							return new SlotInfo(item, true, info.carrys[z]);
+						})
+						.ToList();
+
+					while (list.Count < slotCount)
+						list.Add(new SlotInfo(SlotItemInfo.Dummy, true, info.carrys[list.Count]));
+				}
+				else
+				{
+					var info = DictionaryViewModel.shipInfos.FirstOrDefault(x => x.id == shipId);
+					if (info == null)
+					{
+						while (list.Count < slotCount)
+							list.Add(new SlotInfo(null, true, this.Ship?.Slots?[list.Count] ?? -1));
+
+						while (list.Count < 4) list.Add(new SlotInfo(null, false, 0));
+						return list;
+					}
+
+					list = info.equip
+						.Where(x =>
+						{
+							int id;
+							if (x == null || x.Length == 0) return false;
+							return int.TryParse(x, out id);
+						})
+						.Select((x, z) =>
+						{
+							int id;
+							if (!int.TryParse(x, out id)) return new SlotInfo(SlotItemInfo.Dummy, true, this.Ship?.Slots[z] ?? -1);
+							var master = KanColleClient.Current.Master;
+							var item = master.SlotItems.FirstOrDefault(y => y.Value.Id == id).Value;
+							if (item == null) return new SlotInfo(SlotItemInfo.Dummy, true, this.Ship?.Slots[z] ?? -1);
+
+							return new SlotInfo(item, true, this.Ship?.Slots[z] ?? -1);
+						})
+						.ToList();
+
+					while (list.Count < slotCount)
+						list.Add(new SlotInfo(SlotItemInfo.Dummy, true, this.Ship?.Slots[list.Count] ?? -1));
 				}
 
-				list = info.equip
-					.Where(x =>
-					{
-						int id;
-						if (x == null || x.Length == 0) return false;
-						return int.TryParse(x, out id);
-					})
-					.Select((x, z) => {
-						int id;
-						if (!int.TryParse(x, out id)) return new SlotInfo(SlotItemInfo.Dummy, true, this.Ship?.Slots[z] ?? -1);
-						var master = KanColleClient.Current.Master;
-						var item = master.SlotItems.FirstOrDefault(y => y.Value.Id == id).Value;
-						if (item == null) return new SlotInfo(SlotItemInfo.Dummy, true, this.Ship?.Slots[z] ?? -1);
-
-						return new SlotInfo(item, true, this.Ship?.Slots[z] ?? -1);
-					})
-					.ToList();
-
-				while (list.Count < (this.Ship?.SlotCount ?? 0))
-					list.Add(new SlotInfo(SlotItemInfo.Dummy, true, this.Ship?.Slots[list.Count] ?? -1));
-
 				while (list.Count < 4) list.Add(new SlotInfo(null, false, 0));
-
 				return list;
 			}
 		}
@@ -445,6 +553,43 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 			this._Name = this.Ship?.Name ?? "???";
 			this._Id = this.Ship?.Id.ToString() ?? "???";
 			this._ShipType = this.Ship?.ShipType.Name ?? "???";
+
+			if (this.IsAbyssal)
+			{
+				var info = DictionaryViewModel.abyssalShipInfos.FirstOrDefault(x => x.id == (this.Ship?.Id ?? 0));
+				if (info == null)
+				{
+					this.AbyssalHP = -1;
+					this.AbyssalArmor = -1;
+					this.AbyssalEvasion = -1;
+					this.AbyssalCarry = -1;
+					this.AbyssalFire = -1;
+					this.AbyssalTorpedo = -1;
+					this.AbyssalAA = -1;
+					this.AbyssalASW = -1;
+					this.AbyssalSpeed = (ShipSpeed)(-1);
+					this.AbyssalRange = -1;
+					this.AbyssalLOS = -1;
+					this.AbyssalLuck = -1;
+				}
+				else
+				{
+					this.AbyssalHP = info.hp;
+					this.AbyssalArmor = info.armor;
+					this.AbyssalEvasion = info.evasion;
+					this.AbyssalCarry = info.carry;
+
+					this.AbyssalFire = info.fire;
+					this.AbyssalTorpedo = info.torpedo;
+					this.AbyssalAA = info.aa;
+					this.AbyssalASW = info.asw;
+
+					this.AbyssalSpeed = ShipSpeedConverter.FromInt32(info.speed);
+					this.AbyssalRange = info.range;
+					this.AbyssalLOS = info.los;
+					this.AbyssalLuck = info.luck;
+				}
+			}
 
 			if (this.Ship == null) this.Upgrades = new UpgradeInfo[0];
 			else
@@ -567,12 +712,36 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 		}
 		#endregion
 
+		private string _SearchText { get; set; }
+		public string SearchText
+		{
+			get { return this._SearchText; }
+			set
+			{
+				if (this._SearchText != value)
+				{
+					this._SearchText = value;
+					this.RaisePropertyChanged();
+
+					this.UpdateList();
+				}
+			}
+		}
+
 		public DictionaryEquipmentViewModel()
+		{
+			UpdateList();
+		}
+
+		private void UpdateList()
 		{
 			this.EquipmentList = KanColleClient.Current.Master.SlotItems
 				.OrderBy(x => x.Value.Id)
+				.Where(x => x.Value.Name.IndexOf(this.SearchText ?? "", StringComparison.CurrentCultureIgnoreCase) >= 0)
 				.Select(x => new EquipmentItemViewModel(x.Value))
 				.ToArray();
+
+			this.RaisePropertyChanged(nameof(this.EquipmentList));
 		}
 	}
 
@@ -673,7 +842,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 				: this.Range == 1 ? "단거리"
 				: this.Range == 2 ? "중거리"
 				: this.Range == 3 ? "장거리"
-				: this.Range == 4 ? "최장거리"
+				: this.Range == 4 ? "초장거리"
 				: "???";
 
 		public int LOS => this.Equipment?.RawData.api_saku ?? -1;
@@ -718,6 +887,29 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 
 		public int los { get; set; }
 		public int los_max { get; set; }
+	}
+	public class ships_abyssal_info
+	{
+		public int id { get; set; }
+
+		public int hp { get; set; }
+		public int armor { get; set; }
+		public int evasion { get; set; }
+		public int carry { get; set; }
+
+		public int fire { get; set; }
+		public int torpedo { get; set; }
+		public int aa { get; set; }
+		public int asw { get; set; }
+
+		public int speed { get; set; }
+		public int range { get; set; }
+		public int los { get; set; }
+		public int luck { get; set; }
+
+		public int slots { get; set; }
+		public int[] equips { get; set; }
+		public int[] carrys { get; set; }
 	}
 	// ReSharper restore InconsistentNaming
 	#endregion

--- a/source/Grabacr07.KanColleViewer/ViewModels/Catalogs/DictionaryViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/Catalogs/DictionaryViewModel.cs
@@ -548,6 +548,16 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 			}
 		}
 
+		public int AAPower => // 항공전
+			this.Slots?
+				.Where(x => x.Available && x.Info.IsNumerable && x.Info.IsAerialCombatable)
+				.Sum(x => (int)Math.Floor(x.Available ? (Math.Sqrt(x.Carry) * x.Info.AA) : 0)) ?? -1;
+
+		public int AAPower2 => // 기항대
+			this.Slots?
+				.Where(x => x.Available && x.Info.IsNumerable)
+				.Sum(x => (int)Math.Floor(x.Available ? (Math.Sqrt(x.Carry) * x.Info.AA) : 0)) ?? -1;
+
 		#region Modernize & Destroy
 		public int ModernizeFire => this.Ship?.RawData.api_powup?[0] ?? 0;
 		public int ModernizeTorpedo => this.Ship?.RawData.api_powup?[1] ?? 0;

--- a/source/Grabacr07.KanColleViewer/Views/Catalogs/DictionaryWindow.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Catalogs/DictionaryWindow.xaml
@@ -298,7 +298,7 @@
 												<TextBlock.Style>
 													<Style TargetType="{x:Type TextBlock}">
 														<Style.Triggers>
-															<DataTrigger Binding="{Binding IsAbyssal, Mode=OneWay}">
+															<DataTrigger Binding="{Binding IsAbyssal, Mode=OneWay}" Value="True">
 																<Setter Property="Visibility" Value="Collapsed" />
 															</DataTrigger>
 														</Style.Triggers>

--- a/source/Grabacr07.KanColleViewer/Views/Catalogs/DictionaryWindow.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Catalogs/DictionaryWindow.xaml
@@ -1266,7 +1266,70 @@
 									<StackPanel Orientation="Vertical"
 												Margin="8,20,0,0">
 										<TextBlock Foreground="White"
-												   Text="초기장비 및 탑재량" />
+												   Text="초기장비 및 탑재량, 제공수치" />
+
+										<Grid Margin="8,5,8,0"
+											  Background="#30000000">
+											<Grid.ColumnDefinitions>
+												<ColumnDefinition Width="Auto" />
+												<ColumnDefinition Width="*" />
+											</Grid.ColumnDefinitions>
+											<Grid.RowDefinitions>
+												<RowDefinition Height="Auto" />
+												<RowDefinition Height="Auto" />
+											</Grid.RowDefinitions>
+
+											<TextBlock Padding="1,1"
+													   Margin="8,5"
+													   TextAlignment="Left"
+													   Foreground="#f2f2f2"
+													   Text="제공 수치 (항공전):" />
+											<TextBlock Grid.Column="1"
+													   Margin="8,5"
+													   Padding="1,1"
+													   TextAlignment="Left"
+													   Foreground="#5cccf8">
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Setter Property="Text" Value="{Binding AAPower, Mode=OneWay}" />
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding AAPower, Mode=OneWay}" Value="-1">
+																<Setter Property="Text" Value="???" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+
+											<TextBlock Grid.Row="1"
+													   Margin="8,5"
+													   Padding="1,1"
+													   TextAlignment="Left"
+													   Foreground="#f2f2f2"
+													   Text="제공 수치 (기항대):" />
+											<TextBlock Grid.Column="1"
+													   Grid.Row="1"
+													   Margin="8,5"
+													   Padding="1,1"
+													   TextAlignment="Left"
+													   Foreground="#5cccf8">
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Setter Property="Text" Value="{Binding AAPower2, Mode=OneWay}" />
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding AAPower2, Mode=OneWay}" Value="-1">
+																<Setter Property="Text" Value="???" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+										</Grid>
+
+										<Border Height="1"
+												Margin="5,5,5,0"
+												Background="#20ffffff" />
+
 										<ItemsControl ItemsSource="{Binding Slots, Mode=OneWay}">
 											<ItemsControl.ItemTemplate>
 												<DataTemplate>
@@ -1319,23 +1382,55 @@
 
 															<TextBlock Grid.Column="2"
 																	   Margin="4,0,0,0">
+																<Run>
+																	<Run.Style>
+																		<Style TargetType="{x:Type Run}">
+																			<Setter Property="Text" Value="{Binding Info.Name, Mode=OneWay}" />
+																			<Setter Property="Foreground" Value="#f0f0f0" />
+
+																			<Style.Triggers>
+																				<DataTrigger Binding="{Binding Info.Id, Mode=OneWay}" Value="0">
+																					<Setter Property="Text" Value="비어있는 슬롯입니다." />
+																					<Setter Property="Foreground" Value="#c2f0f0f0" />
+																				</DataTrigger>
+																				<DataTrigger Binding="{Binding Info.Name, Mode=OneWay}" Value="{x:Null}">
+																					<Setter Property="Text" Value="알 수 없는 장비" />
+																					<Setter Property="Foreground" Value="#58f0f0f0" />
+																				</DataTrigger>
+																				<DataTrigger Binding="{Binding Available, Mode=OneWay}" Value="False">
+																					<Setter Property="Text" Value="존재하지 않는 슬롯입니다." />
+																					<Setter Property="Foreground" Value="#58f0f0f0" />
+																				</DataTrigger>
+																			</Style.Triggers>
+																		</Style>
+																	</Run.Style>
+																</Run>
+																<Run FontSize="9">
+																	<Run.Style>
+																		<Style TargetType="{x:Type Run}"
+																			   BasedOn="{StaticResource DefaultTextElementStyleKey}">
+																			<Setter Property="Text" Value="{Binding Info.Id, Mode=OneWay, StringFormat={}No.{0}}" />
+
+																			<Style.Triggers>
+																				<DataTrigger Binding="{Binding Info.Id, Mode=OneWay}" Value="0">
+																					<Setter Property="Text" Value="" />
+																				</DataTrigger>
+																				<DataTrigger Binding="{Binding Info.Name, Mode=OneWay}" Value="{x:Null}">
+																					<Setter Property="Text" Value="" />
+																				</DataTrigger>
+																				<DataTrigger Binding="{Binding Available, Mode=OneWay}" Value="False">
+																					<Setter Property="Text" Value="" />
+																				</DataTrigger>
+																			</Style.Triggers>
+																		</Style>
+																	</Run.Style>
+																</Run>
+
 																<TextBlock.Style>
 																	<Style TargetType="{x:Type TextBlock}">
-																		<Setter Property="Text" Value="{Binding Info.Name, Mode=OneWay}" />
-																		<Setter Property="Foreground" Value="#f0f0f0" />
-
+																		<Setter Property="TextAlignment" Value="Left" />
 																		<Style.Triggers>
-																			<DataTrigger Binding="{Binding Info.Id, Mode=OneWay}" Value="0">
-																				<Setter Property="Text" Value="비어있는 슬롯입니다." />
-																				<Setter Property="Foreground" Value="#c2f0f0f0" />
-																			</DataTrigger>
-																			<DataTrigger Binding="{Binding Info.Name, Mode=OneWay}" Value="{x:Null}">
-																				<Setter Property="Text" Value="알 수 없는 장비" />
-																				<Setter Property="Foreground" Value="#58f0f0f0" />
-																			</DataTrigger>
 																			<DataTrigger Binding="{Binding Available, Mode=OneWay}" Value="False">
-																				<Setter Property="Text" Value="존재하지 않는 슬롯입니다." />
-																				<Setter Property="Foreground" Value="#58f0f0f0" />
 																				<Setter Property="TextAlignment" Value="Center" />
 																			</DataTrigger>
 																		</Style.Triggers>

--- a/source/Grabacr07.KanColleViewer/Views/Catalogs/DictionaryWindow.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Catalogs/DictionaryWindow.xaml
@@ -364,6 +364,7 @@
 
 												<RowDefinition Height="Auto" />
 												<RowDefinition Height="Auto" />
+												<RowDefinition Height="Auto" />
 											</Grid.RowDefinitions>
 
 											<Image Grid.Column="0"
@@ -1243,6 +1244,22 @@
 												</TextBlock.Style>
 											</TextBlock>
 
+											<Image Grid.Column="0"
+												   Grid.Row="10"
+												   Margin="0,4,0,0"
+												   Width="18"
+												   Height="18"
+												   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/dev.png" />
+											<TextBlock Grid.Column="1"
+													   Grid.Row="9"
+													   Margin="4,4,10,0"
+													   Foreground="#f2f2f2"
+													   Text="건조시간" />
+											<TextBlock Grid.Column="2"
+													   Grid.Row="9"
+													   Margin="0,4,0,0"
+													   Foreground="#ff7878"
+													   Text="{Binding BuildTimeText, Mode=OneWay}" />
 										</Grid>
 									</StackPanel>
 

--- a/source/Grabacr07.KanColleViewer/Views/Catalogs/DictionaryWindow.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Catalogs/DictionaryWindow.xaml
@@ -131,9 +131,17 @@
 								<ColumnDefinition Width="Auto" />
 								<ColumnDefinition Width="*" />
 							</Grid.ColumnDefinitions>
+							<Grid.RowDefinitions>
+								<RowDefinition Height="Auto" />
+								<RowDefinition Height="*" />
+							</Grid.RowDefinitions>
 
+							<metro:PromptTextBox Text="{Binding SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+												 Prompt="칸무스 검색"
+												 Padding="2" />
 							<ScrollViewer VerticalScrollBarVisibility="Auto"
-										  Margin="0,0,2,0">
+										  Margin="0,0,2,0"
+										  Grid.Row="1">
 								<ListBox Background="{DynamicResource ActiveBackgroundBrushKey}"
 										 ItemsSource="{Binding ShipList}"
 										 SelectedValue="{Binding SelectedShip}"
@@ -222,6 +230,7 @@
 							</ScrollViewer>
 
 							<ScrollViewer Grid.Column="1"
+										  Grid.RowSpan="2"
 										  VerticalScrollBarVisibility="Auto">
 								<StackPanel Orientation="Vertical"
 											Margin="0,0,0,10"
@@ -285,7 +294,17 @@
 													   VerticalAlignment="Center"
 													   FontSize="12"
 													   Foreground="#FFF08020"
-													   Text="레벨:" />
+													   Text="레벨:">
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding IsAbyssal, Mode=OneWay}">
+																<Setter Property="Visibility" Value="Collapsed" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
 											<metro:PromptComboBox Grid.Column="2"
 																  Margin="8"
 																  VerticalAlignment="Center"
@@ -310,6 +329,15 @@
 														</TextBlock>
 													</DataTemplate>
 												</metro:PromptComboBox.ItemTemplate>
+												<metro:PromptComboBox.Style>
+													<Style TargetType="{x:Type metro:PromptComboBox}">
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding IsAbyssal, Mode=OneWay}" Value="True">
+																<Setter Property="Visibility" Value="Collapsed" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</metro:PromptComboBox.Style>
 											</metro:PromptComboBox>
 										</Grid>
 
@@ -359,6 +387,18 @@
 																<DataTrigger Binding="{Binding CurHP, Mode=OneWay}" Value="-1">
 																	<Setter Property="Text" Value="???" />
 																</DataTrigger>
+																<DataTrigger Binding="{Binding IsAbyssal, Mode=OneWay}" Value="True">
+																	<Setter Property="Text" Value="{Binding AbyssalHP, Mode=OneWay}" />
+																</DataTrigger>
+																<MultiDataTrigger>
+																	<MultiDataTrigger.Conditions>
+																		<Condition Binding="{Binding IsAbyssal, Mode=OneWay}" Value="True" />
+																		<Condition Binding="{Binding AbyssalHP, Mode=OneWay}" Value="-1" />
+																	</MultiDataTrigger.Conditions>
+																	<MultiDataTrigger.Setters>
+																		<Setter Property="Text" Value="???" />
+																	</MultiDataTrigger.Setters>
+																</MultiDataTrigger>
 															</Style.Triggers>
 														</Style>
 													</Run.Style>
@@ -374,6 +414,9 @@
 															<Style TargetType="{x:Type TextBlock}">
 																<Style.Triggers>
 																	<DataTrigger Binding="{Binding MarriageHPResult, Mode=OneWay}" Value="0">
+																		<Setter Property="Visibility" Value="Collapsed" />
+																	</DataTrigger>
+																	<DataTrigger Binding="{Binding IsAbyssal, Mode=OneWay}" Value="True">
 																		<Setter Property="Visibility" Value="Collapsed" />
 																	</DataTrigger>
 																</Style.Triggers>
@@ -404,38 +447,64 @@
 																<DataTrigger Binding="{Binding MinArmor, Mode=OneWay}" Value="-1">
 																	<Setter Property="Text" Value="???" />
 																</DataTrigger>
-															</Style.Triggers>
-														</Style>
-													</Run.Style>
-												</Run>
-												<Run Text="＞" />
-												<Run>
-													<Run.Style>
-														<Style TargetType="{x:Type Run}">
-															<Setter Property="Text" Value="{Binding MaxArmor, Mode=OneWay}" />
-															<Style.Triggers>
-																<DataTrigger Binding="{Binding MaxArmor, Mode=OneWay}" Value="-1">
-																	<Setter Property="Text" Value="???" />
+																<DataTrigger Binding="{Binding IsAbyssal, Mode=OneWay}" Value="True">
+																	<Setter Property="Text" Value="{Binding AbyssalArmor, Mode=OneWay}" />
 																</DataTrigger>
+																<MultiDataTrigger>
+																	<MultiDataTrigger.Conditions>
+																		<Condition Binding="{Binding IsAbyssal, Mode=OneWay}" Value="True" />
+																		<Condition Binding="{Binding AbyssalArmor, Mode=OneWay}" Value="-1" />
+																	</MultiDataTrigger.Conditions>
+																	<MultiDataTrigger.Setters>
+																		<Setter Property="Text" Value="???" />
+																	</MultiDataTrigger.Setters>
+																</MultiDataTrigger>
 															</Style.Triggers>
 														</Style>
 													</Run.Style>
 												</Run>
+												<InlineUIContainer>
+													<TextBlock Foreground="#5cccf8">
+														<Run Text="＞" />
+														<Run>
+															<Run.Style>
+																<Style TargetType="{x:Type Run}">
+																	<Setter Property="Text" Value="{Binding MaxArmor, Mode=OneWay}" />
+																	<Style.Triggers>
+																		<DataTrigger Binding="{Binding MaxArmor, Mode=OneWay}" Value="-1">
+																			<Setter Property="Text" Value="???" />
+																		</DataTrigger>
+																	</Style.Triggers>
+																</Style>
+															</Run.Style>
+														</Run>
 
-												<Run Text="  (" Foreground="#FFF08020" />
-												<Run Foreground="#FFF08020">
-													<Run.Style>
-														<Style TargetType="{x:Type Run}">
-															<Setter Property="Text" Value="{Binding CurArmor, Mode=OneWay}" />
-															<Style.Triggers>
-																<DataTrigger Binding="{Binding CurArmor, Mode=OneWay}" Value="-1">
-																	<Setter Property="Text" Value="???" />
-																</DataTrigger>
-															</Style.Triggers>
-														</Style>
-													</Run.Style>
-												</Run>
-												<Run Text=")" Foreground="#FFF08020" />
+														<Run Text="  (" Foreground="#FFF08020" />
+														<Run Foreground="#FFF08020">
+															<Run.Style>
+																<Style TargetType="{x:Type Run}">
+																	<Setter Property="Text" Value="{Binding CurArmor, Mode=OneWay}" />
+																	<Style.Triggers>
+																		<DataTrigger Binding="{Binding CurArmor, Mode=OneWay}" Value="-1">
+																			<Setter Property="Text" Value="???" />
+																		</DataTrigger>
+																	</Style.Triggers>
+																</Style>
+															</Run.Style>
+														</Run>
+														<Run Text=")" Foreground="#FFF08020" />
+
+														<TextBlock.Style>
+															<Style TargetType="{x:Type TextBlock}">
+																<Style.Triggers>
+																	<DataTrigger Binding="{Binding IsAbyssal, Mode=OneWay}" Value="True">
+																		<Setter Property="Visibility" Value="Collapsed" />
+																	</DataTrigger>
+																</Style.Triggers>
+															</Style>
+														</TextBlock.Style>
+													</TextBlock>
+												</InlineUIContainer>
 											</TextBlock>
 
 											<Image Grid.Column="0"
@@ -461,38 +530,65 @@
 																<DataTrigger Binding="{Binding MinEvasion, Mode=OneWay}" Value="-1">
 																	<Setter Property="Text" Value="???" />
 																</DataTrigger>
-															</Style.Triggers>
-														</Style>
-													</Run.Style>
-												</Run>
-												<Run Text="＞" />
-												<Run>
-													<Run.Style>
-														<Style TargetType="{x:Type Run}">
-															<Setter Property="Text" Value="{Binding MaxEvasion, Mode=OneWay}" />
-															<Style.Triggers>
-																<DataTrigger Binding="{Binding MaxEvasion, Mode=OneWay}" Value="-1">
-																	<Setter Property="Text" Value="???" />
-																</DataTrigger>
-															</Style.Triggers>
-														</Style>
-													</Run.Style>
-												</Run>
 
-												<Run Text="  (" Foreground="#FFF08020" />
-												<Run Foreground="#FFF08020">
-													<Run.Style>
-														<Style TargetType="{x:Type Run}">
-															<Setter Property="Text" Value="{Binding CurEvasion, Mode=OneWay}" />
-															<Style.Triggers>
-																<DataTrigger Binding="{Binding CurEvasion, Mode=OneWay}" Value="-1">
-																	<Setter Property="Text" Value="???" />
+																<DataTrigger Binding="{Binding IsAbyssal, Mode=OneWay}" Value="True">
+																	<Setter Property="Text" Value="{Binding AbyssalEvasion, Mode=OneWay}" />
 																</DataTrigger>
+																<MultiDataTrigger>
+																	<MultiDataTrigger.Conditions>
+																		<Condition Binding="{Binding IsAbyssal, Mode=OneWay}" Value="True" />
+																		<Condition Binding="{Binding AbyssalEvasion, Mode=OneWay}" Value="-1" />
+																	</MultiDataTrigger.Conditions>
+																	<MultiDataTrigger.Setters>
+																		<Setter Property="Text" Value="???" />
+																	</MultiDataTrigger.Setters>
+																</MultiDataTrigger>
 															</Style.Triggers>
 														</Style>
 													</Run.Style>
 												</Run>
-												<Run Text=")" Foreground="#FFF08020" />
+												<InlineUIContainer>
+													<TextBlock Foreground="#5cccf8">
+														<Run Text="＞" />
+														<Run>
+															<Run.Style>
+																<Style TargetType="{x:Type Run}">
+																	<Setter Property="Text" Value="{Binding MaxEvasion, Mode=OneWay}" />
+																	<Style.Triggers>
+																		<DataTrigger Binding="{Binding MaxEvasion, Mode=OneWay}" Value="-1">
+																			<Setter Property="Text" Value="???" />
+																		</DataTrigger>
+																	</Style.Triggers>
+																</Style>
+															</Run.Style>
+														</Run>
+
+														<Run Text="  (" Foreground="#FFF08020" />
+														<Run Foreground="#FFF08020">
+															<Run.Style>
+																<Style TargetType="{x:Type Run}">
+																	<Setter Property="Text" Value="{Binding CurEvasion, Mode=OneWay}" />
+																	<Style.Triggers>
+																		<DataTrigger Binding="{Binding CurEvasion, Mode=OneWay}" Value="-1">
+																			<Setter Property="Text" Value="???" />
+																		</DataTrigger>
+																	</Style.Triggers>
+																</Style>
+															</Run.Style>
+														</Run>
+														<Run Text=")" Foreground="#FFF08020" />
+
+														<TextBlock.Style>
+															<Style TargetType="{x:Type TextBlock}">
+																<Style.Triggers>
+																	<DataTrigger Binding="{Binding IsAbyssal, Mode=OneWay}" Value="True">
+																		<Setter Property="Visibility" Value="Collapsed" />
+																	</DataTrigger>
+																</Style.Triggers>
+															</Style>
+														</TextBlock.Style>
+													</TextBlock>
+												</InlineUIContainer>
 											</TextBlock>
 
 											<Image Grid.Column="3"
@@ -520,6 +616,27 @@
 															<DataTrigger Binding="{Binding TotalCarry, Mode=OneWay}" Value="-1">
 																<Setter Property="Text" Value="???" />
 															</DataTrigger>
+															<DataTrigger Binding="{Binding IsAbyssal, Mode=OneWay}" Value="True">
+																<Setter Property="Text" Value="{Binding AbyssalCarry, Mode=OneWay}" />
+															</DataTrigger>
+															<MultiDataTrigger>
+																<MultiDataTrigger.Conditions>
+																	<Condition Binding="{Binding IsAbyssal, Mode=OneWay}" Value="True" />
+																	<Condition Binding="{Binding AbyssalCarry, Mode=OneWay}" Value="0" />
+																</MultiDataTrigger.Conditions>
+																<MultiDataTrigger.Setters>
+																	<Setter Property="Text" Value="" />
+																</MultiDataTrigger.Setters>
+															</MultiDataTrigger>
+															<MultiDataTrigger>
+																<MultiDataTrigger.Conditions>
+																	<Condition Binding="{Binding IsAbyssal, Mode=OneWay}" Value="True" />
+																	<Condition Binding="{Binding AbyssalCarry, Mode=OneWay}" Value="-1" />
+																</MultiDataTrigger.Conditions>
+																<MultiDataTrigger.Setters>
+																	<Setter Property="Text" Value="???" />
+																</MultiDataTrigger.Setters>
+															</MultiDataTrigger>
 														</Style.Triggers>
 													</Style>
 												</TextBlock.Style>
@@ -552,38 +669,64 @@
 																<DataTrigger Binding="{Binding MinFire, Mode=OneWay}" Value="-1">
 																	<Setter Property="Text" Value="???" />
 																</DataTrigger>
-															</Style.Triggers>
-														</Style>
-													</Run.Style>
-												</Run>
-												<Run Text="＞" />
-												<Run>
-													<Run.Style>
-														<Style TargetType="{x:Type Run}">
-															<Setter Property="Text" Value="{Binding MaxFire, Mode=OneWay}" />
-															<Style.Triggers>
-																<DataTrigger Binding="{Binding MaxFire, Mode=OneWay}" Value="-1">
-																	<Setter Property="Text" Value="???" />
+																<DataTrigger Binding="{Binding IsAbyssal, Mode=OneWay}" Value="True">
+																	<Setter Property="Text" Value="{Binding AbyssalFire, Mode=OneWay}" />
 																</DataTrigger>
+																<MultiDataTrigger>
+																	<MultiDataTrigger.Conditions>
+																		<Condition Binding="{Binding IsAbyssal, Mode=OneWay}" Value="True" />
+																		<Condition Binding="{Binding AbyssalFire, Mode=OneWay}" Value="-1" />
+																	</MultiDataTrigger.Conditions>
+																	<MultiDataTrigger.Setters>
+																		<Setter Property="Text" Value="???" />
+																	</MultiDataTrigger.Setters>
+																</MultiDataTrigger>
 															</Style.Triggers>
 														</Style>
 													</Run.Style>
 												</Run>
+												<InlineUIContainer>
+													<TextBlock Foreground="#5cccf8">
+														<Run Text="＞" />
+														<Run>
+															<Run.Style>
+																<Style TargetType="{x:Type Run}">
+																	<Setter Property="Text" Value="{Binding MaxFire, Mode=OneWay}" />
+																	<Style.Triggers>
+																		<DataTrigger Binding="{Binding MaxFire, Mode=OneWay}" Value="-1">
+																			<Setter Property="Text" Value="???" />
+																		</DataTrigger>
+																	</Style.Triggers>
+																</Style>
+															</Run.Style>
+														</Run>
 
-												<Run Text="  (" Foreground="#FFF08020" />
-												<Run Foreground="#FFF08020">
-													<Run.Style>
-														<Style TargetType="{x:Type Run}">
-															<Setter Property="Text" Value="{Binding CurFire, Mode=OneWay}" />
-															<Style.Triggers>
-																<DataTrigger Binding="{Binding CurFire, Mode=OneWay}" Value="-1">
-																	<Setter Property="Text" Value="???" />
-																</DataTrigger>
-															</Style.Triggers>
-														</Style>
-													</Run.Style>
-												</Run>
-												<Run Text=")" Foreground="#FFF08020" />
+														<Run Text="  (" Foreground="#FFF08020" />
+														<Run Foreground="#FFF08020">
+															<Run.Style>
+																<Style TargetType="{x:Type Run}">
+																	<Setter Property="Text" Value="{Binding CurFire, Mode=OneWay}" />
+																	<Style.Triggers>
+																		<DataTrigger Binding="{Binding CurFire, Mode=OneWay}" Value="-1">
+																			<Setter Property="Text" Value="???" />
+																		</DataTrigger>
+																	</Style.Triggers>
+																</Style>
+															</Run.Style>
+														</Run>
+														<Run Text=")" Foreground="#FFF08020" />
+
+														<TextBlock.Style>
+															<Style TargetType="{x:Type TextBlock}">
+																<Style.Triggers>
+																	<DataTrigger Binding="{Binding IsAbyssal, Mode=OneWay}" Value="True">
+																		<Setter Property="Visibility" Value="Collapsed" />
+																	</DataTrigger>
+																</Style.Triggers>
+															</Style>
+														</TextBlock.Style>
+													</TextBlock>
+												</InlineUIContainer>
 											</TextBlock>
 
 											<Image Grid.Column="3"
@@ -607,38 +750,64 @@
 																<DataTrigger Binding="{Binding MinTorpedo, Mode=OneWay}" Value="-1">
 																	<Setter Property="Text" Value="???" />
 																</DataTrigger>
-															</Style.Triggers>
-														</Style>
-													</Run.Style>
-												</Run>
-												<Run Text="＞" />
-												<Run>
-													<Run.Style>
-														<Style TargetType="{x:Type Run}">
-															<Setter Property="Text" Value="{Binding MaxTorpedo, Mode=OneWay}" />
-															<Style.Triggers>
-																<DataTrigger Binding="{Binding MaxTorpedo, Mode=OneWay}" Value="-1">
-																	<Setter Property="Text" Value="???" />
+																<DataTrigger Binding="{Binding IsAbyssal, Mode=OneWay}" Value="True">
+																	<Setter Property="Text" Value="{Binding AbyssalTorpedo, Mode=OneWay}" />
 																</DataTrigger>
+																<MultiDataTrigger>
+																	<MultiDataTrigger.Conditions>
+																		<Condition Binding="{Binding IsAbyssal, Mode=OneWay}" Value="True" />
+																		<Condition Binding="{Binding AbyssalTorpedo, Mode=OneWay}" Value="-1" />
+																	</MultiDataTrigger.Conditions>
+																	<MultiDataTrigger.Setters>
+																		<Setter Property="Text" Value="???" />
+																	</MultiDataTrigger.Setters>
+																</MultiDataTrigger>
 															</Style.Triggers>
 														</Style>
 													</Run.Style>
 												</Run>
+												<InlineUIContainer>
+													<TextBlock Foreground="#5cccf8">
+														<Run Text="＞" />
+														<Run>
+															<Run.Style>
+																<Style TargetType="{x:Type Run}">
+																	<Setter Property="Text" Value="{Binding MaxTorpedo, Mode=OneWay}" />
+																	<Style.Triggers>
+																		<DataTrigger Binding="{Binding MaxTorpedo, Mode=OneWay}" Value="-1">
+																			<Setter Property="Text" Value="???" />
+																		</DataTrigger>
+																	</Style.Triggers>
+																</Style>
+															</Run.Style>
+														</Run>
 
-												<Run Text="  (" Foreground="#FFF08020" />
-												<Run Foreground="#FFF08020">
-													<Run.Style>
-														<Style TargetType="{x:Type Run}">
-															<Setter Property="Text" Value="{Binding CurTorpedo, Mode=OneWay}" />
-															<Style.Triggers>
-																<DataTrigger Binding="{Binding CurTorpedo, Mode=OneWay}" Value="-1">
-																	<Setter Property="Text" Value="???" />
-																</DataTrigger>
-															</Style.Triggers>
-														</Style>
-													</Run.Style>
-												</Run>
-												<Run Text=")" Foreground="#FFF08020" />
+														<Run Text="  (" Foreground="#FFF08020" />
+														<Run Foreground="#FFF08020">
+															<Run.Style>
+																<Style TargetType="{x:Type Run}">
+																	<Setter Property="Text" Value="{Binding CurTorpedo, Mode=OneWay}" />
+																	<Style.Triggers>
+																		<DataTrigger Binding="{Binding CurTorpedo, Mode=OneWay}" Value="-1">
+																			<Setter Property="Text" Value="???" />
+																		</DataTrigger>
+																	</Style.Triggers>
+																</Style>
+															</Run.Style>
+														</Run>
+														<Run Text=")" Foreground="#FFF08020" />
+
+														<TextBlock.Style>
+															<Style TargetType="{x:Type TextBlock}">
+																<Style.Triggers>
+																	<DataTrigger Binding="{Binding IsAbyssal, Mode=OneWay}" Value="True">
+																		<Setter Property="Visibility" Value="Collapsed" />
+																	</DataTrigger>
+																</Style.Triggers>
+															</Style>
+														</TextBlock.Style>
+													</TextBlock>
+												</InlineUIContainer>
 											</TextBlock>
 
 											<Image Grid.Column="0"
@@ -664,38 +833,64 @@
 																<DataTrigger Binding="{Binding MinAA, Mode=OneWay}" Value="-1">
 																	<Setter Property="Text" Value="???" />
 																</DataTrigger>
-															</Style.Triggers>
-														</Style>
-													</Run.Style>
-												</Run>
-												<Run Text="＞" />
-												<Run>
-													<Run.Style>
-														<Style TargetType="{x:Type Run}">
-															<Setter Property="Text" Value="{Binding MaxAA, Mode=OneWay}" />
-															<Style.Triggers>
-																<DataTrigger Binding="{Binding MaxAA, Mode=OneWay}" Value="-1">
-																	<Setter Property="Text" Value="???" />
+																<DataTrigger Binding="{Binding IsAbyssal, Mode=OneWay}" Value="True">
+																	<Setter Property="Text" Value="{Binding AbyssalAA, Mode=OneWay}" />
 																</DataTrigger>
+																<MultiDataTrigger>
+																	<MultiDataTrigger.Conditions>
+																		<Condition Binding="{Binding IsAbyssal, Mode=OneWay}" Value="True" />
+																		<Condition Binding="{Binding AbyssalAA, Mode=OneWay}" Value="-1" />
+																	</MultiDataTrigger.Conditions>
+																	<MultiDataTrigger.Setters>
+																		<Setter Property="Text" Value="???" />
+																	</MultiDataTrigger.Setters>
+																</MultiDataTrigger>
 															</Style.Triggers>
 														</Style>
 													</Run.Style>
 												</Run>
+												<InlineUIContainer>
+													<TextBlock Foreground="#5cccf8">
+														<Run Text="＞" />
+														<Run>
+															<Run.Style>
+																<Style TargetType="{x:Type Run}">
+																	<Setter Property="Text" Value="{Binding MaxAA, Mode=OneWay}" />
+																	<Style.Triggers>
+																		<DataTrigger Binding="{Binding MaxAA, Mode=OneWay}" Value="-1">
+																			<Setter Property="Text" Value="???" />
+																		</DataTrigger>
+																	</Style.Triggers>
+																</Style>
+															</Run.Style>
+														</Run>
 
-												<Run Text="  (" Foreground="#FFF08020" />
-												<Run Foreground="#FFF08020">
-													<Run.Style>
-														<Style TargetType="{x:Type Run}">
-															<Setter Property="Text" Value="{Binding CurAA, Mode=OneWay}" />
-															<Style.Triggers>
-																<DataTrigger Binding="{Binding CurAA, Mode=OneWay}" Value="-1">
-																	<Setter Property="Text" Value="???" />
-																</DataTrigger>
-															</Style.Triggers>
-														</Style>
-													</Run.Style>
-												</Run>
-												<Run Text=")" Foreground="#FFF08020" />
+														<Run Text="  (" Foreground="#FFF08020" />
+														<Run Foreground="#FFF08020">
+															<Run.Style>
+																<Style TargetType="{x:Type Run}">
+																	<Setter Property="Text" Value="{Binding CurAA, Mode=OneWay}" />
+																	<Style.Triggers>
+																		<DataTrigger Binding="{Binding CurAA, Mode=OneWay}" Value="-1">
+																			<Setter Property="Text" Value="???" />
+																		</DataTrigger>
+																	</Style.Triggers>
+																</Style>
+															</Run.Style>
+														</Run>
+														<Run Text=")" Foreground="#FFF08020" />
+
+														<TextBlock.Style>
+															<Style TargetType="{x:Type TextBlock}">
+																<Style.Triggers>
+																	<DataTrigger Binding="{Binding IsAbyssal, Mode=OneWay}" Value="True">
+																		<Setter Property="Visibility" Value="Collapsed" />
+																	</DataTrigger>
+																</Style.Triggers>
+															</Style>
+														</TextBlock.Style>
+													</TextBlock>
+												</InlineUIContainer>
 											</TextBlock>
 
 											<Image Grid.Column="3"
@@ -721,38 +916,64 @@
 																<DataTrigger Binding="{Binding MinASW, Mode=OneWay}" Value="-1">
 																	<Setter Property="Text" Value="???" />
 																</DataTrigger>
-															</Style.Triggers>
-														</Style>
-													</Run.Style>
-												</Run>
-												<Run Text="＞" />
-												<Run>
-													<Run.Style>
-														<Style TargetType="{x:Type Run}">
-															<Setter Property="Text" Value="{Binding MaxASW, Mode=OneWay}" />
-															<Style.Triggers>
-																<DataTrigger Binding="{Binding MaxASW, Mode=OneWay}" Value="-1">
-																	<Setter Property="Text" Value="???" />
+																<DataTrigger Binding="{Binding IsAbyssal, Mode=OneWay}" Value="True">
+																	<Setter Property="Text" Value="{Binding AbyssalASW, Mode=OneWay}" />
 																</DataTrigger>
+																<MultiDataTrigger>
+																	<MultiDataTrigger.Conditions>
+																		<Condition Binding="{Binding IsAbyssal, Mode=OneWay}" Value="True" />
+																		<Condition Binding="{Binding AbyssalASW, Mode=OneWay}" Value="-1" />
+																	</MultiDataTrigger.Conditions>
+																	<MultiDataTrigger.Setters>
+																		<Setter Property="Text" Value="???" />
+																	</MultiDataTrigger.Setters>
+																</MultiDataTrigger>
 															</Style.Triggers>
 														</Style>
 													</Run.Style>
 												</Run>
+												<InlineUIContainer>
+													<TextBlock Foreground="#5cccf8">
+														<Run Text="＞" />
+														<Run>
+															<Run.Style>
+																<Style TargetType="{x:Type Run}">
+																	<Setter Property="Text" Value="{Binding MaxASW, Mode=OneWay}" />
+																	<Style.Triggers>
+																		<DataTrigger Binding="{Binding MaxASW, Mode=OneWay}" Value="-1">
+																			<Setter Property="Text" Value="???" />
+																		</DataTrigger>
+																	</Style.Triggers>
+																</Style>
+															</Run.Style>
+														</Run>
 
-												<Run Text="  (" Foreground="#FFF08020" />
-												<Run Foreground="#FFF08020">
-													<Run.Style>
-														<Style TargetType="{x:Type Run}">
-															<Setter Property="Text" Value="{Binding CurASW, Mode=OneWay}" />
-															<Style.Triggers>
-																<DataTrigger Binding="{Binding CurASW, Mode=OneWay}" Value="-1">
-																	<Setter Property="Text" Value="???" />
-																</DataTrigger>
-															</Style.Triggers>
-														</Style>
-													</Run.Style>
-												</Run>
-												<Run Text=")" Foreground="#FFF08020" />
+														<Run Text="  (" Foreground="#FFF08020" />
+														<Run Foreground="#FFF08020">
+															<Run.Style>
+																<Style TargetType="{x:Type Run}">
+																	<Setter Property="Text" Value="{Binding CurASW, Mode=OneWay}" />
+																	<Style.Triggers>
+																		<DataTrigger Binding="{Binding CurASW, Mode=OneWay}" Value="-1">
+																			<Setter Property="Text" Value="???" />
+																		</DataTrigger>
+																	</Style.Triggers>
+																</Style>
+															</Run.Style>
+														</Run>
+														<Run Text=")" Foreground="#FFF08020" />
+
+														<TextBlock.Style>
+															<Style TargetType="{x:Type TextBlock}">
+																<Style.Triggers>
+																	<DataTrigger Binding="{Binding IsAbyssal, Mode=OneWay}" Value="True">
+																		<Setter Property="Visibility" Value="Collapsed" />
+																	</DataTrigger>
+																</Style.Triggers>
+															</Style>
+														</TextBlock.Style>
+													</TextBlock>
+												</InlineUIContainer>
 											</TextBlock>
 
 											<Border Grid.ColumnSpan="6"
@@ -773,8 +994,18 @@
 													   Text="속력" />
 											<TextBlock Grid.Column="2"
 													   Grid.Row="6"
-													   Foreground="#5cccf8"
-													   Text="{Binding SpeedText, Mode=OneWay}" />
+													   Foreground="#5cccf8">
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Setter Property="Text" Value="{Binding SpeedText, Mode=OneWay}" />
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding IsAbyssal, Mode=OneWay}" Value="True">
+																<Setter Property="Text" Value="{Binding AbyssalSpeedText, Mode=OneWay}" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
 
 											<Image Grid.Column="3"
 												   Grid.Row="6"
@@ -788,8 +1019,18 @@
 													   Text="사거리" />
 											<TextBlock Grid.Column="5"
 													   Grid.Row="6"
-													   Foreground="#5cccf8"
-													   Text="{Binding RangeText, Mode=OneWay}" />
+													   Foreground="#5cccf8">
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Setter Property="Text" Value="{Binding RangeText, Mode=OneWay}" />
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding IsAbyssal, Mode=OneWay}" Value="True">
+																<Setter Property="Text" Value="{Binding AbyssalRangeText, Mode=OneWay}" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
 
 											<Image Grid.Column="0"
 												   Grid.Row="7"
@@ -814,38 +1055,64 @@
 																<DataTrigger Binding="{Binding MinLOS, Mode=OneWay}" Value="-1">
 																	<Setter Property="Text" Value="???" />
 																</DataTrigger>
-															</Style.Triggers>
-														</Style>
-													</Run.Style>
-												</Run>
-												<Run Text="＞" />
-												<Run>
-													<Run.Style>
-														<Style TargetType="{x:Type Run}">
-															<Setter Property="Text" Value="{Binding MaxLOS, Mode=OneWay}" />
-															<Style.Triggers>
-																<DataTrigger Binding="{Binding MaxLOS, Mode=OneWay}" Value="-1">
-																	<Setter Property="Text" Value="???" />
+																<DataTrigger Binding="{Binding IsAbyssal, Mode=OneWay}" Value="True">
+																	<Setter Property="Text" Value="{Binding AbyssalLOS, Mode=OneWay}" />
 																</DataTrigger>
+																<MultiDataTrigger>
+																	<MultiDataTrigger.Conditions>
+																		<Condition Binding="{Binding IsAbyssal, Mode=OneWay}" Value="True" />
+																		<Condition Binding="{Binding AbyssalLOS, Mode=OneWay}" Value="-1" />
+																	</MultiDataTrigger.Conditions>
+																	<MultiDataTrigger.Setters>
+																		<Setter Property="Text" Value="???" />
+																	</MultiDataTrigger.Setters>
+																</MultiDataTrigger>
 															</Style.Triggers>
 														</Style>
 													</Run.Style>
 												</Run>
+												<InlineUIContainer>
+													<TextBlock Foreground="#5cccf8">
+														<Run Text="＞" />
+														<Run>
+															<Run.Style>
+																<Style TargetType="{x:Type Run}">
+																	<Setter Property="Text" Value="{Binding MaxLOS, Mode=OneWay}" />
+																	<Style.Triggers>
+																		<DataTrigger Binding="{Binding MaxLOS, Mode=OneWay}" Value="-1">
+																			<Setter Property="Text" Value="???" />
+																		</DataTrigger>
+																	</Style.Triggers>
+																</Style>
+															</Run.Style>
+														</Run>
 
-												<Run Text="  (" Foreground="#FFF08020" />
-												<Run Foreground="#FFF08020">
-													<Run.Style>
-														<Style TargetType="{x:Type Run}">
-															<Setter Property="Text" Value="{Binding CurLOS, Mode=OneWay}" />
-															<Style.Triggers>
-																<DataTrigger Binding="{Binding CurLOS, Mode=OneWay}" Value="-1">
-																	<Setter Property="Text" Value="???" />
-																</DataTrigger>
-															</Style.Triggers>
-														</Style>
-													</Run.Style>
-												</Run>
-												<Run Text=")" Foreground="#FFF08020" />
+														<Run Text="  (" Foreground="#FFF08020" />
+														<Run Foreground="#FFF08020">
+															<Run.Style>
+																<Style TargetType="{x:Type Run}">
+																	<Setter Property="Text" Value="{Binding CurLOS, Mode=OneWay}" />
+																	<Style.Triggers>
+																		<DataTrigger Binding="{Binding CurLOS, Mode=OneWay}" Value="-1">
+																			<Setter Property="Text" Value="???" />
+																		</DataTrigger>
+																	</Style.Triggers>
+																</Style>
+															</Run.Style>
+														</Run>
+														<Run Text=")" Foreground="#FFF08020" />
+
+														<TextBlock.Style>
+															<Style TargetType="{x:Type TextBlock}">
+																<Style.Triggers>
+																	<DataTrigger Binding="{Binding IsAbyssal, Mode=OneWay}" Value="True">
+																		<Setter Property="Visibility" Value="Collapsed" />
+																	</DataTrigger>
+																</Style.Triggers>
+															</Style>
+														</TextBlock.Style>
+													</TextBlock>
+												</InlineUIContainer>
 											</TextBlock>
 
 											<Image Grid.Column="3"
@@ -871,23 +1138,49 @@
 																<DataTrigger Binding="{Binding CurLuck, Mode=OneWay}" Value="-1">
 																	<Setter Property="Text" Value="???" />
 																</DataTrigger>
+																<DataTrigger Binding="{Binding IsAbyssal, Mode=OneWay}" Value="True">
+																	<Setter Property="Text" Value="{Binding AbyssalLuck, Mode=OneWay}" />
+																</DataTrigger>
+																<MultiDataTrigger>
+																	<MultiDataTrigger.Conditions>
+																		<Condition Binding="{Binding IsAbyssal, Mode=OneWay}" Value="True" />
+																		<Condition Binding="{Binding AbyssalLuck, Mode=OneWay}" Value="-1" />
+																	</MultiDataTrigger.Conditions>
+																	<MultiDataTrigger.Setters>
+																		<Setter Property="Text" Value="???" />
+																	</MultiDataTrigger.Setters>
+																</MultiDataTrigger>
 															</Style.Triggers>
 														</Style>
 													</Run.Style>
 												</Run>
-												<Run Text="(max" />
-												<Run>
-													<Run.Style>
-														<Style TargetType="{x:Type Run}">
-															<Setter Property="Text" Value="{Binding MaxLuck, Mode=OneWay}" />
-															<Style.Triggers>
-																<DataTrigger Binding="{Binding MaxLuck, Mode=OneWay}" Value="-1">
-																	<Setter Property="Text" Value="???" />
-																</DataTrigger>
-															</Style.Triggers>
-														</Style>
-													</Run.Style>
-												</Run><Run Text=")" />
+												<InlineUIContainer>
+													<TextBlock Foreground="#5cccf8">
+														<Run Text="(max" />
+														<Run>
+															<Run.Style>
+																<Style TargetType="{x:Type Run}">
+																	<Setter Property="Text" Value="{Binding MaxLuck, Mode=OneWay}" />
+																	<Style.Triggers>
+																		<DataTrigger Binding="{Binding MaxLuck, Mode=OneWay}" Value="-1">
+																			<Setter Property="Text" Value="???" />
+																		</DataTrigger>
+																	</Style.Triggers>
+																</Style>
+															</Run.Style>
+														</Run><Run Text=")" />
+
+														<TextBlock.Style>
+															<Style TargetType="{x:Type TextBlock}">
+																<Style.Triggers>
+																	<DataTrigger Binding="{Binding IsAbyssal, Mode=OneWay}" Value="True">
+																		<Setter Property="Visibility" Value="Collapsed" />
+																	</DataTrigger>
+																</Style.Triggers>
+															</Style>
+														</TextBlock.Style>
+													</TextBlock>
+												</InlineUIContainer>
 											</TextBlock>
 
 											<Border Grid.ColumnSpan="6"
@@ -1301,6 +1594,16 @@
 												</StackPanel.Style>
 											</StackPanel>
 										</Grid>
+
+										<StackPanel.Style>
+											<Style TargetType="{x:Type StackPanel}">
+												<Style.Triggers>
+													<DataTrigger Binding="{Binding IsAbyssal,Mode=OneWay}" Value="True">
+														<Setter Property="Visibility" Value="Collapsed" />
+													</DataTrigger>
+												</Style.Triggers>
+											</Style>
+										</StackPanel.Style>
 									</StackPanel>
 
 									<StackPanel Orientation="Vertical"
@@ -1376,6 +1679,16 @@
 												</DataTemplate>
 											</ItemsControl.ItemTemplate>
 										</ItemsControl>
+
+										<StackPanel.Style>
+											<Style TargetType="{x:Type StackPanel}">
+												<Style.Triggers>
+													<DataTrigger Binding="{Binding IsAbyssal,Mode=OneWay}" Value="True">
+														<Setter Property="Visibility" Value="Collapsed" />
+													</DataTrigger>
+												</Style.Triggers>
+											</Style>
+										</StackPanel.Style>
 									</StackPanel>
 								</StackPanel>
 							</ScrollViewer>
@@ -1388,9 +1701,17 @@
 								<ColumnDefinition Width="Auto" />
 								<ColumnDefinition Width="*" />
 							</Grid.ColumnDefinitions>
+							<Grid.RowDefinitions>
+								<RowDefinition Height="Auto" />
+								<RowDefinition Height="*" />
+							</Grid.RowDefinitions>
 
+							<metro:PromptTextBox Text="{Binding SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+												 Prompt="칸무스 검색"
+												 Padding="2" />
 							<ScrollViewer VerticalScrollBarVisibility="Auto"
-										  Margin="0,0,2,0">
+										  Margin="0,0,2,0"
+										  Grid.Row="1">
 								<ListBox Background="{DynamicResource ActiveBackgroundBrushKey}"
 										 ItemsSource="{Binding EquipmentList}"
 										 SelectedValue="{Binding SelectedEquipment}"
@@ -1429,6 +1750,7 @@
 										<DataTemplate DataType="{x:Type metro_controls:ITabItem}">
 											<Grid Margin="3">
 												<Grid.ColumnDefinitions>
+													<ColumnDefinition Width="20" />
 													<ColumnDefinition Width="Auto" SharedSizeGroup="IdType" />
 													<ColumnDefinition Width="*" />
 												</Grid.ColumnDefinitions>
@@ -1437,14 +1759,22 @@
 													<RowDefinition Height="Auto" />
 												</Grid.RowDefinitions>
 
-												<TextBlock Grid.Column="0"
+												<kcvc:SlotItemIcon Grid.Column="0"
+																   Grid.RowSpan="2"
+																   Margin="0,0,2,0"
+																   Type="{Binding Equipment.IconType, Mode=OneWay}"
+																   VerticalAlignment="Center"
+																   Width="18"
+																   Height="18" />
+
+												<TextBlock Grid.Column="1"
 														   Grid.Row="0"
 														   Margin="3,0"
 														   VerticalAlignment="Bottom"
 														   Style="{StaticResource DetailTextStyleKey}"
 														   FontSize="8"
 														   Text="{Binding Id, Mode=OneWay, StringFormat={}No.{0}}" />
-												<TextBlock Grid.Column="0"
+												<TextBlock Grid.Column="1"
 														   Grid.Row="1"
 														   Margin="3,0"
 														   VerticalAlignment="Top"
@@ -1452,7 +1782,7 @@
 														   FontSize="10"
 														   Text="{Binding ItemType, Mode=OneWay}" />
 
-												<TextBlock Grid.Column="1"
+												<TextBlock Grid.Column="2"
 														   Grid.RowSpan="2"
 														   Margin="5,1,3,1"
 														   Style="{StaticResource EmphaticTextStyleKey}"
@@ -1460,6 +1790,16 @@
 														   VerticalAlignment="Center"
 														   TextTrimming="CharacterEllipsis"
 														   Text="{Binding Name, Mode=OneWay}" />
+
+												<Grid.Style>
+													<Style TargetType="{x:Type Grid}">
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding IsVisible, Mode=OneWay}">
+																<Setter Property="Visibility" Value="Collapsed" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</Grid.Style>
 											</Grid>
 										</DataTemplate>
 									</ListBox.ItemTemplate>
@@ -1479,6 +1819,7 @@
 							</ScrollViewer>
 
 							<ScrollViewer Grid.Column="1"
+										  Grid.RowSpan="2"
 										  VerticalScrollBarVisibility="Auto">
 								<StackPanel Orientation="Vertical"
 											Margin="0,0,0,10"

--- a/source/Grabacr07.KanColleViewer/Views/Catalogs/DictionaryWindow.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Catalogs/DictionaryWindow.xaml
@@ -1251,12 +1251,12 @@
 												   Height="18"
 												   Source="http://wolfgangkurz.github.io/KanColleAssets/stats/dev.png" />
 											<TextBlock Grid.Column="1"
-													   Grid.Row="9"
+													   Grid.Row="10"
 													   Margin="4,4,10,0"
 													   Foreground="#f2f2f2"
 													   Text="건조시간" />
 											<TextBlock Grid.Column="2"
-													   Grid.Row="9"
+													   Grid.Row="10"
 													   Margin="0,4,0,0"
 													   Foreground="#ff7878"
 													   Text="{Binding BuildTimeText, Mode=OneWay}" />

--- a/source/Grabacr07.KanColleWrapper/Models/AirBase.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/AirBase.cs
@@ -213,9 +213,12 @@ namespace Grabacr07.KanColleWrapper.Models
 
 					// 정찰기, 수상정찰기, (분식정찰기?)
 					// 본래는 제공치에 포함되지 않으나 기항대에는 포함되는 듯
+					// 다만 기지항공대 공격을 방공할 때에만 출격하는 듯함. 일단은 주석처리
 					default:
+						/*
 						bonus = Math.Sqrt(proficiency.GetInternalValue(def) / 10.0)
 							+ 0;
+						*/
 						break;
 				}
 				bonus = Math.Min(22, bonus) + Math.Sqrt(12);

--- a/source/Grabacr07.KanColleWrapper/Models/AirBase.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/AirBase.cs
@@ -212,9 +212,10 @@ namespace Grabacr07.KanColleWrapper.Models
 						break;
 
 					// 정찰기, 수상정찰기, (분식정찰기?)
-					// 본래는 제공치에 포함되지 않으나 기항대에는 포함되나?
-					// 다만 어차피 대공이 안붙어있음
+					// 본래는 제공치에 포함되지 않으나 기항대에는 포함되는 듯
 					default:
+						bonus = Math.Sqrt(proficiency.GetInternalValue(def) / 10.0)
+							+ 0;
 						break;
 				}
 				bonus = Math.Min(22, bonus) + Math.Sqrt(12);

--- a/source/Grabacr07.KanColleWrapper/Models/SlotItemInfo.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/SlotItemInfo.cs
@@ -79,6 +79,28 @@ namespace Grabacr07.KanColleWrapper.Models
 
 		public bool IsNumerable => this.Type.IsNumerable();
 
+		public bool IsAerialCombatable // 항공전 참여 여부
+		{
+			get
+			{
+				switch (this.Type)
+				{
+					case SlotItemType.艦上戦闘機: // 전투기
+					case SlotItemType.水上戦闘機: // 수상전투기
+					case SlotItemType.噴式戦闘機: // 분식전투기
+					case SlotItemType.局地戦闘機: // 국지전투기
+					case SlotItemType.艦上攻撃機: // 뇌격기
+					case SlotItemType.艦上爆撃機: // 폭격기
+					case SlotItemType.噴式攻撃機: // 분식뇌격기
+					case SlotItemType.噴式戦闘爆撃機: // 분식전투폭격기
+					case SlotItemType.陸上攻撃機: // 육상공격기
+					case SlotItemType.水上爆撃機: // 수상폭격기
+						return true;
+				}
+				return false;
+			}
+		}
+
 		public bool IsFirstEncounter => this.Type == SlotItemType.艦上偵察機
 									   || this.Type == SlotItemType.水上偵察機;
 


### PR DESCRIPTION
### ↯ 다운로드
- GitHub [다운로드](https://github.com/CirnoV/KanColleViewer/releases/download/v4.2.10r14/KanColleViewer-KR.4.2.10.r14.zip)
- MEGA [다운로드](https://mega.nz/#!LxwDCRjY!6h2OIdU94JF_VbuSIcemg3WCrHB3Q0iQjkSsXrZCRVk)

### 🔗 외부 링크
- VirusTotal [검사 결과](https://virustotal.com/ko/file/e685ba255f46850f761a19283cc38a7636db45f043803dfeeab4b4054780a699/analysis/1496053636/)
- OpenDB Project Website ([http://swaytwig.com/opendb/](http://swaytwig.com/opendb/))
- 업데이트 페이지 [http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html](http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html)

질문 및 건의사항은 [wolfgangkurzdev@gmail.com](mailto:wolfgangkurzdev@gmail.com) 으로 메일 부탁드립니다.
뷰어 사용중 오류가 발생하는 경우, error.log 혹은 battleinfo_error.log 를 첨부해주시면 해결에 도움이 됩니다.

----

### 💬 공통
- CSS 적용 및 플래시 퀄리티 작동을 수정했습니다.
  * 간헐적으로 CSS 가 적용이 안되거나 늦게 적용되는 문제를 수정했습니다.
  * 구동 후 플래시 퀄리티가 적용되지 않는 문제를 수정했습니다.
  * 플래시 퀄리티가 중간이나 낮음으로 설정된 경우, 게임이 시작될 때 한 번 새로고침 될 수 있습니다.
- 게임이 시작되기 전에 DMM 화면이 나오는 대신 검은 화면이 덮이도록 수정했습니다.

### 💬 번역
- 신규 장비의 번역이 갱신되었습니다. 
  * 시제 41cm 3연장포改 번역이 추가되었습니다.

### 💬 데이터 사전
- 검색 기능을 추가했습니다.
- 칸무스/심해서함 연료/탄약 표시 다음 줄에 해당 함선의 건조 시간을 추가했습니다.
- 칸무스/심해서함의 장비 표시에 해당 함선을 상대할 때의 항공전/기항대 제공 수치를 추가했습니다.
  * 기항대 제공은 항공전에 참여하지 않는 항공기의 제공 수치도 포함되어 계산됩니다.
- 칸무스/심해서함의 장비 표시에 해당 장비의 번호 표시를 추가했습니다.
- 심해서함 데이터를 외부에서 불러오도록 추가했습니다.
  * 모든 심해서함의 데이터가 ""???"" 로 표기되는 경우에는 데이터 사전 창을 껐다 다시 켜보시기 바랍니다.
  * 데이터는 [https://github.com/WolfgangKurz/KanColleAssets/blob/master/abyssal_table.json](https://github.com/WolfgangKurz/KanColleAssets/blob/master/abyssal_table.json) 에서 참조합니다.
  * 보기 편하게 정리된 데이터는 [https://docs.google.com/spreadsheets/d/13Qi8UZgD8fVpeIDwEtDMrY_Zc16qnem9wh0X-h3V0hY/edit?usp=sharing](https://docs.google.com/spreadsheets/d/13Qi8UZgD8fVpeIDwEtDMrY_Zc16qnem9wh0X-h3V0hY/edit?usp=sharing) 에서 확인할 수 있습니다.