### PR TITLE
v4.2.10 rev20 (Hotfix)

### DIFF
--- a/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
@@ -15,4 +15,4 @@ using System.Windows;
 	ResourceDictionaryLocation.None,
 	ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("4.2.10.19")]
+[assembly: AssemblyVersion("4.2.10.20")]

--- a/source/Grabacr07.KanColleWrapper/KanColleClient.cs
+++ b/source/Grabacr07.KanColleWrapper/KanColleClient.cs
@@ -159,12 +159,19 @@ namespace Grabacr07.KanColleWrapper
 
 		private void SetRequireInfo(kcsapi_require_info data)
 		{
-			this.Homeport.UpdateAdmiral(data.api_basic);
-			this.Homeport.Itemyard.Update(data.api_slot_item);
-			this.Homeport.Dockyard.Update(data.api_kdock);
+			if (this.Homeport == null) return;
 
-			try { this.Homeport.Itemyard.Update(data.api_useitem); }
-			catch { }
+			if (data.api_basic != null)
+				this.Homeport.UpdateAdmiral(data.api_basic);
+
+			if (data.api_slot_item != null)
+				this.Homeport.Itemyard.Update(data.api_slot_item);
+
+			if (data.api_kdock != null)
+				this.Homeport.Dockyard.Update(data.api_kdock);
+
+			if (data.api_useitem != null)
+				this.Homeport.Itemyard.Update(data.api_useitem);
 		}
 	}
 }

--- a/source/Grabacr07.KanColleWrapper/KanColleClient.cs
+++ b/source/Grabacr07.KanColleWrapper/KanColleClient.cs
@@ -134,15 +134,14 @@ namespace Grabacr07.KanColleWrapper
 			// 2 回目以降は受信したタイミングでそれぞれ更新すればよい
 
 			var firstTime = start2Source
-				// .CombineLatest(requireInfoSource, (start2, requireInfo) => new { start2, requireInfo, })
+				.CombineLatest(requireInfoSource, (start2, requireInfo) => new { start2, requireInfo })
 				.FirstAsync();
 
 			firstTime.Subscribe(x =>
 			{
-				this.Master = new Master(x.Data);
-				// this.Master = new Master(x.start2.Data);
+				this.Master = new Master(x.start2.Data);
 				this.Homeport = new Homeport(proxy);
-				// this.SetRequireInfo(x.requireInfo.Data);
+				this.SetRequireInfo(x.requireInfo.Data);
 				this.IsStarted = true;
 			});
 
@@ -163,7 +162,9 @@ namespace Grabacr07.KanColleWrapper
 			this.Homeport.UpdateAdmiral(data.api_basic);
 			this.Homeport.Itemyard.Update(data.api_slot_item);
 			this.Homeport.Dockyard.Update(data.api_kdock);
-			this.Homeport.Itemyard.Update(data.api_useitem);
+
+			try { this.Homeport.Itemyard.Update(data.api_useitem); }
+			catch { }
 		}
 	}
 }

--- a/source/Grabacr07.KanColleWrapper/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleWrapper/Properties/AssemblyInfo.cs
@@ -10,5 +10,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("8C42F9E0-E2C9-4741-8F98-653A4D275798")]
 
-[assembly: AssemblyVersion("1.7.9")]
-[assembly: AssemblyInformationalVersion("1.7.9")]
+[assembly: AssemblyVersion("1.7.10")]
+[assembly: AssemblyInformationalVersion("1.7.10")]


### PR DESCRIPTION
### ↯ 다운로드
- GitHub [다운로드](https://github.com/CirnoV/KanColleViewer/releases/download/v4.2.10r20/KanColleViewer-KR.4.2.10.r20.zip)
- MEGA [다운로드](https://mega.nz/#!LoYRmSaD!4V7ucjUQV6Fb9NA8xwb7LeFcg2wwYTOqz-TPSa1Afzc)

### 🔗 외부 링크
- VirusTotal [검사 결과](https://virustotal.com/ko/file/fecac4cffa5a080cf156f7ac6310a1058a8b0e8554365d94a4ce3da517f80672/analysis/1497201140/)
- OpenDB Project Website ([http://swaytwig.com/opendb/](http://swaytwig.com/opendb/))
- 업데이트 페이지 [http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html](http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html)

질문 및 건의사항은 [wolfgangkurzdev@gmail.com](mailto:wolfgangkurzdev@gmail.com) 으로 메일 부탁드립니다.
뷰어 사용중 오류가 발생하는 경우, error.log 혹은 battleinfo_error.log 를 첨부하여 메일로 제보해주시면 해결에 도움이 됩니다.

뷰어를 완전히 삭제하신 후 재설치를 해보시는 것도 방법이 될 수 있습니다.
뷰어의 각종 로그, 함대 프리셋, 전과 데이터 등을 백업하시려면, **뷰어 폴더 내의 csv 파일들과 Record 폴더를 백업**하면 됩니다.

```diff
- Hotfix 업데이트입니다.
```

```diff
- 장비목록을 열 때 프로그램이 종료되면, 뷰어 폴더의 KanColleWrapper.dll 을 삭제하시기 바랍니다.
- (lib 폴더 내부에 있는 파일은 삭제하지 마세요)
```

----
### 💬 공통
- 칸코레 기동을 탐지하는 루틴을 수정했습니다.
  * #22 (rev19) 의 최적화를 롤백했습니다.
  * #20 (rev17) 에서 추가된 코드 및 기존 코드의 예외처리를 추가했습니다.
