### PR TITLE
v4.2.10 rev17

### DIFF
--- a/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
@@ -15,4 +15,4 @@ using System.Windows;
 	ResourceDictionaryLocation.None,
 	ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("4.2.10.16")]
+[assembly: AssemblyVersion("4.2.10.17")]

--- a/source/Grabacr07.KanColleViewer/ViewModels/Catalogs/ShipCatalogFilter.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/Catalogs/ShipCatalogFilter.cs
@@ -342,6 +342,83 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 		}
 	}
 
+	public class DaihatsueFilter : ShipCatalogFilter
+	{
+		#region Both 変更通知プロパティ
+
+		private bool _Both;
+
+		public bool Both
+		{
+			get { return this._Both; }
+			set
+			{
+				if (this._Both != value)
+				{
+					this._Both = value;
+					this.RaisePropertyChanged();
+					this.Update();
+				}
+			}
+		}
+
+		#endregion
+
+		#region CanEquip 変更通知プロパティ
+
+		private bool _CanEquip;
+
+		public bool CanEquip
+		{
+			get { return this._CanEquip; }
+			set
+			{
+				if (this._CanEquip != value)
+				{
+					this._CanEquip = value;
+					this.RaisePropertyChanged();
+					this.Update();
+				}
+			}
+		}
+
+		#endregion
+
+		#region CannotEquip 変更通知プロパティ
+
+		private bool _CannotEquip;
+
+		public bool CannotEquip
+		{
+			get { return this._CannotEquip; }
+			set
+			{
+				if (this._CannotEquip != value)
+				{
+					this._CannotEquip = value;
+					this.RaisePropertyChanged();
+					this.Update();
+				}
+			}
+		}
+
+		#endregion
+
+		public DaihatsueFilter(Action updateAction) : base(updateAction)
+		{
+			this._Both = true;
+		}
+
+		public override bool Predicate(Ship ship)
+		{
+			if (this.Both) return true;
+			if (this.CanEquip && ship.DaihatsuEquipable) return true;
+			if (this.CannotEquip && !ship.DaihatsuEquipable) return true;
+
+			return false;
+		}
+	}
+
 	public class ShipRemodelingFilter : ShipCatalogFilter
 	{
 		#region Both 変更通知プロパティ

--- a/source/Grabacr07.KanColleViewer/ViewModels/Catalogs/ShipCatalogWindowViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/Catalogs/ShipCatalogWindowViewModel.cs
@@ -35,6 +35,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 		public ShipConditionFilter ShipConditionFilter { get; }
 		public ShipExSlotFilter ShipExSlotFilter { get; }
 		public ShipFleetFilter ShipFleetFilter { get; }
+		public DaihatsueFilter DaihatsueFilter { get; }
 
 		public bool CheckAllShipTypes
 		{
@@ -151,6 +152,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 			this.ShipConditionFilter = new ShipConditionFilter(this.Update);
 			this.ShipExSlotFilter = new ShipExSlotFilter(this.Update);
 			this.ShipFleetFilter = new ShipFleetFilter(this.Update);
+			this.DaihatsueFilter = new DaihatsueFilter(this.Update);
 
 			this.updateSource
 				.Do(_ => this.IsReloading = true)
@@ -191,7 +193,8 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 					.Where(this.ShipDamagedFilter.Predicate)
 					.Where(this.ShipConditionFilter.Predicate)
 					.Where(this.ShipExSlotFilter.Predicate)
-					.Where(this.ShipFleetFilter.Predicate);
+					.Where(this.ShipFleetFilter.Predicate)
+					.Where(this.DaihatsueFilter.Predicate);
 
 				this.Ships = this.SortWorker.Sort(list)
 					.Select((x, i) => new ShipViewModel(i + 1, x, areas.FirstOrDefault(y => y.Area == x.SallyArea)))

--- a/source/Grabacr07.KanColleViewer/ViewModels/Contents/AdmiralViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/Contents/AdmiralViewModel.cs
@@ -66,6 +66,9 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents
 		}
 		#endregion
 
+		public int MamiyaCount => KanColleClient.Current.Homeport?.Itemyard?.UseItems[54]?.Count ?? 0;
+		public int IrakoCount => KanColleClient.Current.Homeport?.Itemyard?.UseItems[59]?.Count ?? 0;
+
 		public static HQRecord Record;
 
 		public AdmiralViewModel()

--- a/source/Grabacr07.KanColleViewer/Views/Catalogs/ShipCatalogWindow.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Catalogs/ShipCatalogWindow.xaml
@@ -392,6 +392,28 @@
 													 IsChecked="{Binding NotMaxModernized, Mode=TwoWay}" />
 									</WrapPanel>
 								</Grid>
+
+								<Grid DataContext="{Binding DaihatsueFilter}">
+									<Grid.ColumnDefinitions>
+										<ColumnDefinition Width="Auto"
+														  SharedSizeGroup="FilterName" />
+										<ColumnDefinition Width="10" />
+										<ColumnDefinition Width="*" />
+									</Grid.ColumnDefinitions>
+									<TextBlock Margin="0,2"
+											   HorizontalAlignment="Right">
+										<Run Text="대발동정" />
+										<Run Text=":" />
+									</TextBlock>
+									<WrapPanel Grid.Column="2">
+										<RadioButton Content="모두"
+													 IsChecked="{Binding Both, Mode=TwoWay}" />
+										<RadioButton Content="장착가능"
+													 IsChecked="{Binding CanEquip, Mode=TwoWay}" />
+										<RadioButton Content="불가능"
+													 IsChecked="{Binding CannotEquip, Mode=TwoWay}" />
+									</WrapPanel>
+								</Grid>
 							</StackPanel>
 
 							<StackPanel>
@@ -784,49 +806,59 @@
 								</GridViewColumn.CellTemplate>
 							</GridViewColumn>
 
-							<GridViewColumn>
+							<GridViewColumn Width="92">
 								<GridViewColumn.Header>
 									<TextBlock Text="개조레벨" />
 								</GridViewColumn.Header>
 								<GridViewColumn.CellTemplate>
 									<DataTemplate>
-										<Border x:Name="LvBorder"
-												Margin="-2,0">
+										<Grid x:Name="LvBorder"
+											  Margin="-2,0">
+											<Grid.ColumnDefinitions>
+												<ColumnDefinition Width="*" />
+												<ColumnDefinition Width="Auto" />
+												<ColumnDefinition Width="Auto" />
+											</Grid.ColumnDefinitions>
+
 											<TextBlock FontSize="9"
-												   Margin="0,3"
-												  >
-											<Run Text="Lv."
-												 x:Name="Lvtext"/>
-											<Run Text="{Binding Ship.RemodelLevel, Mode=OneWay}"
-												 FontSize="12"
-												  x:Name="NextLv"
-												 Foreground="{DynamicResource ActiveForegroundBrushKey}" />
+													   Margin="0,3,3,3">
+												<Run Text="Lv."
+													 x:Name="Lvtext" />
+												<Run Text="{Binding Ship.RemodelLevel, Mode=OneWay}"
+													 FontSize="12"
+													 x:Name="NextLv"
+													 Foreground="{DynamicResource ActiveForegroundBrushKey}" />
 											</TextBlock>
-										</Border>
+
+											<Image x:Name="BlueprintImage"
+												   Source="http://wolfgangkurz.github.io/KanColleAssets/useitem/blueprint.png"
+												   Grid.Column="1"
+												   Margin="2,0"
+												   VerticalAlignment="Center"
+												   Width="18"
+												   Height="18"
+												   Visibility="{Binding Ship.NeedBlueprint, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+											<Image x:Name="CatapultImage"
+												   Source="http://wolfgangkurz.github.io/KanColleAssets/useitem/catapult.png"
+												   Grid.Column="2"
+												   Margin="2,0"
+												   VerticalAlignment="Center"
+												   Width="18"
+												   Height="18"
+												   Visibility="{Binding Ship.NeedCatapult, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+										</Grid>
 										<DataTemplate.Triggers>
-											<DataTrigger Binding="{Binding Ship.RemodelLevel}"
-															 Value="0">
-												<Setter TargetName="Lvtext"
-															Property="Text"
-															Value="" />
-												<Setter TargetName="NextLv"
-															Property="Text"
-															Value="" />
+											<DataTrigger Binding="{Binding Ship.RemodelLevel}" Value="0">
+												<Setter TargetName="Lvtext" Property="Text" Value="" />
+												<Setter TargetName="NextLv" Property="Text" Value="" />
+												<Setter TargetName="BlueprintImage" Property="Visibility" Value="Collapsed" />
+												<Setter TargetName="CatapultImage" Property="Visibility" Value="Collapsed" />
 											</DataTrigger>
-											<DataTrigger Binding="{Binding Ship.RemodelLevel}"
-															 Value="-1">
-												<Setter TargetName="Lvtext"
-															Property="Text"
-															Value="" />
-												<Setter TargetName="NextLv"
-															Property="Text"
-															Value="개조가능" />
-												<Setter TargetName="NextLv"
-															Property="Foreground"
-															Value="White" />
-												<Setter TargetName="LvBorder"
-														Property="Background"
-														Value="#FF384CD1" />
+											<DataTrigger Binding="{Binding Ship.RemodelLevel}" Value="-1">
+												<Setter TargetName="Lvtext" Property="Text" Value="" />
+												<Setter TargetName="NextLv" Property="Text" Value="개조가능" />
+												<Setter TargetName="NextLv" Property="Foreground" Value="White" />
+												<Setter TargetName="LvBorder" Property="Background" Value="#FF384CD1" />
 											</DataTrigger>
 										</DataTemplate.Triggers>
 									</DataTemplate>

--- a/source/Grabacr07.KanColleViewer/Views/Contents/Homeport.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Contents/Homeport.xaml
@@ -86,6 +86,16 @@
 					</DataTrigger>
 				</Style.Triggers>
 			</Style>
+			<Style TargetType="{x:Type TextBlock}"
+				   x:Key="Emphatic14"
+				   BasedOn="{StaticResource EmphaticTextStyleKey}">
+				<Setter Property="FontSize" Value="14" />
+				<Style.Triggers>
+					<DataTrigger Binding="{Binding Source={x:Static ms:KanColleSettings.HomeportBigFont}, Path=Value}" Value="False">
+						<Setter Property="FontSize" Value="12" />
+					</DataTrigger>
+				</Style.Triggers>
+			</Style>
 			<Style TargetType="{x:Type Run}"
 				   x:Key="EmphaticRun"
 				   BasedOn="{StaticResource EmphaticTextElementStyleKey}">
@@ -285,25 +295,47 @@
 							   Fill="{DynamicResource InactiveForegroundBrushKey}"
 							   Opacity="0.6" />
 
-					<StackPanel Orientation="Horizontal"
+					<StackPanel Orientation="Vertical"
 								VerticalAlignment="Center">
-						<TextBlock>
-								<Run Text="자연회복한계:" />
-								<Run Text="{Binding Model.ResourceLimit, Mode=OneWay}"
-									 Style="{StaticResource EmphaticRun14}" />
-								<Run Text="까지" />
+						<Grid>
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition Width="Auto" />
+								<ColumnDefinition Width="*" />
+								<ColumnDefinition Width="Auto" />
+								<ColumnDefinition Width="*" />
+							</Grid.ColumnDefinitions>
 
-								<Run Text="(" />
-								<Run Text="{Binding ResourceLimitRemaining, Mode=OneWay}"
-									 Style="{StaticResource EmphaticRun14}" />
-								<Run Text="남음" />
-								<Run Text=")" />
-								<LineBreak />
-								<Run Text="가구코인:" />
-								<Run Text="{Binding Model.FurnitureCoins, Mode=OneWay}"
-									 Style="{StaticResource EmphaticRun14}" />
-								<Run Text="개" />
-								<LineBreak />
+							<TextBlock Grid.Column="0"
+									   Text="마미야:" />
+							<TextBlock Grid.Column="1"
+									   Text="{Binding MamiyaCount, Mode=OneWay, StringFormat={}{0}개}"
+									   Style="{StaticResource Emphatic14}" />
+
+							<TextBlock Grid.Column="2"
+									   Text="이라코:" />
+							<TextBlock Grid.Column="3"
+									   Text="{Binding IrakoCount, Mode=OneWay, StringFormat={}{0}개}"
+									   Style="{StaticResource Emphatic14}" />
+						</Grid>
+						<TextBlock>
+							<Run Text="자연회복한계:" />
+							<Run Text="{Binding Model.ResourceLimit, Mode=OneWay}"
+								 Style="{StaticResource EmphaticRun14}" />
+							<Run Text="까지" />
+
+							<Run Text="(" />
+							<Run Text="{Binding ResourceLimitRemaining, Mode=OneWay}"
+								 Style="{StaticResource EmphaticRun14}" />
+							<Run Text="남음" />
+							<Run Text=")" />
+							<LineBreak />
+
+							<Run Text="가구코인:" />
+							<Run Text="{Binding Model.FurnitureCoins, Mode=OneWay}"
+								 Style="{StaticResource EmphaticRun14}" />
+							<Run Text="개" />
+						</TextBlock>
+						<TextBlock>
 								<Run Text="갑훈장:" />
 								<Run Text="{Binding Model.Medals, Mode=OneWay}"
 									 Style="{StaticResource EmphaticRun14}" />

--- a/source/Grabacr07.KanColleViewer/Views/Controls/KanColleHost.cs
+++ b/source/Grabacr07.KanColleViewer/Views/Controls/KanColleHost.cs
@@ -234,6 +234,8 @@ namespace Grabacr07.KanColleViewer.Views.Controls
 				if (KanColleSettings.FlashElementQuality != FlashQuality.High)
 					this.ApplyFlashQuality(true);
 			}
