### PR TITLE
v4.2.11 rev12

### DIFF
--- a/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
@@ -15,4 +15,4 @@ using System.Windows;
 	ResourceDictionaryLocation.None,
 	ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("4.2.11.11")]
+[assembly: AssemblyVersion("4.2.11.12")]

--- a/source/Grabacr07.KanColleViewer/Views/Contents/Fleets.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Contents/Fleets.xaml
@@ -507,34 +507,34 @@
 													<DataTrigger Binding="{Binding FitValueString}" Value="">
 														<Setter Property="Visibility" Value="Collapsed" />
 													</DataTrigger>
-													<DataTrigger Binding="{Binding FitValue}" Value="-5">
+													<DataTrigger Binding="{Binding FitValueColor}" Value="-5">
 														<Setter Property="Foreground" Value="#ffa50a0a" />
 													</DataTrigger>
-													<DataTrigger Binding="{Binding FitValue}" Value="-4">
+													<DataTrigger Binding="{Binding FitValueColor}" Value="-4">
 														<Setter Property="Foreground" Value="#ffa50a0a" />
 													</DataTrigger>
-													<DataTrigger Binding="{Binding FitValue}" Value="-3">
+													<DataTrigger Binding="{Binding FitValueColor}" Value="-3">
 														<Setter Property="Foreground" Value="#ffa50a0a" />
 													</DataTrigger>
-													<DataTrigger Binding="{Binding FitValue}" Value="-2">
+													<DataTrigger Binding="{Binding FitValueColor}" Value="-2">
 														<Setter Property="Foreground" Value="#ffa50a0a" />
 													</DataTrigger>
-													<DataTrigger Binding="{Binding FitValue}" Value="-1">
+													<DataTrigger Binding="{Binding FitValueColor}" Value="-1">
 														<Setter Property="Foreground" Value="#ffa50a0a" />
 													</DataTrigger>
-													<DataTrigger Binding="{Binding FitValue}" Value="1">
+													<DataTrigger Binding="{Binding FitValueColor}" Value="1">
 														<Setter Property="Foreground" Value="#ff62b5f5" />
 													</DataTrigger>
-													<DataTrigger Binding="{Binding FitValue}" Value="2">
+													<DataTrigger Binding="{Binding FitValueColor}" Value="2">
 														<Setter Property="Foreground" Value="#ff62b5f5" />
 													</DataTrigger>
-													<DataTrigger Binding="{Binding FitValue}" Value="3">
+													<DataTrigger Binding="{Binding FitValueColor}" Value="3">
 														<Setter Property="Foreground" Value="#ff62b5f5" />
 													</DataTrigger>
-													<DataTrigger Binding="{Binding FitValue}" Value="4">
+													<DataTrigger Binding="{Binding FitValueColor}" Value="4">
 														<Setter Property="Foreground" Value="#ff62b5f5" />
 													</DataTrigger>
-													<DataTrigger Binding="{Binding FitValue}" Value="5">
+													<DataTrigger Binding="{Binding FitValueColor}" Value="5">
 														<Setter Property="Foreground" Value="#ff62b5f5" />
 													</DataTrigger>
 												</Style.Triggers>
@@ -589,34 +589,34 @@
 										<Setter TargetName="ItemProficiencyBlock" Property="Visibility" Value="Collapsed" />
 									</DataTrigger>
 
-									<DataTrigger Binding="{Binding FitValue}" Value="-5">
+									<DataTrigger Binding="{Binding FitValueColor}" Value="-5">
 										<Setter TargetName="Elements" Property="Background" Value="#52a50a0a" />
 									</DataTrigger>
-									<DataTrigger Binding="{Binding FitValue}" Value="-4">
+									<DataTrigger Binding="{Binding FitValueColor}" Value="-4">
 										<Setter TargetName="Elements" Property="Background" Value="#41a50a0a" />
 									</DataTrigger>
-									<DataTrigger Binding="{Binding FitValue}" Value="-3">
+									<DataTrigger Binding="{Binding FitValueColor}" Value="-3">
 										<Setter TargetName="Elements" Property="Background" Value="#31a50a0a" />
 									</DataTrigger>
-									<DataTrigger Binding="{Binding FitValue}" Value="-2">
+									<DataTrigger Binding="{Binding FitValueColor}" Value="-2">
 										<Setter TargetName="Elements" Property="Background" Value="#21a50a0a" />
 									</DataTrigger>
