### PR TITLE
v4.2.10 rev23

### DIFF
--- a/source/Grabacr07.KanColleViewer.Controls/Controls/ColorIndicator.cs
+++ b/source/Grabacr07.KanColleViewer.Controls/Controls/ColorIndicator.cs
@@ -72,7 +72,10 @@ namespace Grabacr07.KanColleViewer.Controls
 			else if (percentage <= 0.75) color = Color.FromRgb(240, 240, 0);
 
 			// 0.75 より大きいとき、「小破未満」
-			else color = Color.FromRgb(64, 200, 32);
+			else if (percentage < 1.0) color = Color.FromRgb(64, 200, 32);
+
+			// 1 (100%)
+			else color = Color.FromRgb(40, 160, 240);
 
 			this.Foreground = new SolidColorBrush(color);
 		}

--- a/source/Grabacr07.KanColleViewer.Controls/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer.Controls/Properties/AssemblyInfo.cs
@@ -20,5 +20,5 @@ using System.Windows.Markup;
 [assembly: XmlnsDefinition("http://schemes.grabacr.net/winfx/2015/kancolleviewer/converters", "Grabacr07.KanColleViewer.Converters")]
 [assembly: XmlnsDefinition("http://schemes.grabacr.net/winfx/2015/kancolleviewer/interactivity", "Grabacr07.KanColleViewer.Interactivity")]
 
-[assembly: AssemblyVersion("1.3.6")]
-[assembly: AssemblyInformationalVersion("1.3.6")]
+[assembly: AssemblyVersion("1.3.7")]
+[assembly: AssemblyInformationalVersion("1.3.7")]

--- a/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Windows;
 
@@ -15,4 +15,4 @@ using System.Windows;
 	ResourceDictionaryLocation.None,
 	ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("4.2.10.22")]
+[assembly: AssemblyVersion("4.2.10.23")]

--- a/source/Grabacr07.KanColleViewer/ViewModels/Catalogs/CalculatorViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/Catalogs/CalculatorViewModel.cs
@@ -15,7 +15,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 	public class CalculatorViewModel : WindowViewModel
 	{
 		/// <summary>
-		/// Completely experience table from 1 to 155. Each line = 20 levels
+		/// Completely experience table from 1 to 165. Each line = 20 levels
 		/// </summary>
 		public static int[] ExpTable = new int[] { 0, 0, 100, 300, 600, 1000, 1500, 2100, 2800, 3600, 4500, 5500, 6600, 7800, 9100, 10500, 12000, 13600, 15300, 17100, 19000,
 			21000, 23100, 25300, 27600, 30000, 32500, 35100, 37800, 40600, 43500, 46500, 49600, 52800, 56100, 59500, 63000, 66600, 70300, 74100, 78000,
@@ -24,7 +24,8 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 			397000, 411500, 426500, 442000, 458000, 474500, 491500, 509000, 527000, 545500, 564500, 584500, 606500, 631500, 661500, 701500, 761500, 851500, 1000000, 1000000,
 			1010000, 1011000, 1013000, 1016000, 1020000, 1025000, 1031000, 1038000, 1046000, 1055000, 1065000, 1077000, 1091000, 1107000, 1125000, 1145000, 1168000, 1194000, 1223000, 1255000,
 			1290000, 1329000, 1372000, 1419000, 1470000, 1525000, 1584000, 1647000, 1714000, 1785000, 1860000, 1940000, 2025000, 2115000, 2210000, 2310000, 2415000, 2525000, 2640000, 2760000,
-			2887000, 3021000, 3162000, 3310000, 3465000, 3628000, 3799000, 3978000, 4165000, 4360000, 4564000, 4777000, 4999000, 5230000, 5470000 };
+			2887000, 3021000, 3162000, 3310000, 3465000, 3628000, 3799000, 3978000, 4165000, 4360000, 4564000, 4777000, 4999000, 5230000, 5470000, 5720000, 5780000, 5860000, 5970000, 6120000,
+			6320000, 6580000, 6910000, 7320000, 7820000 };
 
 		/// <summary>
 		/// Sea exp table. Cannot be used properly in xaml without dumb workarounds.