+			this.ApplyStyleSheet(1);
+			this.Update();
 		}
 
 		private void HandleWebBrowserNewWindow(string url, int flags, string targetFrameName, ref object postData, string headers, ref bool processed)
@@ -245,39 +247,43 @@ namespace Grabacr07.KanColleViewer.Views.Controls
 			window.WebBrowser.Navigate(url);
 		}
 
-		private void ApplyStyleSheet()
+		private void ApplyStyleSheet(int step = 0)
 		{
 			if (!this.firstLoaded) return;
 
 			try
 			{
-				var script = string.Format(
-					"document.addEventListener('DOMContentLoaded', function(){{"
-						+ "var x=document.createElement('style');x.type='text/css';x.innerHTML='{0}';document.body.appendChild(x);"
-					+ "}});",
-					this.UserStyleSheet.Replace("'", "\\'").Replace("\r\n", "\\n")
-				);
-				WebBrowser.InvokeScript("eval", new object[] { script });
-				this.styleSheetApplied = true;
-
-
-				var document = this.WebBrowser.Document as HTMLDocument;
-				if (document == null) return;
-
-				var gameFrame = document.getElementById("game_frame");
-				if (gameFrame == null)
+				if (step == 0)
 				{
-					if (document.url.Contains(".swf?"))
-					{
-						gameFrame = document.body;
-					}
-				}
-
-				var target = gameFrame?.document as HTMLDocument;
-				if (target != null)
-				{
-					target.createStyleSheet().cssText = this.UserStyleSheet;
+					var script = string.Format(
+						"document.addEventListener('DOMContentLoaded', function(){{"
+							+ "var x=document.createElement('style');x.type='text/css';x.innerHTML='{0}';document.body.appendChild(x);"
+						+ "}});",
+						this.UserStyleSheet.Replace("'", "\\'").Replace("\r\n", "\\n")
+					);
+					WebBrowser.InvokeScript("eval", new object[] { script });
 					this.styleSheetApplied = true;
+				}
+				else
+				{
+					var document = this.WebBrowser.Document as HTMLDocument;
+					if (document == null) return;
+
+					var gameFrame = document.getElementById("game_frame");
+					if (gameFrame == null)
+					{
+						if (document.url.Contains(".swf?"))
+						{
+							gameFrame = document.body;
+						}
+					}
+
+					var target = gameFrame?.document as HTMLDocument;
+					if (target != null)
+					{
+						target.createStyleSheet().cssText = this.UserStyleSheet;
+						this.styleSheetApplied = true;
+					}
 				}
 			}
 			catch (Exception) when (Application.Instance.State == ApplicationState.Startup)

--- a/source/Grabacr07.KanColleWrapper/KanColleClient.cs
+++ b/source/Grabacr07.KanColleWrapper/KanColleClient.cs
@@ -151,16 +151,17 @@ namespace Grabacr07.KanColleWrapper
 			requireInfoSource
 				.SkipUntil(firstTime)
 				.Subscribe(x => this.SetRequireInfo(x.Data));
-			
+
 			this.Logger = new Logger(proxy);
 			this.ResourceLogger = new ResourceLogManager(this);
 		}
 
 		private void SetRequireInfo(kcsapi_require_info data)
