### PR TITLE
v4.2.10 rev22

### DIFF
--- a/source/Grabacr07.KanColleViewer.QuestTracker/Models/Tracker/B/B/B71.cs
+++ b/source/Grabacr07.KanColleViewer.QuestTracker/Models/Tracker/B/B/B71.cs
@@ -16,7 +16,7 @@ namespace Grabacr07.KanColleViewer.QuestTracker.Models.Tracker
 	internal class B71 : ITracker
 	{
 		private QuestProgressType lastProgress = QuestProgressType.None;
-		private readonly int max_count = 2;
+		private readonly int max_count = 1;
 		private int count;
 
 		public event EventHandler ProcessChanged;
@@ -36,18 +36,12 @@ namespace Grabacr07.KanColleViewer.QuestTracker.Models.Tracker
 				if (args.MapWorldId != 1 || args.MapAreaId != 6) return; // 1-6
 				if (args.MapNodeId != 14 && args.MapNodeId != 17) return; // 1-6-N node
 
-				var shipTable = new int[]
-				{
-					141, // 五十鈴改二
-					309, // 卯月改
-					418, // 皐月改二
-				};
-
 				var fleet = KanColleClient.Current.Homeport.Organization.Fleets.FirstOrDefault(x => x.Value.IsInSortie).Value;
 				var ships = fleet?.Ships;
+				var flagship = ships[0]?.Info.ShipType.Id;
 
-				if ((ships[0]?.Info.Id ?? 0) != 141) return; // 이스즈改2 기함
-				if (ships.Count(x => shipTable.Contains(x.Info.Id)) < 3) return;
+				if (flagship != 3) return; // 기함 경순
+				if (ships.Count(x => x.Info.ShipType.Id == 2) < 4) return; // 구축 4척
 
 				count = count.Add(1).Max(max_count);
 
@@ -68,7 +62,7 @@ namespace Grabacr07.KanColleViewer.QuestTracker.Models.Tracker
 
 		public string GetProgressText()
 		{
-			return count >= max_count ? "완료" : "이스즈改2 기함,사츠키改2,우즈키改 포함 편성 1-6 클리어 " + count.ToString() + " / " + max_count.ToString();
+			return count >= max_count ? "완료" : "경순 기함, 구축 4척 편성 1-6 클리어 " + count.ToString() + " / " + max_count.ToString();
 		}
 
 		public string SerializeData()

--- a/source/Grabacr07.KanColleViewer.QuestTracker/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer.QuestTracker/Properties/AssemblyInfo.cs
@@ -10,5 +10,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("039E4D88-DECD-494D-92D2-407C6403A010")]
 
-[assembly: AssemblyVersion("1.0.16")]
-[assembly: AssemblyInformationalVersion("1.0.16")]
+[assembly: AssemblyVersion("1.0.17")]
+[assembly: AssemblyInformationalVersion("1.0.17")]

--- a/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
@@ -15,4 +15,4 @@ using System.Windows;
 	ResourceDictionaryLocation.None,
 	ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("4.2.10.21")]
+[assembly: AssemblyVersion("4.2.10.22")]

--- a/source/Grabacr07.KanColleViewer/Views/Catalogs/RemodelListWindow.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Catalogs/RemodelListWindow.xaml
@@ -137,8 +137,15 @@
 		</Border>
 		<StackPanel Margin="10,0" Grid.Row="1">
 			<TextBlock Foreground="#FFF50000" Text="※갱신시간은 0:00이지만 실제로는 약간 늦게 갱신됩니다."/>
-			<TextBlock Foreground="#FFF50000" Text="※특이사항이 있는 장비의 경우 툴팁으로 특이사항을 확인할 수 있습니다."/>
-			<TextBlock/>
+			<TextBlock Foreground="#FFF50000" Text="※필요한 재료 장비 및 개수변환 정보는 툴팁으로 확인할 수 있습니다."/>
+			<TextBlock>
+				<Run>※개수공창 정보는</Run>
+				<metro2:HyperlinkEx Uri="http://akashi-list.me/">
+					<Run Text="http://akashi-list.me/" />
+				</metro2:HyperlinkEx>
+				<Run>를 참조하여 작성되었습니다.</Run>
+			</TextBlock>
+			<TextBlock />
 			<Grid>
 				<Grid.ColumnDefinitions>
 					<ColumnDefinition Width="Auto"/>
@@ -236,17 +243,38 @@
 										</DataTemplate>
 									</Panel.Resources>
 
