### PR TITLE
v4.2.10 rev27

### DIFF
--- a/source/Grabacr07.KanColleViewer.QuestTracker/KanColleViewer.QuestTracker.csproj
+++ b/source/Grabacr07.KanColleViewer.QuestTracker/KanColleViewer.QuestTracker.csproj
@@ -33,6 +33,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Nekoxy, Version=1.5.3.21, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nekoxy.1.5.3.21\lib\net45\Nekoxy.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -41,10 +44,6 @@
     <Reference Include="System.Xml" />
     <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Nekoxy, Version=1.5.2.20, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nekoxy.1.5.2.20\lib\net45\Nekoxy.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -58,6 +57,9 @@
     <Reference Include="System.Reactive.Linq, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="TrotiNet, Version=0.8.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nekoxy.1.5.3.21\lib\net45\TrotiNet.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -360,6 +362,9 @@
   </ItemGroup>
   <ItemGroup>
     <Resource Include="Models\QuestInfo.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/source/Grabacr07.KanColleViewer.QuestTracker/packages.config
+++ b/source/Grabacr07.KanColleViewer.QuestTracker/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="log4net" version="2.0.3" targetFramework="net45" />
-  <package id="Nekoxy" version="1.5.2.20" targetFramework="net46" />
+  <package id="Nekoxy" version="1.5.3.21" targetFramework="net46" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Linq" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Main" version="2.2.5" targetFramework="net45" />

--- a/source/Grabacr07.KanColleViewer/App.config
+++ b/source/Grabacr07.KanColleViewer/App.config
@@ -4,7 +4,7 @@
         <sectionGroup name="applicationSettings" type="System.Configuration.ApplicationSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
             <section name="Grabacr07.KanColleViewer.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
         </sectionGroup>
-        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
+        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
             <section name="Grabacr07.KanColleViewer.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
         </sectionGroup>
     </configSections>

--- a/source/Grabacr07.KanColleViewer/KanColleViewer.csproj
+++ b/source/Grabacr07.KanColleViewer/KanColleViewer.csproj
@@ -101,9 +101,8 @@
     <Reference Include="Microsoft.mshtml, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
-    <Reference Include="Nekoxy, Version=1.5.2.20, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nekoxy.1.5.2.20\lib\net45\Nekoxy.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Nekoxy, Version=1.5.3.21, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nekoxy.1.5.3.21\lib\net45\Nekoxy.dll</HintPath>
     </Reference>
     <Reference Include="StatefulModel">
       <HintPath>..\packages\StatefulModel.0.6.0\lib\portable-net45+win+wp80+MonoAndroid10+xamarinios10+MonoTouch10\StatefulModel.dll</HintPath>
@@ -149,8 +148,7 @@
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>
     <Reference Include="TrotiNet, Version=0.8.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nekoxy.1.5.2.20\lib\net45\TrotiNet.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Nekoxy.1.5.3.21\lib\net45\TrotiNet.dll</HintPath>
     </Reference>
     <Reference Include="Vannatech.CoreAudio">
       <HintPath>..\..\assemblies\Vannatech.CoreAudio.dll</HintPath>

--- a/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
@@ -15,4 +15,4 @@ using System.Windows;
 	ResourceDictionaryLocation.None,
 	ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("4.2.10.26")]
+[assembly: AssemblyVersion("4.2.10.27")]

--- a/source/Grabacr07.KanColleViewer/ViewModels/Catalogs/SlotItemEquipTypeViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/Catalogs/SlotItemEquipTypeViewModel.cs
@@ -122,6 +122,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 				{ SlotItemIconType.SeaplaneFighter, "수상전투기" },
 				{ SlotItemIconType.LandBasedFighter, "육군전투기" },
 				{ SlotItemIconType.NightFighter, "야간전투기" },