-				{
+		{
 			this.Homeport.UpdateAdmiral(data.api_basic);
 			this.Homeport.Itemyard.Update(data.api_slot_item);
 			this.Homeport.Dockyard.Update(data.api_kdock);
+			this.Homeport.Itemyard.Update(data.api_useitem);
 		}
 	}
 }

--- a/source/Grabacr07.KanColleWrapper/Models/Raw/kcsapi_mst_stype.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/Raw/kcsapi_mst_stype.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Runtime.Serialization;
 
 namespace Grabacr07.KanColleWrapper.Models.Raw
 {
@@ -14,6 +15,13 @@ namespace Grabacr07.KanColleWrapper.Models.Raw
 		public string api_name { get; set; }
 		public int api_scnt { get; set; }
 		public int api_kcnt { get; set; }
+		public Api_Equip_Type api_equip_type { get; set; }
+	}
+
+	public class Api_Equip_Type
+	{
+		[DataMember(Name = "24")]
+		public int _24 { get; set; }
 	}
 	// ReSharper restore InconsistentNaming
 }

--- a/source/Grabacr07.KanColleWrapper/Models/Ship.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/Ship.cs
@@ -56,7 +56,26 @@ namespace Grabacr07.KanColleWrapper.Models
 			}
 		}
 
-		public string LvName=>"[Lv." + this.Level + "]  " + this.Info.Name;
+		public bool NeedBlueprint
+		{
+			get
+			{
+				return KanColleClient.Current.Master.RawData.api_mst_shipupgrade
+					.FirstOrDefault(x => x.api_current_ship_id == this.Info.Id)
+					?.api_drawing_count > 0;
+			}
+		}
+		public bool NeedCatapult
+		{
+			get
+			{
+				return KanColleClient.Current.Master.RawData.api_mst_shipupgrade
+					.FirstOrDefault(x => x.api_current_ship_id == this.Info.Id)
+					?.api_catapult_count > 0;
+			}
+		}
+
+		public string LvName => "[Lv." + this.Level + "]  " + this.Info.Name;
 		public string RepairTimeString
 		{
 			get
@@ -197,7 +216,7 @@ namespace Grabacr07.KanColleWrapper.Models
 		}
 
 		#endregion