-									<DataTrigger Binding="{Binding FitValue}" Value="-1">
+									<DataTrigger Binding="{Binding FitValueColor}" Value="-1">
 										<Setter TargetName="Elements" Property="Background" Value="#10a50a0a" />
 									</DataTrigger>
-									<DataTrigger Binding="{Binding FitValue}" Value="1">
+									<DataTrigger Binding="{Binding FitValueColor}" Value="1">
 										<Setter TargetName="Elements" Property="Background" Value="#1057ab7b" />
 									</DataTrigger>
-									<DataTrigger Binding="{Binding FitValue}" Value="2">
+									<DataTrigger Binding="{Binding FitValueColor}" Value="2">
 										<Setter TargetName="Elements" Property="Background" Value="#2157ab7b" />
 									</DataTrigger>
-									<DataTrigger Binding="{Binding FitValue}" Value="3">
+									<DataTrigger Binding="{Binding FitValueColor}" Value="3">
 										<Setter TargetName="Elements" Property="Background" Value="#3157ab7b" />
 									</DataTrigger>
-									<DataTrigger Binding="{Binding FitValue}" Value="4">
+									<DataTrigger Binding="{Binding FitValueColor}" Value="4">
 										<Setter TargetName="Elements" Property="Background" Value="#4157ab7b" />
 									</DataTrigger>
-									<DataTrigger Binding="{Binding FitValue}" Value="5">
+									<DataTrigger Binding="{Binding FitValueColor}" Value="5">
 										<Setter TargetName="Elements" Property="Background" Value="#5257ab7b" />
 									</DataTrigger>
 								</DataTemplate.Triggers>

--- a/source/Grabacr07.KanColleWrapper/Models/Raw/Battle/member_mapinfo.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/Raw/Battle/member_mapinfo.cs
@@ -21,7 +21,7 @@ namespace Grabacr07.KanColleWrapper.Models.Raw
 		public int api_max_maphp { get; set; }
 		public int api_dmg { get; set; }
 		public int api_state { get; set; }
-		public int api_selected_rank { get; set; }
+		public int? api_selected_rank { get; set; }
 		public int api_gauge_type { get; set; }
 	}
 }

--- a/source/Grabacr07.KanColleWrapper/Models/ShipFitClass.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/ShipFitClass.cs
@@ -1193,6 +1193,31 @@ namespace Grabacr07.KanColleWrapper.Models
 						new ShipFitData(245, 0, 0, 0),
 						new ShipFitData(246, 0, 0, 0)
 				}
+			}, {
+				546,
+				new ShipFitData[] {
+					new ShipFitData(7, 0, 0, 0),
+						new ShipFitData(8, 0, 0, 0),
+						new ShipFitData(9, 0, 0, 0),
+						new ShipFitData(76, 0, 0, 0),
+						new ShipFitData(103, 0, 0, 0),
+						new ShipFitData(104, 0, 0, 0),
+						new ShipFitData(105, 0, 0, 0),
+						new ShipFitData(114, 0, 0, 0),
+						new ShipFitData(117, 0, 0, 0),
+						new ShipFitData(128, 0, 0, 0),
+						new ShipFitData(133, 0, 0, 0),
+						new ShipFitData(137, 0, 0, 0),
+						new ShipFitData(161, 0, 0, 0),
+						new ShipFitData(183, 0, 0, 0),
+						new ShipFitData(190, 0, 0, 0),
+						new ShipFitData(192, 0, 0, 0),
+						new ShipFitData(231, 0, 0, 0),
+						new ShipFitData(232, 0, 0, 0),
+						new ShipFitData(236, 0, 0, 0),
+						new ShipFitData(245, 0, 0, 0),
+						new ShipFitData(246, 0, 0, 0)
+				}
 			}
 		};
 		#endregion

--- a/source/Grabacr07.KanColleWrapper/Models/ShipSlot.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/ShipSlot.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -15,6 +15,8 @@ namespace Grabacr07.KanColleWrapper.Models
 		public bool IsAirplane => this.Item.Info.Type.IsNumerable();
 
 		public int FitValue => this.CalculateFit();
