### PR TITLE
v4.2.11 rev7

### DIFF
--- a/source/Grabacr07.KanColleViewer.QuestTracker/Models/Tracker/B/B/B5.cs
+++ b/source/Grabacr07.KanColleViewer.QuestTracker/Models/Tracker/B/B/B5.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -33,7 +33,7 @@ namespace Grabacr07.KanColleViewer.QuestTracker.Models.Tracker
 			{
 				if (!IsTracking) return;
 
-				if ("敵主力部隊" == args.EnemyName) // 1-2 보스전
+				if ("敵主力艦隊" == args.EnemyName) // 1-2 보스전
 				{
 					if ("SAB".Contains(args.Rank)) // 보스전 승리
 						count = count.Add(1).Max(max_count);

--- a/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
@@ -15,4 +15,4 @@ using System.Windows;
 	ResourceDictionaryLocation.None,
 	ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("4.2.11.6")]
+[assembly: AssemblyVersion("4.2.11.7")]

--- a/source/Grabacr07.KanColleWrapper/Models/Raw/kcsapi_data_enemyinfo.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/Raw/kcsapi_data_enemyinfo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -9,7 +9,7 @@ namespace Grabacr07.KanColleWrapper.Models.Raw
     public class kcsapi_data_enemyinfo
     {
         public string api_user_name { get; set; }
-        public int api_level { get; set; }
+        public string api_level { get; set; }
 
         public string api_deck_name { get; set; }
         public string api_rank { get; set; }


### PR DESCRIPTION
### ↯ 다운로드
- GitHub [다운로드](https://github.com/CirnoV/KanColleViewer/releases/download/v4.2.11r7/KanColleViewer-KR.4.2.11.r7.zip)
- MEGA [다운로드](https://mega.nz/#!asQhQDYR!cka9bWLDYnip_l6HkM2sWX9kpwgK7bh6B8MUmjhxgPg)

### 🔗 외부 링크
- VirusTotal [검사 결과](https://virustotal.com/ko/file/f349767a488b002367024d34eb9f4efd6247df26f32593ac7a9aebb42376c3fe/analysis/1514480711/)
- OpenDB Project Website ([http://swaytwig.com/opendb/](http://swaytwig.com/opendb/))
- 업데이트 페이지 [http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html](http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html)

질문 및 건의사항은 [wolfgangkurzdev@gmail.com](mailto:wolfgangkurzdev@gmail.com) 으로 메일 부탁드립니다.
뷰어 사용중 오류가 발생하는 경우, error.log 혹은 battleinfo_error.log 를 첨부하여 메일로 제보해주시면 해결에 도움이 됩니다.

뷰어를 완전히 삭제하신 후 재설치를 해보시는 것도 방법이 될 수 있습니다.
뷰어의 각종 로그, 함대 프리셋, 전과 데이터 등을 백업하시려면, **뷰어 폴더 내의 csv 파일들과 Record 폴더를 백업**하면 됩니다.

```diff
- 갑자기 혹은 장비목록을 열 때 프로그램이 종료되면, 뷰어 폴더의 KanColleWrapper.dll 을 삭제하시기 바랍니다.
- (lib 폴더 내부에 있는 파일은 삭제하지 마세요)
- 파일이 없거나 삭제 후에도 동일한 증상이 나타난다면 메일로 문의 바랍니다.
```

----
### 💬 공통
- 전투시 드롭 로그가 작성되지 않던 문제를 수정했습니다.

### 💬 임무 탭
- rev5, rev6 업데이트 이후 임무 추적기가 작동하지 않던 문제를 수정했습니다.
- B5 임무가 추적되지 않던 문제를 수정했습니다.

### 💬 번역
- 일부 장비의 번역이 추가되었습니다.
  * 12.7cm 연장포D형 改2
  * 북방미채(+북방장비)
  * 심해 14inch 해협연장포
  * 심해대복어뢰
- 일부 함선의 번역이 추가되었습니다.
  * 나가나미改2
- 일부 함선의 번역이 수정되었습니다.
  * 전함불서희
  * 전함불서희-괴
- 일부 임무의 번역이 추가되었습니다.
  * 「유격부대」 함대사령부 창설
  * 「제8 구축대」, 남서로!
  * 「첩 1호 작전」 병참 보급선을 확보하라!
  * 야전형 함상 전투기의 성능 강화
  * 신편 「제1 전대」, 발묘하라!
  * 북방해역 전투초계를 실시하라!
  * 신편 「수뢰전대」를 포함한 함대를 재편성하라!
  * 신형 포공 병기, 전력화 시작!
  * 보급선의 안전을 확보하라!
- 일부 원정의 정보가 추가되었습니다.
  * [B2] 적 정박지 강습 반격작전
- 일부 원정의 설명이 수정되었습니다.
  * [A1] 병참 강화 임무
  * [A2] 해협 경비 행동
  * [A3] 장시간 대잠 경계
  * [B1] 남서방면 항공정찰 작전