-		
+
 		#region Torpedo 変更通知プロパティ
 
 		private ModernizableStatus _Torpedo;
@@ -220,7 +239,7 @@ namespace Grabacr07.KanColleWrapper.Models
 		#region YasenFp 変更通知プロパティ
 
 		private ModernizableStatus _YasenFp;
-		
+
 		public ModernizableStatus YasenFp
 		{
 			get { return this._YasenFp; }
@@ -432,6 +451,10 @@ namespace Grabacr07.KanColleWrapper.Models
 		/// </summary>
 		public bool IsMaxModernized => this.Firepower.IsMax && this.Torpedo.IsMax && this.AA.IsMax && this.Armer.IsMax;
 
+		public bool DaihatsuEquipable =>
+			(new int[] { 541, 500, 490, 487, 470, 464, 469, 435, 434, 352, 200, 468, 418, 199, 147 }.Contains(this.Info.Id)) ||
+			(!(new int[] { 491, 445 }.Contains(this.Info.Id)) && this.Info.ShipType.RawData.api_equip_type?._24 == 1);
+
 		/// <summary>
 		/// 現在のコンディション値を取得します。
 		/// </summary>
@@ -551,7 +574,7 @@ namespace Grabacr07.KanColleWrapper.Models
 					new int[] {
 						this.Info.RawData.api_houg[0] + this.Info.RawData.api_raig[0],
 						this.Info.RawData.api_houg[1] + this.Info.RawData.api_raig[1]},
-					this.RawData.api_kyouka[0]+ this.RawData.api_kyouka[1]);
+					this.RawData.api_kyouka[0] + this.RawData.api_kyouka[1]);
 				this.AA = new ModernizableStatus(this.Info.RawData.api_tyku, this.RawData.api_kyouka[2]);
 				this.Armer = new ModernizableStatus(this.Info.RawData.api_souk, this.RawData.api_kyouka[3]);
 				this.Luck = new ModernizableStatus(this.Info.RawData.api_luck, this.RawData.api_kyouka[4]);


