### PR TITLE
v4.2.10 rev21

### DIFF
--- a/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
@@ -15,4 +15,4 @@ using System.Windows;
 	ResourceDictionaryLocation.None,
 	ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("4.2.10.20")]
+[assembly: AssemblyVersion("4.2.10.21")]

--- a/source/Grabacr07.KanColleWrapper/Models/Ship.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/Ship.cs
@@ -452,7 +452,7 @@ namespace Grabacr07.KanColleWrapper.Models
 		public bool IsMaxModernized => this.Firepower.IsMax && this.Torpedo.IsMax && this.AA.IsMax && this.Armer.IsMax;
 
 		public bool DaihatsuEquipable =>
-			(new int[] { 541, 500, 490, 487, 470, 464, 469, 435, 434, 352, 200, 468, 418, 199, 147 }.Contains(this.Info.Id)) ||
+			(new int[] { 541, 500, 490, 487, 470, 464, 469, 435, 434, 352, 200, 468, 418, 199, 147, 488 }.Contains(this.Info.Id)) ||
 			(!(new int[] { 491, 445 }.Contains(this.Info.Id)) && this.Info.ShipType.RawData.api_equip_type?._24 == 1);
 
 		/// <summary>

--- a/source/Grabacr07.KanColleWrapper/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleWrapper/Properties/AssemblyInfo.cs
@@ -10,5 +10,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("8C42F9E0-E2C9-4741-8F98-653A4D275798")]
 
-[assembly: AssemblyVersion("1.7.10")]
-[assembly: AssemblyInformationalVersion("1.7.10")]
+[assembly: AssemblyVersion("1.7.11")]
+[assembly: AssemblyInformationalVersion("1.7.11")]


### PR DESCRIPTION
### ↯ 다운로드
- GitHub [다운로드](https://github.com/CirnoV/KanColleViewer/releases/download/v4.2.10r21/KanColleViewer-KR.4.2.10.r21.zip)
- MEGA [다운로드](https://mega.nz/#!rlBB1TTT!4U6G_NIL3x0J6KOa9VWHr0bjew-dNtoTmx-j1Wx_54A)

### 🔗 외부 링크
- VirusTotal [검사 결과](https://virustotal.com/ko/file/3bfe160e3b92b5600f24e774ddfe49d84a41ce0b8a62d12bc1c218b7da510487/analysis/1498213157/)
- OpenDB Project Website ([http://swaytwig.com/opendb/](http://swaytwig.com/opendb/))
- 업데이트 페이지 [http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html](http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html)

질문 및 건의사항은 [wolfgangkurzdev@gmail.com](mailto:wolfgangkurzdev@gmail.com) 으로 메일 부탁드립니다.
뷰어 사용중 오류가 발생하는 경우, error.log 혹은 battleinfo_error.log 를 첨부하여 메일로 제보해주시면 해결에 도움이 됩니다.

뷰어를 완전히 삭제하신 후 재설치를 해보시는 것도 방법이 될 수 있습니다.
뷰어의 각종 로그, 함대 프리셋, 전과 데이터 등을 백업하시려면, **뷰어 폴더 내의 csv 파일들과 Record 폴더를 백업**하면 됩니다.

```diff
- 장비목록을 열 때 프로그램이 종료되면, 뷰어 폴더의 KanColleWrapper.dll 을 삭제하시기 바랍니다.
- (lib 폴더 내부에 있는 파일은 삭제하지 마세요)
```

----
### 💬 공통
- 대발동정 장착 가능 필터를 갱신했습니다.
  * 유라改2 가 추가되었습니다.

### 💬 번역
- 신규 칸무스 번역이 추가되었습니다.
  * 유라改2
- 신규 장비 번역이 추가되었습니다.
  * 15.5cm 3연장부포改
  * 15.5cm 3연장포改
  * 즈이운(634 해군항공대/숙련)
  * 영식 수상정찰기 11형乙