@@ -136,7 +137,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 					if (value != null)
 					{
 						this.CurrentLevel = this.CurrentShip.Level;
-						this.TargetLevel = Math.Min(this.CurrentShip.Level + 1, 155);
+						this.TargetLevel = Math.Min(this.CurrentShip.Level + 1, 165);
 						if (this.CurrentShip.Info.NextRemodelingLevel.HasValue)
 						{
 							if (this.CurrentShip.Info.NextRemodelingLevel.Value > this.CurrentLevel)
@@ -161,11 +162,11 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 			get { return this._CurrentLevel; }
 			set
 			{
-				if (this._CurrentLevel != value && value >= 1 && value <= 155)
+				if (this._CurrentLevel != value && value >= 1 && value <= 165)
 				{
 					this._CurrentLevel = value;
 					this.CurrentExp = ExpTable[value];
-					this.TargetLevel = Math.Max(this.TargetLevel, Math.Min(value + 1, 155));
+					this.TargetLevel = Math.Max(this.TargetLevel, Math.Min(value + 1, 165));
 					this.RaisePropertyChanged();
 					this.UpdateCalculator();
 				}
@@ -180,7 +181,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 			get { return this._TargetLevel; }
 			set
 			{
-				if (this._TargetLevel != value && value >= 1 && value <= 155)
+				if (this._TargetLevel != value && value >= 1 && value <= 165)
 				{
 					this._TargetLevel = value;
 					this.TargetExp = ExpTable[value];

--- a/source/Grabacr07.KanColleViewer/ViewModels/Catalogs/ShipCatalogFilter.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/Catalogs/ShipCatalogFilter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -81,7 +81,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 			: base(updateAction)
 		{
 			this._MinLevel = "2";
-			this._MaxLevel = "155";
+			this._MaxLevel = "165";
 		}
 
 		public override bool Predicate(Ship ship)

--- a/source/Grabacr07.KanColleViewer/Views/Catalogs/Calculator.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Catalogs/Calculator.xaml
@@ -42,7 +42,7 @@
 			ObjectType="{x:Type linq:Enumerable}" MethodName="Range">
 			<ObjectDataProvider.MethodParameters>
 				<sys:Int32>1</sys:Int32>
-				<sys:Int32>155</sys:Int32>
+				<sys:Int32>165</sys:Int32>
 			</ObjectDataProvider.MethodParameters>
 		</ObjectDataProvider>
 

--- a/source/Grabacr07.KanColleViewer/Views/Catalogs/DictionaryWindow.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Catalogs/DictionaryWindow.xaml
@@ -41,7 +41,7 @@
 								ObjectType="{x:Type linq:Enumerable}" MethodName="Range">
 				<ObjectDataProvider.MethodParameters>
 					<sys:Int32>1</sys:Int32>
-					<sys:Int32>155</sys:Int32>
+					<sys:Int32>165</sys:Int32>
 				</ObjectDataProvider.MethodParameters>
 			</ObjectDataProvider>
 

--- a/source/Grabacr07.KanColleViewer/Views/Catalogs/ShipCatalogWindow.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Catalogs/ShipCatalogWindow.xaml
@@ -1,4 +1,4 @@
-<metro:MetroWindow x:Class="Grabacr07.KanColleViewer.Views.Catalogs.ShipCatalogWindow"
+﻿<metro:MetroWindow x:Class="Grabacr07.KanColleViewer.Views.Catalogs.ShipCatalogWindow"
 				   x:Name="GlowMetroWindow"
 				   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 				   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -280,9 +280,9 @@
 											</metro:PromptTextBox>
 										</WrapPanel>
 										<WrapPanel Margin="0,3,0,0">
-											<metro2:CallMethodButton Margin="0,0,5,0" Content="모두" MethodName="SetLevelRange" MethodParameter="1-155"/>
+											<metro2:CallMethodButton Margin="0,0,5,0" Content="모두" MethodName="SetLevelRange" MethodParameter="1-165"/>
 											<metro2:CallMethodButton Margin="0,0,5,0" Content="Lv. 1" MethodName="SetLevelRange" MethodParameter="1-1"/>
-											<metro2:CallMethodButton Margin="0,0,5,0" Content="Lv. 2 이상" MethodName="SetLevelRange" MethodParameter="2-155"/>
+											<metro2:CallMethodButton Margin="0,0,5,0" Content="Lv. 2 이상" MethodName="SetLevelRange" MethodParameter="2-165"/>
 										</WrapPanel>
 									</StackPanel>
 								</Grid>

--- a/source/Grabacr07.KanColleWrapper/Models/Experience.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/Experience.cs
@@ -308,6 +308,16 @@ namespace Grabacr07.KanColleWrapper.Models
 			{ 153, new Experience(153, 222000, 4999000) },
 			{ 154, new Experience(154, 231000, 5230000) },
 			{ 155, new Experience(155, 240000, 5470000) },
+			{ 156, new Experience(156, 250000, 5720000) },
+			{ 157, new Experience(157, 60000,  5780000) },
+			{ 158, new Experience(158, 80000,  5860000) },
+			{ 159, new Experience(159, 110000, 5970000) },
+			{ 160, new Experience(160, 150000, 6120000) },
+			{ 161, new Experience(161, 200000, 6320000) },
+			{ 162, new Experience(162, 260000, 6580000) },
+			{ 163, new Experience(163, 330000, 6910000) },
+			{ 164, new Experience(164, 410000, 7320000) },
+			{ 165, new Experience(165, 500000, 7820000) },
 		};
 
 		#endregion

--- a/source/Grabacr07.KanColleWrapper/Models/Ship.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/Ship.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Grabacr07.KanColleWrapper.Internal;
@@ -128,7 +128,7 @@ namespace Grabacr07.KanColleWrapper.Models
 		/// <summary>
 		/// この艦娘が最大Lvになるために必要な経験値を取得します。
 		/// </summary>
-		public int ExpForLevelMax => Experience.GetShipExpForSpecifiedLevel(this.Exp, 155);
+		public int ExpForLevelMax => Experience.GetShipExpForSpecifiedLevel(this.Exp, 165);
 
 		/// <summary>
 		/// ExSlot 이 존재하는지 여부

--- a/source/Grabacr07.KanColleWrapper/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleWrapper/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("KanColleWrapper")]
@@ -10,5 +10,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("8C42F9E0-E2C9-4741-8F98-653A4D275798")]
 
-[assembly: AssemblyVersion("1.7.11")]
-[assembly: AssemblyInformationalVersion("1.7.11")]
+[assembly: AssemblyVersion("1.7.12")]
+[assembly: AssemblyInformationalVersion("1.7.12")]


### PR DESCRIPTION
### ↯ 다운로드
- GitHub [다운로드](https://github.com/CirnoV/KanColleViewer/releases/download/v4.2.10r23/KanColleViewer-KR.4.2.10.r23.zip)
- MEGA [다운로드](https://mega.nz/#!O0JBWRZD!1GD7DBJ0PS9e1QIr4JQZNE1edx4yzRKotOhS1j8_61A)

### 🔗 외부 링크
- VirusTotal [검사 결과](https://virustotal.com/ko/file/59b879ee3235368504af9ed4696f39c631b94015e66ac8c902e6e775195cc4d2/analysis/1501654831/)
- OpenDB Project Website ([http://swaytwig.com/opendb/](http://swaytwig.com/opendb/))
- 업데이트 페이지 [http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html](http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html)

질문 및 건의사항은 [wolfgangkurzdev@gmail.com](mailto:wolfgangkurzdev@gmail.com) 으로 메일 부탁드립니다.
뷰어 사용중 오류가 발생하는 경우, error.log 혹은 battleinfo_error.log 를 첨부하여 메일로 제보해주시면 해결에 도움이 됩니다.

뷰어를 완전히 삭제하신 후 재설치를 해보시는 것도 방법이 될 수 있습니다.
뷰어의 각종 로그, 함대 프리셋, 전과 데이터 등을 백업하시려면, **뷰어 폴더 내의 csv 파일들과 Record 폴더를 백업**하면 됩니다.

```diff
- 장비목록을 열 때 프로그램이 종료되면, 뷰어 폴더의 KanColleWrapper.dll 을 삭제하시기 바랍니다.
- (lib 폴더 내부에 있는 파일은 삭제하지 마세요)
```

----
### 💬 공통
- 체력, 보급 상황 등의 상태가 100% 일 때, 막대의 색상이 푸른색으로 표시되게 변경했습니다.
- 칸무스 레벨이 최대치인 165까지로의 변경에 대해 대응하였습니다.

### 💬 번역
- 일부 함선의 번역이 추가되었습니다.
  * 후미즈키改2