### PR TITLE
v4.2.11 rev10

### DIFF
--- a/source/Grabacr07.KanColleViewer.QuestTracker/Models/Model/BattleCalcaultor.cs
+++ b/source/Grabacr07.KanColleViewer.QuestTracker/Models/Model/BattleCalcaultor.cs
@@ -994,6 +994,7 @@ namespace Grabacr07.KanColleViewer.QuestTracker.Models.Model
 					for (int j = 0; j < target.Length; j++)
 					{
 						var target_idx = target[j];
+						if (target_idx < 0) continue;
 
 						// 아군이 공격 (적군이 맞음)
 						if (eflag == 0)
@@ -1042,6 +1043,8 @@ namespace Grabacr07.KanColleViewer.QuestTracker.Models.Model
 					{
 						int target_idx = target[j];
 						int damage_value = (int)target_dmg[j];
+
+						if (target_idx < 0) continue;
 
 						if (combinedType == CombinedType.Default)
 						{
@@ -1168,6 +1171,8 @@ namespace Grabacr07.KanColleViewer.QuestTracker.Models.Model
 						int target_idx = target[j];
 						int damage_value = (int)target_dmg[j];
 
+						if (target_idx < 0) continue;
+
 						if (combinedPhase == EachCombinedPhase.FirstPhase)
 						{
 							// 아군이 공격 (적군이 맞음)
@@ -1269,6 +1274,7 @@ namespace Grabacr07.KanColleViewer.QuestTracker.Models.Model
 					for (int j = 0; j < target.Length; j++)
 					{
 						var target_idx = target[j];
+						if (target_idx < 0) continue;
 
 						// 아군이 공격 (적군이 맞음)
 						if (eflag == 0)

--- a/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
@@ -15,4 +15,4 @@ using System.Windows;
 	ResourceDictionaryLocation.None,
 	ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("4.2.11.9")]
+[assembly: AssemblyVersion("4.2.11.10")]

--- a/source/Grabacr07.KanColleViewer/Views/Catalogs/ShipCatalogWindow.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Catalogs/ShipCatalogWindow.xaml
@@ -1,4 +1,4 @@
-﻿<metro:MetroWindow x:Class="Grabacr07.KanColleViewer.Views.Catalogs.ShipCatalogWindow"
+<metro:MetroWindow x:Class="Grabacr07.KanColleViewer.Views.Catalogs.ShipCatalogWindow"
 				   x:Name="GlowMetroWindow"
 				   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 				   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -815,7 +815,8 @@
 										<Grid x:Name="LvBorder"
 											  Margin="-2,0">
 											<Grid.ColumnDefinitions>
-												<ColumnDefinition Width="*" />
+												<ColumnDefinition Width="Auto" />
+												<ColumnDefinition Width="Auto" />
 												<ColumnDefinition Width="Auto" />
 												<ColumnDefinition Width="Auto" />
 											</Grid.ColumnDefinitions>
@@ -846,6 +847,14 @@
 												   Width="18"
 												   Height="18"
 												   Visibility="{Binding Ship.NeedCatapult, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+											<Image x:Name="ReportImage"
+												   Source="http://wolfgangkurz.github.io/KanColleAssets/useitem/action_report.png"
+												   Grid.Column="3"
+												   Margin="2,0"
+												   VerticalAlignment="Center"
+												   Width="18"
+												   Height="18"
+												   Visibility="{Binding Ship.NeedReport, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
 										</Grid>
 										<DataTemplate.Triggers>
 											<DataTrigger Binding="{Binding Ship.RemodelLevel}" Value="0">

--- a/source/Grabacr07.KanColleViewer/Views/StartContent.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/StartContent.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="Grabacr07.KanColleViewer.Views.StartContent"
+<UserControl x:Class="Grabacr07.KanColleViewer.Views.StartContent"
 			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 			 xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
@@ -201,25 +201,31 @@
 							</metro2:HyperlinkEx>
 						</TextBlock>
 						<TextBlock FontFamily="Segoe UI">
-								<Run Text="Developer" />
-								<Run Text="(Korean)"
-									 FontSize="10" />
-								<Run Text=":" />
-								<metro2:HyperlinkEx Uri="http://kaster.egloos.com">
-									<Run Text="Kaster" />
-								</metro2:HyperlinkEx>
-								<metro2:HyperlinkEx Uri="http://swaytwig.com">
-									<Run Text="WolfgangKurz" />
-								</metro2:HyperlinkEx>
-								<metro2:HyperlinkEx Uri="http://kcvkr.tistory.com">
-									<Run Text="Cirno V" />
-								</metro2:HyperlinkEx>
-                                    <metro2:HyperlinkEx Uri="https://github.com/DaeWha">
-									<Run Text="DaeWha" />
-								</metro2:HyperlinkEx>
-							<metro2:HyperlinkEx Uri="https://github.com/FreyYa">
-								<Run Text="FreyYa" />
-							</metro2:HyperlinkEx>
+							<Run Text="Developer" />
+							<Run Text="(Korean)"
+								 FontSize="10" />
+							<Run Text=":" />
+							<InlineUIContainer BaselineAlignment="Top">
+								<TextBlock>
+									<metro2:HyperlinkEx Uri="http://kaster.egloos.com">
+										<Run Text="Kaster" />
+									</metro2:HyperlinkEx>
+									<metro2:HyperlinkEx Uri="http://swaytwig.com">
+										<Run Text="WolfgangKurz" />
+									</metro2:HyperlinkEx>
+									<LineBreak />
+
+									<metro2:HyperlinkEx Uri="http://kcvkr.tistory.com">
+										<Run Text="Cirno V" />
+									</metro2:HyperlinkEx>
+										<metro2:HyperlinkEx Uri="https://github.com/DaeWha">
+										<Run Text="DaeWha" />
+									</metro2:HyperlinkEx>
+									<metro2:HyperlinkEx Uri="https://github.com/FreyYa">
+										<Run Text="FreyYa" />
+									</metro2:HyperlinkEx>
+								</TextBlock>
+							</InlineUIContainer>
 						</TextBlock>
 						<TextBlock FontFamily="Segoe UI">
 								<Run Text="Localization" />

--- a/source/Grabacr07.KanColleWrapper/Models/AirSuperiorityPotential.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/AirSuperiorityPotential.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -121,10 +121,24 @@ namespace Grabacr07.KanColleWrapper.Models
 		{
 			public override AirSuperiorityCalculationOptions Options => AirSuperiorityCalculationOptions.Attacker;
 
+			protected override double GetAirSuperiority(SlotItem slotItem, int onslot)
+			{
+				switch (slotItem.Info.Id)
+				{
+					case 60:
+					case 154:
+					case 219:
+						// 装備改修による対空値加算 (★ x 0.25)
+						return (slotItem.Info.AA + slotItem.Level * 0.25) * Math.Sqrt(onslot);
+					default:
+						return base.GetAirSuperiority(slotItem, onslot);
+				}
+			}
+
 			protected override double GetProficiencyBonus(SlotItem slotItem, AirSuperiorityCalculationOptions options)
 			{
 				var proficiency = slotItem.GetProficiency();
-				return Math.Sqrt(proficiency.GetInternalValue(options) / 10.0);
+				return Math.Sqrt(proficiency.GetInternalValue(options) / 10.0) + proficiency.BomberBonus;
 			}
 		}
 
@@ -159,13 +173,15 @@ namespace Grabacr07.KanColleWrapper.Models
 
 			public int FighterBonus { get; }
 			public int SeaplaneBomberBonus { get; }
+			public int BomberBonus { get; }
 
-			public Proficiency(int internalMin, int internalMax, int fighterBonus, int seaplaneBomberBonus)
+			public Proficiency(int internalMin, int internalMax, int fighterBonus, int seaplaneBomberBonus, int bomberBonus)
 			{
 				this.internalMinValue = internalMin;
 				this.internalMaxValue = internalMax;
 				this.FighterBonus = fighterBonus;
 				this.SeaplaneBomberBonus = seaplaneBomberBonus;
+				this.BomberBonus = bomberBonus;
 			}
 
 			/// <summary>
@@ -181,14 +197,14 @@ namespace Grabacr07.KanColleWrapper.Models
 
 		private static readonly Dictionary<int, Proficiency> proficiencies = new Dictionary<int, Proficiency>()
 		{
-			{ 0, new Proficiency(0, 9, 0, 0) },
-			{ 1, new Proficiency(10, 24, 0, 0) },
-			{ 2, new Proficiency(25, 39, 2, 1) },
-			{ 3, new Proficiency(40, 54, 5, 1) },
-			{ 4, new Proficiency(55, 69, 9, 1) },
-			{ 5, new Proficiency(70, 84, 14, 3) },
-			{ 6, new Proficiency(85, 99, 14, 3) },
-			{ 7, new Proficiency(100, 120, 22, 6) },
+			{ 0, new Proficiency(0, 9, 0, 0, 0) },
+			{ 1, new Proficiency(10, 24, 1, 1, 1) },
+			{ 2, new Proficiency(25, 39, 3, 2, 1) },
+			{ 3, new Proficiency(40, 54, 7, 3, 2) },
+			{ 4, new Proficiency(55, 69, 11, 3, 2) },
+			{ 5, new Proficiency(70, 84, 16, 6, 2) },
+			{ 6, new Proficiency(85, 99, 16, 5, 2) },
+			{ 7, new Proficiency(100, 120, 25, 9, 3) },
 		};
 
 		private static Proficiency GetProficiency(this SlotItem slotItem) => proficiencies[Math.Max(Math.Min(slotItem.Proficiency, 7), 0)];

--- a/source/Grabacr07.KanColleWrapper/Models/Raw/kcsapi_mst_shipupgrade.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/Raw/kcsapi_mst_shipupgrade.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -19,6 +19,7 @@ namespace Grabacr07.KanColleWrapper.Models.Raw
 
 		public int api_drawing_count { get; set; }
 		public int api_catapult_count { get; set; }
+		public int api_report_count { get; set; }
 
 		public int api_sortno { get; set; }
 	}

--- a/source/Grabacr07.KanColleWrapper/Models/Ship.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/Ship.cs
@@ -74,6 +74,15 @@ namespace Grabacr07.KanColleWrapper.Models
 					?.api_catapult_count > 0;
 			}
 		}
+		public bool NeedReport
+		{
+			get
+			{
+				return KanColleClient.Current.Master.RawData.api_mst_shipupgrade
+					.FirstOrDefault(x => x.api_current_ship_id == this.Info.Id)
+					?.api_report_count > 0;
+			}
+		}
 
 		public string LvName => "[Lv." + this.Level + "]  " + this.Info.Name;
 		public string RepairTimeString

--- a/source/Grabacr07.KanColleWrapper/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleWrapper/Properties/AssemblyInfo.cs
@@ -10,5 +10,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("8C42F9E0-E2C9-4741-8F98-653A4D275798")]
 