### PR DESCRIPTION
### ↯ 다운로드
- GitHub [다운로드](https://github.com/CirnoV/KanColleViewer/releases/download/v4.2.10r17/KanColleViewer-KR.4.2.10.r17.zip)
- MEGA [다운로드](https://mega.nz/#!L8Y3xZwQ!aJ-M5MVwb5rck394SOCYQScqZB84H381NGQYLIEtlVs)

### 🔗 외부 링크
- VirusTotal [검사 결과](https://virustotal.com/ko/file/2e72fc45f78f6d93fcd1f211eddba8695392a23b5919409fe40788a0f9bf1883/analysis/1496249150/)
- OpenDB Project Website ([http://swaytwig.com/opendb/](http://swaytwig.com/opendb/))
- 업데이트 페이지 [http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html](http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html)

질문 및 건의사항은 [wolfgangkurzdev@gmail.com](mailto:wolfgangkurzdev@gmail.com) 으로 메일 부탁드립니다.
뷰어 사용중 오류가 발생하는 경우, error.log 혹은 battleinfo_error.log 를 첨부해주시면 해결에 도움이 됩니다.

----

### 💬 공통
- 사령부 정보 툴팁에 표시되는 정보를 추가했습니다.
  * 마미야, 이라코 갯수 표시가 추가되었습니다.

### 💬 함선 목록 창
- 필터가 추가되었습니다.
  * 대발동정 장착 가능 여부가 추가되었습니다.
- **개조레벨** 컬럼이 수정되었습니다.
  * 다음 개장에 "**개장설계도**" 혹은 "**시제 캐터펄트**"가 필요한 경우, 해당 아이템을 이미지로 표시합니다.

### 💬 번역
- 일부 장비의 번역이 수정되었습니다.
  * 시제 41cm 3연장포改 -> 41cm 3연장포改
  * 1식 전투기 하야부사 3형改(55전대) -> 폭장 1식 전투기 하야부사 3형改(55전대)