+				{ SlotItemIconType.NightAttacker, "야간공격기" },
 			};
 			IconAliasNamable = new Dictionary<SlotItemIconType, SlotItemIconType>
 			{

--- a/source/Grabacr07.KanColleViewer/Views/Catalogs/SlotItemCatalogWindow.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Catalogs/SlotItemCatalogWindow.xaml
@@ -185,6 +185,7 @@
 													<s:Int32>39</s:Int32>
 													<s:Int32>40</s:Int32>
 													<s:Int32>45</s:Int32>
+													<s:Int32>46</s:Int32>
 												</x:Array>
 											</metro2:CallMethodButton.MethodParameter>
 										</metro2:CallMethodButton>

--- a/source/Grabacr07.KanColleViewer/packages.config
+++ b/source/Grabacr07.KanColleViewer/packages.config
@@ -3,7 +3,7 @@
   <package id="LivetCask" version="1.3.1.0" targetFramework="net45" />
   <package id="LivetExtensions" version="1.1.0.0" targetFramework="net45" />
   <package id="log4net" version="2.0.3" targetFramework="net45" />
-  <package id="Nekoxy" version="1.5.2.20" targetFramework="net46" />
+  <package id="Nekoxy" version="1.5.3.21" targetFramework="net46" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Linq" version="2.2.5" targetFramework="net45" />

--- a/source/Grabacr07.KanColleWrapper/KanColleWrapper.csproj
+++ b/source/Grabacr07.KanColleWrapper/KanColleWrapper.csproj
@@ -64,9 +64,8 @@
       <HintPath>..\packages\LivetCask.1.3.1.0\lib\net45\Microsoft.Expression.Interactions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Nekoxy, Version=1.5.2.20, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nekoxy.1.5.2.20\lib\net45\Nekoxy.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Nekoxy, Version=1.5.3.21, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nekoxy.1.5.3.21\lib\net45\Nekoxy.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -105,8 +104,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="TrotiNet, Version=0.8.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nekoxy.1.5.2.20\lib\net45\TrotiNet.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Nekoxy.1.5.3.21\lib\net45\TrotiNet.dll</HintPath>
     </Reference>
     <Reference Include="WindowsBase" />
   </ItemGroup>

--- a/source/Grabacr07.KanColleWrapper/packages.config
+++ b/source/Grabacr07.KanColleWrapper/packages.config
@@ -6,7 +6,7 @@
   <package id="ElementalAnnotations-Dualism" version="1.0.1" targetFramework="net45" />
   <package id="ElementalAnnotations-Light" version="1.0.1" targetFramework="net45" />
   <package id="log4net" version="2.0.3" targetFramework="net45" />
-  <package id="Nekoxy" version="1.5.2.20" targetFramework="net46" />
+  <package id="Nekoxy" version="1.5.3.21" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net46" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />


### PR DESCRIPTION
### ↯ 다운로드
- GitHub [다운로드](https://github.com/CirnoV/KanColleViewer/releases/download/v4.2.10r27/KanColleViewer-KR.4.2.10.r27.zip)
- MEGA [다운로드](https://mega.nz/#!78IHXKSZ!2ZgMhxd3WWsq-WP2FJFtFVK1vRqTtZhb2EOwJFmJOOs)

### 🔗 외부 링크
- VirusTotal [검사 결과](https://virustotal.com/ko/file/af0ac8434460e25ca6016b841ddbbbb1b94d18c30c2090d497ead75bb2ac4746/analysis/)
- OpenDB Project Website ([http://swaytwig.com/opendb/](http://swaytwig.com/opendb/))
- 업데이트 페이지 [http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html](http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html)

질문 및 건의사항은 [wolfgangkurzdev@gmail.com](mailto:wolfgangkurzdev@gmail.com) 으로 메일 부탁드립니다.
뷰어 사용중 오류가 발생하는 경우, error.log 혹은 battleinfo_error.log 를 첨부하여 메일로 제보해주시면 해결에 도움이 됩니다.

뷰어를 완전히 삭제하신 후 재설치를 해보시는 것도 방법이 될 수 있습니다.
뷰어의 각종 로그, 함대 프리셋, 전과 데이터 등을 백업하시려면, **뷰어 폴더 내의 csv 파일들과 Record 폴더를 백업**하면 됩니다.

```diff
- 갑자기 혹은 장비목록을 열 때 프로그램이 종료되면, 뷰어 폴더의 KanColleWrapper.dll 을 삭제하시기 바랍니다.
- (lib 폴더 내부에 있는 파일은 삭제하지 마세요)
- 파일이 없거나 삭제 후에도 동일한 증상이 나타난다면 메일로 문의 바랍니다.
```

----
### 💬 공통
- 접속 문제를 해결했습니다.
- Nekoxy 라이브러리 버전을 올렸습니다.

### 💬 장비 목록 창
- **야간공격기**가 표시되지 않던 문제를 수정했습니다.
