### PR TITLE
v4.2.11 rev13

### DIFF
--- a/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
@@ -15,4 +15,4 @@ using System.Windows;
 	ResourceDictionaryLocation.None,
 	ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("4.2.11.12")]
+[assembly: AssemblyVersion("4.2.11.13")]

--- a/source/Grabacr07.KanColleWrapper/Translations.cs
+++ b/source/Grabacr07.KanColleWrapper/Translations.cs
@@ -1,4 +1,4 @@
-//#define LOG_TRANSLATION
+#define LOG_TRANSLATION
 
 using Grabacr07.KanColleWrapper.Models;
 using Grabacr07.KanColleWrapper.Models.Raw;


### PR DESCRIPTION
### ↯ 다운로드
- GitHub [다운로드](https://github.com/CirnoV/KanColleViewer/releases/download/v4.2.11r13/KanColleViewer-KR.4.2.11.r13.zip)
- MEGA [다운로드](https://mega.nz/#!vkx0ySrQ!Gkfoxy-FI1QQvnh_ZiBTJ81Zy5Xs45rPXY7pdLQ5Hrs)

### 🔗 외부 링크
- VirusTotal [검사 결과](https://virustotal.com/ko/file/66502923f1d4a050117816c7e7f5a5c984fe2637729550ea5b9ef758a1a27bcf/analysis/1518964964/)
- OpenDB Project Website ([http://swaytwig.com/opendb/](http://swaytwig.com/opendb/))
- 업데이트 페이지 [http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html](http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html)

질문 및 건의사항은 [wolfgangkurzdev@gmail.com](mailto:wolfgangkurzdev@gmail.com) 으로 메일 부탁드립니다.
뷰어 사용중 오류가 발생하는 경우, error.log 혹은 battleinfo_error.log 를 첨부하여 메일로 제보해주시면 해결에 도움이 됩니다.

뷰어를 완전히 삭제하신 후 재설치를 해보시는 것도 방법이 될 수 있습니다.
뷰어의 각종 로그, 함대 프리셋, 전과 데이터 등을 백업하시려면, **뷰어 폴더 내의 csv 파일들과 Record 폴더를 백업**하면 됩니다.

```diff
- 갑자기 혹은 장비목록을 열 때 프로그램이 종료되면, 뷰어 폴더의 KanColleWrapper.dll 을 삭제하시기 바랍니다.
- (lib 폴더 내부에 있는 파일은 삭제하지 마세요)
- 파일이 없거나 삭제 후에도 동일한 증상이 나타난다면 메일로 문의 바랍니다.
```

----
### 💬 번역
- 번역 파일들이 정상적으로 불러와지지 않고 초기화되는 문제를 수정했습니다.