-[assembly: AssemblyVersion("1.7.15")]
-[assembly: AssemblyInformationalVersion("1.7.15")]
+[assembly: AssemblyVersion("1.7.16")]
+[assembly: AssemblyInformationalVersion("1.7.16")]


### PR DESCRIPTION
### ↯ 다운로드
- GitHub [다운로드](https://github.com/CirnoV/KanColleViewer/releases/download/v4.2.11r10/KanColleViewer-KR.4.2.11.r10.zip)
- MEGA [다운로드](https://mega.nz/#!X0IBSCAT!k7_1xbmUHAq82LR8web-kPM9xYDSeZi-2jQcaZwUIMw)

### 🔗 외부 링크
- VirusTotal [검사 결과](https://virustotal.com/ko/file/9feba1e0e167deea96878706aec1f3d0f1656d11250138b4e4af38b8319902a8/analysis/1518250258/)
- OpenDB Project Website ([http://swaytwig.com/opendb/](http://swaytwig.com/opendb/))
- 업데이트 페이지 [http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html](http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html)

질문 및 건의사항은 [wolfgangkurzdev@gmail.com](mailto:wolfgangkurzdev@gmail.com) 으로 메일 부탁드립니다.
뷰어 사용중 오류가 발생하는 경우, error.log 혹은 battleinfo_error.log 를 첨부하여 메일로 제보해주시면 해결에 도움이 됩니다.

뷰어를 완전히 삭제하신 후 재설치를 해보시는 것도 방법이 될 수 있습니다.
뷰어의 각종 로그, 함대 프리셋, 전과 데이터 등을 백업하시려면, **뷰어 폴더 내의 csv 파일들과 Record 폴더를 백업**하면 됩니다.

```diff
- 갑자기 혹은 장비목록을 열 때 프로그램이 종료되면, 뷰어 폴더의 KanColleWrapper.dll 을 삭제하시기 바랍니다.
- (lib 폴더 내부에 있는 파일은 삭제하지 마세요)
- 파일이 없거나 삭제 후에도 동일한 증상이 나타난다면 메일로 문의 바랍니다.
```

----
### 💬 공통
- 함재기 제공치의 개수 및 숙련도 보너스 수치 문제를 수정했습니다.
  * 전투기 제공권 보너스 수치 오류를 수정했습니다. (최대 22 -> 최대 25)
  * 폭격기 및 공격기에 제공치 보너스가 붙지 않던 것을 수정했습니다.
  * 폭격기 중 전투폭격기(폭전)은 개수시 최대 +2.5 의 대공치를 갖도록 수정했습니다.

### 💬 함선목록 창
- 개장시 전투상보가 필요한 칸무스의 경우, 전투상보 아이콘이 표시되도록 추가했습니다.

### 💬 BattleInfoPlugin
- 야전시 아군 또는 적군이 컷인을 사용하는 경우, 플러그인 및 임무 추적기가 먹통이 되던 문제를 수정했습니다.
- 적군이 다메콘을 사용하는 문제를 수정했습니다. (연습전 포함)

### 💬 번역
- 일부 함선의 번역이 추가되었습니다.
  * 루이지 토렐리改
  * 무사시改2 (예비 추가)
- 일부 장비의 번역이 추가되었습니다.
  * 사이운(정4)
  * 12cm 30연장 분진포改2
  * 46cm 삼연장포改
  * FM-2
- 일부 장비의 번역이 수정되었습니다.
  * HF/DF + Type144/147 ASDIC
- 일부 임무의 번역이 추가되었습니다.
  * 정예 「제21구축대」, 발묘 준비!
  * 소나무 수송 작전, 계속 실시하라!
  * 신편 「4항전」 전력 출격!
  * 장비 개발력 정비
  * 대공 병기의 확충
  * 공창 환경의 정비
  * 장비 개발력의 집중 정비
  * 계전 지원 능력의 정비
  * 급양함 이라코 지원
  * 정예 「제21구축대」, 맹훈련!
  * 주력 함상전투기의 갱신
