### PR TITLE
v4.2.11 rev11

### DIFF
--- a/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
@@ -15,4 +15,4 @@ using System.Windows;
 	ResourceDictionaryLocation.None,
 	ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("4.2.11.10")]
+[assembly: AssemblyVersion("4.2.11.11")]

--- a/source/Grabacr07.KanColleWrapper/Models/AirSuperiorityPotential.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/AirSuperiorityPotential.cs
@@ -138,7 +138,7 @@ namespace Grabacr07.KanColleWrapper.Models
 			protected override double GetProficiencyBonus(SlotItem slotItem, AirSuperiorityCalculationOptions options)
 			{
 				var proficiency = slotItem.GetProficiency();
-				return Math.Sqrt(proficiency.GetInternalValue(options) / 10.0) + proficiency.BomberBonus;
+				return Math.Sqrt(proficiency.GetInternalValue(options) / 10.0);
 			}
 		}
 
@@ -173,15 +173,13 @@ namespace Grabacr07.KanColleWrapper.Models
 
 			public int FighterBonus { get; }
 			public int SeaplaneBomberBonus { get; }
-			public int BomberBonus { get; }
 
-			public Proficiency(int internalMin, int internalMax, int fighterBonus, int seaplaneBomberBonus, int bomberBonus)
+			public Proficiency(int internalMin, int internalMax, int fighterBonus, int seaplaneBomberBonus)
 			{
 				this.internalMinValue = internalMin;
 				this.internalMaxValue = internalMax;
 				this.FighterBonus = fighterBonus;
 				this.SeaplaneBomberBonus = seaplaneBomberBonus;
-				this.BomberBonus = bomberBonus;
 			}
 
 			/// <summary>
@@ -197,14 +195,14 @@ namespace Grabacr07.KanColleWrapper.Models
 
 		private static readonly Dictionary<int, Proficiency> proficiencies = new Dictionary<int, Proficiency>()
 		{
-			{ 0, new Proficiency(0, 9, 0, 0, 0) },
-			{ 1, new Proficiency(10, 24, 1, 1, 1) },
-			{ 2, new Proficiency(25, 39, 3, 2, 1) },
-			{ 3, new Proficiency(40, 54, 7, 3, 2) },
-			{ 4, new Proficiency(55, 69, 11, 3, 2) },
-			{ 5, new Proficiency(70, 84, 16, 6, 2) },
-			{ 6, new Proficiency(85, 99, 16, 5, 2) },
-			{ 7, new Proficiency(100, 120, 25, 9, 3) },
+			{ 0, new Proficiency(0, 9, 0, 0) },
+			{ 1, new Proficiency(10, 24, 0, 0) },
+			{ 2, new Proficiency(25, 39, 2, 1) },
+			{ 3, new Proficiency(40, 54, 5, 1) },
+			{ 4, new Proficiency(55, 69, 9, 1) },
+			{ 5, new Proficiency(70, 84, 14, 3) },
+			{ 6, new Proficiency(85, 99, 14, 3) },
+			{ 7, new Proficiency(100, 120, 22, 6) },
 		};
 
 		private static Proficiency GetProficiency(this SlotItem slotItem) => proficiencies[Math.Max(Math.Min(slotItem.Proficiency, 7), 0)];

--- a/source/Grabacr07.KanColleWrapper/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleWrapper/Properties/AssemblyInfo.cs
@@ -10,5 +10,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("8C42F9E0-E2C9-4741-8F98-653A4D275798")]
 
-[assembly: AssemblyVersion("1.7.16")]
-[assembly: AssemblyInformationalVersion("1.7.16")]
+[assembly: AssemblyVersion("1.7.17")]
+[assembly: AssemblyInformationalVersion("1.7.17")]


### PR DESCRIPTION
### ↯ 다운로드
- GitHub [다운로드](https://github.com/CirnoV/KanColleViewer/releases/download/v4.2.11r11/KanColleViewer-KR.4.2.11.r11.zip)
- MEGA [다운로드](https://mega.nz/#!OxRXXaCD!iAf0pj0hGmKETJsWP5-R8uQ00d__iwX2DgNNXOEDku8)

### 🔗 외부 링크
- VirusTotal [검사 결과](https://virustotal.com/ko/file/490efb6fd102e845b2baba5f71c489e2734e5956d56b40e1aeb96eafc6675504/analysis/1518340807/)
- OpenDB Project Website ([http://swaytwig.com/opendb/](http://swaytwig.com/opendb/))
- 업데이트 페이지 [http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html](http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html)

질문 및 건의사항은 [wolfgangkurzdev@gmail.com](mailto:wolfgangkurzdev@gmail.com) 으로 메일 부탁드립니다.
뷰어 사용중 오류가 발생하는 경우, error.log 혹은 battleinfo_error.log 를 첨부하여 메일로 제보해주시면 해결에 도움이 됩니다.

뷰어를 완전히 삭제하신 후 재설치를 해보시는 것도 방법이 될 수 있습니다.
뷰어의 각종 로그, 함대 프리셋, 전과 데이터 등을 백업하시려면, **뷰어 폴더 내의 csv 파일들과 Record 폴더를 백업**하면 됩니다.

```diff
- 갑자기 혹은 장비목록을 열 때 프로그램이 종료되면, 뷰어 폴더의 KanColleWrapper.dll 을 삭제하시기 바랍니다.
- (lib 폴더 내부에 있는 파일은 삭제하지 마세요)
- 파일이 없거나 삭제 후에도 동일한 증상이 나타난다면 메일로 문의 바랍니다.
```

----
### 💬 공통
- 함재기 제공치의 개수 및 숙련도 보너스 수치 문제를 수정했습니다.
  * rev10 업데이트 이후로 숙련도 보너스가 최대 +3 까지 오차가 발생하는 것을 수정했습니다.

### 💬 BattleInfoPlugin
- 노드의 특이사항을 표시할 수 있는 옵션이 추가되었습니다. (기본 ON)
- 특이사항 표시는 다음과 같은 규칙을 따릅니다.

표시 | 설명
------ | ------
(없음) | 특이사항이 없습니다.
잠수함 | 모든 패턴에서 대다수의 적 함선이 잠수함입니다.
잠수함? | 일부 패턴에서 대다수의 적 함선이 잠수함입니다.

- 위 특이사항 외에는 아직 추가되지 않았습니다.