-									<CheckBox Margin="0,0,10,0"
+									<CheckBox Margin="0,0,12,0"
 											  IsChecked="{Binding OnlyOwnSlotItems}"
 											  Content="보유중인 장비만"
 											  HorizontalAlignment="Left" />
 
-									<CheckBox Margin="0,0,10,0"
+									<CheckBox Margin="0,0,12,0"
 											  IsChecked="{Binding OnlyRemodeledSlotItems}"
 											  Content="개수된 장비만"
 											  HorizontalAlignment="Left" />
 
-									<CheckBox Margin="0,0,10,0"
+									<CheckBox Margin="0,0,12,0"
+											  IsEnabled="{Binding OnlyRemodeledSlotItems, Mode=OneWay}"
+											  IsChecked="{Binding ExcludeMaxRemodeledSlotItems}"
+											  HorizontalAlignment="Left">
+										<CheckBox.Content>
+											<TextBlock>
+												<Run Text="★max" Foreground="#FF45A9A5" />
+												<Run Text="제외" Foreground="{StaticResource ActiveForegroundBrushKey}" />
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding OnlyRemodeledSlotItems}" Value="False">
+																<Setter Property="Opacity" Value="0.3" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+										</CheckBox.Content>
+									</CheckBox>
+
+									<CheckBox Margin="0,0,12,0"
 											  IsChecked="{Binding OnlyOwnShips}"
 											  Content="칸무스가 있는 장비만"
 											  HorizontalAlignment="Left" />


### PR DESCRIPTION
### ↯ 다운로드
- GitHub [다운로드](https://github.com/CirnoV/KanColleViewer/releases/download/v4.2.10r22/KanColleViewer-KR.4.2.10.r22.zip)
- MEGA [다운로드](https://mega.nz/#!HwZXEQyL!cnPF5HIw3Ef_Y6eX9-zGnpzGpPW2m4spCOtYm9kBN2I)

### 🔗 외부 링크
- VirusTotal [검사 결과](https://virustotal.com/ko/file/ab86642b4d6882afa91a871d1cd5f26591f335cde8ea23cffd6efa599b4ec4ac/analysis/1499444737/)
- OpenDB Project Website ([http://swaytwig.com/opendb/](http://swaytwig.com/opendb/))
- 업데이트 페이지 [http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html](http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html)

질문 및 건의사항은 [wolfgangkurzdev@gmail.com](mailto:wolfgangkurzdev@gmail.com) 으로 메일 부탁드립니다.
뷰어 사용중 오류가 발생하는 경우, error.log 혹은 battleinfo_error.log 를 첨부하여 메일로 제보해주시면 해결에 도움이 됩니다.

뷰어를 완전히 삭제하신 후 재설치를 해보시는 것도 방법이 될 수 있습니다.
뷰어의 각종 로그, 함대 프리셋, 전과 데이터 등을 백업하시려면, **뷰어 폴더 내의 csv 파일들과 Record 폴더를 백업**하면 됩니다.

```diff
- 장비목록을 열 때 프로그램이 종료되면, 뷰어 폴더의 KanColleWrapper.dll 을 삭제하시기 바랍니다.
- (lib 폴더 내부에 있는 파일은 삭제하지 마세요)
```

----
### 💬 개수공창 윈도우
- 잘못된 정보를 수정했습니다.
  * 모든 정보를 다시 확인하여 잘못된 부분을 수정했습니다.
- 작동을 개선했습니다.
  * "칸무스가 있는 장비만" 옵션이 정확하게 작동하도록 수정했습니다.
- "★max 제외" 옵션이 추가되었습니다.
  * "개수된 장비만" 옵션이 사용될 때만 사용할 수 있습니다.
  * 체크된 경우, ★max 가 아닌 개수된 장비만 표시됩니다.

### 💬 임무 탭
- 일부 임무 진행도 추적이 갱신되었습니다.
  * B71 의 내용이 잘못되어 있던 점을 수정했습니다.

### 💬 번역
- 일부 퀘스트 번역이 추가되었습니다.
  * 정예 「제4항공전대」를 재편성하라!
  * 신편 「제4수뢰전대」를 편성하라!
  * 전탐 기술의 사격 장치로의 활용
  * 민생 산업에 대한 협력
  * 정예 「제4항공전대」, 발묘하라!
- 위 임무들의 진행도 추적은 추가되지 않았습니다.