+		public int FitValueColor => Math.Min(5, Math.Max(-5, this.FitValue)); // -5 ~ +5
+
 		public string FitValueString
 		{
 			get

--- a/source/Grabacr07.KanColleWrapper/Translations.cs
+++ b/source/Grabacr07.KanColleWrapper/Translations.cs
@@ -1,3 +1,5 @@
+//#define LOG_TRANSLATION
+
 using Grabacr07.KanColleWrapper.Models;
 using Grabacr07.KanColleWrapper.Models.Raw;
 using System;
@@ -293,7 +295,7 @@ namespace Grabacr07.KanColleWrapper
 
 					foreach (XElement el in FoundTranslation)
 					{
-#if DEBUG
+#if DEBUG && LOG_TRANSLATION
 						if (ID >= 0 && el.Element("ID") != null && Convert.ToInt32(el.Element("ID").Value) == ID)
 							Debug.WriteLine(string.Format("Translation: {0,-20} {1,-20} {2}", JPString, el.Element(TRChildElement).Value, ID));
 #endif
@@ -307,7 +309,7 @@ namespace Grabacr07.KanColleWrapper
 					}
 				}
 
-#if DEBUG
+#if DEBUG && LOG_TRANSLATION
 				Debug.WriteLine(string.Format("Can't find Translation: {0,-20} {1}", JPString, ID));
 #endif
 			}


### PR DESCRIPTION
### ↯ 다운로드
- GitHub [다운로드](https://github.com/CirnoV/KanColleViewer/releases/download/v4.2.11r12/KanColleViewer-KR.4.2.11.r12.zip)
- MEGA [다운로드](https://mega.nz/#!615jnIyb!eyBOD17e7IvlTRQHjUGY8fJb8xQ6FojLxh23zo0ypa4)

### 🔗 외부 링크
- VirusTotal [검사 결과](https://virustotal.com/ko/file/b89b8cdaedd5ea74bba2cdd5068da942486df39693d7a73710a04d9a63d30cde/analysis/1518960846/)
- OpenDB Project Website ([http://swaytwig.com/opendb/](http://swaytwig.com/opendb/))
- 업데이트 페이지 [http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html](http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html)

질문 및 건의사항은 [wolfgangkurzdev@gmail.com](mailto:wolfgangkurzdev@gmail.com) 으로 메일 부탁드립니다.
뷰어 사용중 오류가 발생하는 경우, error.log 혹은 battleinfo_error.log 를 첨부하여 메일로 제보해주시면 해결에 도움이 됩니다.

뷰어를 완전히 삭제하신 후 재설치를 해보시는 것도 방법이 될 수 있습니다.
뷰어의 각종 로그, 함대 프리셋, 전과 데이터 등을 백업하시려면, **뷰어 폴더 내의 csv 파일들과 Record 폴더를 백업**하면 됩니다.

```diff
- 갑자기 혹은 장비목록을 열 때 프로그램이 종료되면, 뷰어 폴더의 KanColleWrapper.dll 을 삭제하시기 바랍니다.
- (lib 폴더 내부에 있는 파일은 삭제하지 마세요)
- 파일이 없거나 삭제 후에도 동일한 증상이 나타난다면 메일로 문의 바랍니다.
```

----
### 💬 공통
- 丁 난이도 추가에 대응했습니다.
- 피트 표시의 색상을 -5 아래 및 +5 위에도 표시되도록 수정했습니다.

### 💬 BattleInfoPlugin
- 이벤트 해역이 "E-1" 과 같이 표시되지 않던 점을 수정했습니다.
- 이벤트 해역의 난이도가 표시되지 않던 점을 수정했습니다.
- 1-5 및 1-6의 특이사항을 추가했습니다. (잠수함 노드)

### 💬 번역
- 일부 함선의 번역이 추가되었습니다.
  * 저비스
  * 저비스改
  * 타슈캔트
  * 타슈캔트改
  * 갬비어 베이
  * 갬비어 베이改
  * 인트레피드
  * 인트레피드改
  * 하마나미
  * 하마나미改
  * 히부리
  * 히부리改
  * 다이토
  * 다이토改
  * 호위서수희
  * 호위서수희-괴
- 일부 장비의 번역이 추가되었습니다.
  * 시덴改(343 항공대) 301전투기대
  * 10cm 연장고각포改+증설기총
  * SK 레이더
  * SK&SG 레이더
  * QF 4.7inch포 Mk.XII改
  * 51cm 연장포
  * 130mm B-13연장포
  * 533mm 삼연장어뢰
