### PR TITLE
v4.2.11 rev3

### DIFF
--- a/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
@@ -15,4 +15,4 @@ using System.Windows;
 	ResourceDictionaryLocation.None,
 	ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("4.2.11.2")]
+[assembly: AssemblyVersion("4.2.11.3")]

--- a/source/Grabacr07.KanColleViewer/ViewModels/Contents/Fleets/FleetViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/Contents/Fleets/FleetViewModel.cs
@@ -501,30 +501,6 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents.Fleets
 
 			if (KanColleClient.Current.Translations.GetExpeditionData("DrumCount", Mission) != string.Empty) Chk = this.DrumCount(Mission, fleet);
 
-			if (fleet.Length < Convert.ToInt32(NeedShipRaw[0])) Chk = false;
-
-			if (FLv != string.Empty && FLv != "-")
-			{
-				int lv = Convert.ToInt32(FLv);
-				if (fleet[0] != null && fleet[0].Level < lv) Chk = false;
-				this.FlagLv = ("Lv" + lv);
-				this.vFlag = Visibility.Visible;
-			}
-			if (TotalLevel != string.Empty)
-			{
-				int totallv = Convert.ToInt32(TotalLevel);
-				if (fleet.Sum(x => x.Level) < totallv) Chk = false;
-				this.TotalLv = ("Lv" + totallv);
-				this.vTotal = Visibility.Visible;
-			}
-			if (FlagShipType != string.Empty)
-			{
-				int flagship = Convert.ToInt32(FlagShipType);
-				if (fleet[0].Info.ShipType.Id != flagship) Chk = false;
-				this.FlagType = (KanColleClient.Current.Translations.GetTranslation("", TranslationType.ShipTypes, false, null, flagship));
-				this.vFlagType = Visibility.Visible;
-			}
-
 			var ExpeditionTable = new Dictionary<int, int>();
 			var strb = new StringBuilder();
 			if (NeedShipRaw[0] == string.Empty)
@@ -556,6 +532,30 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents.Fleets
 					this.ShipTypeString = strb.ToString();
 					if (this.ShipTypeString.Length > 0) this.vNeed = Visibility.Visible;
 				}
+			}
+
+			if (fleet.Length < Convert.ToInt32(NeedShipRaw[0])) Chk = false;
+
+			if (FLv != string.Empty && FLv != "-")
+			{
+				int lv = Convert.ToInt32(FLv);
+				if (fleet[0] != null && fleet[0].Level < lv) Chk = false;
+				this.FlagLv = ("Lv" + lv);
+				this.vFlag = Visibility.Visible;
+			}
+			if (TotalLevel != string.Empty)
+			{
+				int totallv = Convert.ToInt32(TotalLevel);
+				if (fleet.Sum(x => x.Level) < totallv) Chk = false;
+				this.TotalLv = ("Lv" + totallv);
+				this.vTotal = Visibility.Visible;
+			}
+			if (FlagShipType != string.Empty)
+			{
+				int flagship = Convert.ToInt32(FlagShipType);
+				if (fleet[0].Info.ShipType.Id != flagship) Chk = false;
+				this.FlagType = (KanColleClient.Current.Translations.GetTranslation("", TranslationType.ShipTypes, false, null, flagship));
+				this.vFlagType = Visibility.Visible;
 			}
 
 			var bChk = false;


### PR DESCRIPTION
### ↯ 다운로드
- GitHub [다운로드](https://github.com/CirnoV/KanColleViewer/releases/download/v4.2.11r3/KanColleViewer-KR.4.2.11.r3.zip)
- MEGA [다운로드](https://mega.nz/#!y54C2ZBZ!6p0bC4uKB6S6MqAcXD7wJwHkfrgq7-1io7ArsX0djA4)

### 🔗 외부 링크
- VirusTotal [검사 결과](https://virustotal.com/ko/file/2e37a2bca3d93f88a9fe4773864fa21b3a4ae24b8547a2fde6c0a70fc563deed/analysis/1510945745/)
- OpenDB Project Website ([http://swaytwig.com/opendb/](http://swaytwig.com/opendb/))
- 업데이트 페이지 [http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html](http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html)

질문 및 건의사항은 [wolfgangkurzdev@gmail.com](mailto:wolfgangkurzdev@gmail.com) 으로 메일 부탁드립니다.
뷰어 사용중 오류가 발생하는 경우, error.log 혹은 battleinfo_error.log 를 첨부하여 메일로 제보해주시면 해결에 도움이 됩니다.

뷰어를 완전히 삭제하신 후 재설치를 해보시는 것도 방법이 될 수 있습니다.
뷰어의 각종 로그, 함대 프리셋, 전과 데이터 등을 백업하시려면, **뷰어 폴더 내의 csv 파일들과 Record 폴더를 백업**하면 됩니다.

```diff
- 갑자기 혹은 장비목록을 열 때 프로그램이 종료되면, 뷰어 폴더의 KanColleWrapper.dll 을 삭제하시기 바랍니다.
- (lib 폴더 내부에 있는 파일은 삭제하지 마세요)
- 파일이 없거나 삭제 후에도 동일한 증상이 나타난다면 메일로 문의 바랍니다.
```

----
### 💬 공통
- 일부 원정 상태에서 뷰어가 종료되는 문제를 수정했습니다.
