### PR TITLE
v4.2.11 rev9

### DIFF
--- a/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
@@ -15,4 +15,4 @@ using System.Windows;
 	ResourceDictionaryLocation.None,
 	ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("4.2.11.8")]
+[assembly: AssemblyVersion("4.2.11.9")]

--- a/source/Grabacr07.KanColleViewer/Views/Catalogs/DictionaryWindow.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Catalogs/DictionaryWindow.xaml
@@ -1,4 +1,4 @@
-﻿<metro:MetroWindow x:Class="Grabacr07.KanColleViewer.Views.Catalogs.DictionaryWindow"
+<metro:MetroWindow x:Class="Grabacr07.KanColleViewer.Views.Catalogs.DictionaryWindow"
 				   x:Name="GlowMetroWindow"
 				   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 				   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -1338,7 +1338,8 @@
 															<Grid.ColumnDefinitions>
 																<ColumnDefinition Width="Auto" />
 																<ColumnDefinition Width="Auto" />
-																<ColumnDefinition Width="*" />
+																<ColumnDefinition Width="*" SharedSizeGroup="NameGroup" />
+																<ColumnDefinition Width="Auto" />
 															</Grid.ColumnDefinitions>
 
 															<TextBlock Margin="0,0,6,0"
@@ -1432,6 +1433,23 @@
 																		<Style.Triggers>
 																			<DataTrigger Binding="{Binding Available, Mode=OneWay}" Value="False">
 																				<Setter Property="TextAlignment" Value="Center" />
+																			</DataTrigger>
+																		</Style.Triggers>
+																	</Style>
+																</TextBlock.Style>
+															</TextBlock>
+
+															<TextBlock Grid.Column="3"
+																	   Margin="4,0,0,0"
+																	   VerticalAlignment="Center"
+																	   FontSize="10"
+																	   Foreground="#FF45A9A5"
+																	   Text="{Binding Star, Mode=OneWay, StringFormat={}★+{0}}">
+																<TextBlock.Style>
+																	<Style BasedOn="{StaticResource EmphaticTextStyleKey}" TargetType="{x:Type TextBlock}">
+																		<Style.Triggers>
+																			<DataTrigger Binding="{Binding Star}" Value="0">
+																				<Setter Property="Visibility" Value="Collapsed" />
 																			</DataTrigger>
 																		</Style.Triggers>
 																	</Style>
@@ -1865,6 +1883,7 @@
 													<ColumnDefinition Width="20" />
 													<ColumnDefinition Width="Auto" SharedSizeGroup="IdType" />
 													<ColumnDefinition Width="*" />
+													<ColumnDefinition Width="Auto" SharedSizeGroup="Star" />
 												</Grid.ColumnDefinitions>
 												<Grid.RowDefinitions>
 													<RowDefinition Height="Auto" />


### PR DESCRIPTION
### ↯ 다운로드
- GitHub [다운로드](https://github.com/CirnoV/KanColleViewer/releases/download/v4.2.11r9/KanColleViewer-KR.4.2.11.r9.zip)
- MEGA [다운로드](https://mega.nz/#!zh4mRaLD!qxe1zPJEo3hI1zLILAzuUHh2qBKuniNJck7xIegTpvI)

### 🔗 외부 링크
- VirusTotal [검사 결과](https://virustotal.com/ko/file/9ca2ce46bc668cd8672846b06ae1cecb990aeee67d8b7849008e6df9de696e15/analysis/1516811098/)
- OpenDB Project Website ([http://swaytwig.com/opendb/](http://swaytwig.com/opendb/))
- 업데이트 페이지 [http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html](http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html)

질문 및 건의사항은 [wolfgangkurzdev@gmail.com](mailto:wolfgangkurzdev@gmail.com) 으로 메일 부탁드립니다.
뷰어 사용중 오류가 발생하는 경우, error.log 혹은 battleinfo_error.log 를 첨부하여 메일로 제보해주시면 해결에 도움이 됩니다.

뷰어를 완전히 삭제하신 후 재설치를 해보시는 것도 방법이 될 수 있습니다.
뷰어의 각종 로그, 함대 프리셋, 전과 데이터 등을 백업하시려면, **뷰어 폴더 내의 csv 파일들과 Record 폴더를 백업**하면 됩니다.

```diff
- 갑자기 혹은 장비목록을 열 때 프로그램이 종료되면, 뷰어 폴더의 KanColleWrapper.dll 을 삭제하시기 바랍니다.
- (lib 폴더 내부에 있는 파일은 삭제하지 마세요)
- 파일이 없거나 삭제 후에도 동일한 증상이 나타난다면 메일로 문의 바랍니다.
```

----
### 💬 사전 창
- 사전을 열면 프로그램이 종료되던 문제를 수정했습니다.
- 획득/개장 시 개수된 장비를 가져오는 경우, 해당 장비의 개수치도 표시하도록 추가하였습니다.

### 💬 BattleInfoPlugin
- 플러그인을 복사하지 않아서 구버전 플러그인 그대로여서 수정점이 적용되지 않았습니다. 죄송합니다.
- 함선 툴팁에서 명중 수치가 표시되지 않던 문제를 수정했습니다.

### 💬 번역
- 일부 함선의 번역이 추가되었습니다.
  * 타마改2