### PR TITLE
v4.2.10 rev26

### DIFF
--- a/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
@@ -15,4 +15,4 @@ using System.Windows;
 	ResourceDictionaryLocation.None,
 	ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("4.2.10.25")]
+[assembly: AssemblyVersion("4.2.10.26")]


### PR DESCRIPTION
### ↯ 다운로드
- GitHub [다운로드](https://github.com/CirnoV/KanColleViewer/releases/download/v4.2.10r26/KanColleViewer-KR.4.2.10.r26.zip)
- MEGA [다운로드](https://mega.nz/#!zs41WCDC!6FAUgBk47v_mBYWv4YJXc4SCCv8figk46Jh5MzqGy1w)

### 🔗 외부 링크
- VirusTotal [검사 결과](https://virustotal.com/ko/file/acaa46b845d9a4ca916e980bd245425a6434da76fc6295dbe66f8750f55946a8/analysis/1507453046/)
- OpenDB Project Website ([http://swaytwig.com/opendb/](http://swaytwig.com/opendb/))
- 업데이트 페이지 [http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html](http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html)

질문 및 건의사항은 [wolfgangkurzdev@gmail.com](mailto:wolfgangkurzdev@gmail.com) 으로 메일 부탁드립니다.
뷰어 사용중 오류가 발생하는 경우, error.log 혹은 battleinfo_error.log 를 첨부하여 메일로 제보해주시면 해결에 도움이 됩니다.

뷰어를 완전히 삭제하신 후 재설치를 해보시는 것도 방법이 될 수 있습니다.
뷰어의 각종 로그, 함대 프리셋, 전과 데이터 등을 백업하시려면, **뷰어 폴더 내의 csv 파일들과 Record 폴더를 백업**하면 됩니다.

```diff
- 갑자기 혹은 장비목록을 열 때 프로그램이 종료되면, 뷰어 폴더의 KanColleWrapper.dll 을 삭제하시기 바랍니다.
- (lib 폴더 내부에 있는 파일은 삭제하지 마세요)
- 파일이 없거나 삭제 후에도 동일한 증상이 나타난다면 메일로 문의 바랍니다.
```

----
### 💬 공통
- **야간공격기**의 아이콘이 추가되었습니다. **야간전투기**와 동일합니다.

### 💬 OpenDB Plugin
- 서버의 디스크가 손상되는 피해가 있어 모든 데이터가 날아갔습니다. (백업 없음)
- 재구축 하면서 API 의 Endpoint 를 교체했습니다.
- 실험적 통계인 **원정 통계**를 삭제했습니다.

### 💬 BattleInfoPlugin
- 기믹 표시의 텍스트를 수정했습니다.
  * "기믹이 발동되었습니다." -> "기믹 발동됨"
- 이벤트 맵에서의 맵 확장(새 길이 생기는 등) 이 있는 경우의 표시가 추가되었습니다.
  * "맵 확장됨"

### 💬 번역
- 일부 장비의 번역이 추가되었습니다.
  * TBF
  * TBM-3D
  * 야간작전항공요원
  * 야간작전항공요원+숙련갑판원
  * Type124 ASDIC
  * Type144/147 ASDIC
  * GF/DF+Type144/147 ASDIC
- 일부 함선의 번역이 추가되었습니다.
  * 새러토가 Mk.II
  * 새러토가 Mk.II Mod.2
- 일부 임무의 번역이 추가되었습니다.
  * 강행수송함대, 발묘!
  * 해상통상항로의 경계를 엄격히 하라!
  * 정예 제 22구축대 출격하라!
  * 기함 유라, 발묘!
  * 정예 임무부대를 편성하라!
  * 수송 부대의 숙련도 향상에 노력하라!
  * 정예 대형 항공모함, 발묘!
  * 야전형 함상전투기 개발
  * 개장 공격형 경항모, 전선 전개하라!
  * 정예 즈이운 부대 편성
  * 야간작전 항공모함, 전선에 출격하라!
  * 신편 제 7전대를 편성하라!
  * 정예 수전 부대의 증세
  * 신편 제 7전대, 출격하라!
