### PR TITLE
v4.2.11 rev14

### DIFF
--- a/source/Grabacr07.KanColleViewer.Controls/Themes/Generic.SlotItemIcon.xaml
+++ b/source/Grabacr07.KanColleViewer.Controls/Themes/Generic.SlotItemIcon.xaml
@@ -1036,6 +1036,37 @@
 					</Setter.Value>
 				</Setter>
 			</Trigger>
+			<Trigger Property="Type"
+					 Value="LandBasedAntiSubmarineAttacker">
+				<Setter Property="Template">
+					<Setter.Value>
+						<ControlTemplate TargetType="{x:Type controls:SlotItemIcon}">
+							<Viewbox>
+								<Grid>
+									<Path Data="m16756,14823c-709,985 3399,3945 3945,4249s485,1213 546,1821s-1274,2549 -910,2913s3582,-1396 4006,-1396s-1092,2003 363,3399s4855,-242 5341,0s-1213,3581 -667,4067s3399,-1578 4431,-1882s10744,4430 12566,2670c1400,-1353 -7410,-6180 -7717,-6511s406,-980 225,-1104s-684,537 -1113,514s-602,-400 -742,-623c-1092,-1744 3338,-4051 4552,-4172s3217,1760 3641,1031s-2913,-1760 -3217,-2549s667,-3035 -363,-2974s-485,2549 -1760,2427s-2306,-1638 -3399,-1153s2913,1881 2306,1941s-5524,2549 -8013,2367s-910,-1396 -1396,-1396s-424,910 -910,667s-10622,-5825 -11715,-4308z"
+										  Fill="#FF39B74E"
+										  HorizontalAlignment="Left"
+										  Height="139"
+										  Stretch="Uniform"
+										  VerticalAlignment="Top"
+										  Width="235" />
+									<ed:RegularPolygon PointCount="6"
+													   InnerRadius="1"
+													   Stretch="Fill"
+													   Stroke="Black"
+													   StrokeThickness="2"
+													   Fill="#FF5B71D2"
+													   Width="126"
+													   Height="146"
+													   HorizontalAlignment="Left"
+													   VerticalAlignment="Top"
+													   Margin="91.033,50.606,0,0" />
+								</Grid>
+							</Viewbox>
+						</ControlTemplate>
+					</Setter.Value>
+				</Setter>
+			</Trigger>
 		</Style.Triggers>
 	</Style>
 

--- a/source/Grabacr07.KanColleViewer.QuestTracker/Models/Model/BattleCalcaultor.cs
+++ b/source/Grabacr07.KanColleViewer.QuestTracker/Models/Model/BattleCalcaultor.cs
@@ -790,6 +790,7 @@ namespace Grabacr07.KanColleViewer.QuestTracker.Models.Model
 				?.Index ?? 0;
 
 			this.MVP_Second = this.AliasSecondShips
+				?.Where(x => x != null)
 				?.OrderByDescending(x => x.TotalDealt)
 				?.FirstOrDefault()
 				?.Index ?? 0;

--- a/source/Grabacr07.KanColleViewer.QuestTracker/Models/TrackManager.cs
+++ b/source/Grabacr07.KanColleViewer.QuestTracker/Models/TrackManager.cs
@@ -484,7 +484,7 @@ namespace Grabacr07.KanColleViewer.QuestTracker.Models
 		private void Update(kcsapi_combined_battle_each data, ApiTypes apiType)
 		{
 			// 적, 아군 함대 정보 갱신
-			this.UpdateFleets(data.api_deck_id, data, data.api_formation);
+			this.UpdateFleetsCombinedEnemy(data.api_deck_id, data, data.api_formation);
 
 			// 체력 갱신
 			this.UpdateMaxHP(data.api_f_maxhps, data.api_e_maxhps, data.api_f_maxhps_combined, data.api_e_maxhps_combined);
@@ -544,9 +544,6 @@ namespace Grabacr07.KanColleViewer.QuestTracker.Models
 		}
 		private void Update(kcsapi_combined_battle_midnight_ec data, ApiTypes apiType)
 		{
-			// 적, 아군 함대 정보 갱신
-			this.UpdateFleetsCombinedEnemy(data.api_deck_id, data);
-
 			// 체력 갱신
 			this.UpdateNowHP(data.api_f_nowhps, data.api_e_nowhps, data.api_f_nowhps_combined, data.api_e_nowhps_combined);
 

--- a/source/Grabacr07.KanColleViewer.QuestTracker/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer.QuestTracker/Properties/AssemblyInfo.cs
@@ -10,5 +10,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("039E4D88-DECD-494D-92D2-407C6403A010")]
 
-[assembly: AssemblyVersion("1.1.0")]
-[assembly: AssemblyInformationalVersion("1.1.0")]
+[assembly: AssemblyVersion("1.1.1")]
+[assembly: AssemblyInformationalVersion("1.1.1")]

--- a/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
@@ -15,4 +15,4 @@ using System.Windows;
 	ResourceDictionaryLocation.None,
 	ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("4.2.11.12")]
+[assembly: AssemblyVersion("4.2.11.14")]

--- a/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
@@ -15,4 +15,4 @@ using System.Windows;
 	ResourceDictionaryLocation.None,
 	ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("4.2.11.13")]
+[assembly: AssemblyVersion("4.2.11.14")]

--- a/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
@@ -15,4 +15,4 @@ using System.Windows;
 	ResourceDictionaryLocation.None,
 	ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("4.2.11.11")]
+[assembly: AssemblyVersion("4.2.11.14")]

--- a/source/Grabacr07.KanColleViewer/Views/Contents/Fleets.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Contents/Fleets.xaml
@@ -507,34 +507,34 @@
 													<DataTrigger Binding="{Binding FitValueString}" Value="">
 														<Setter Property="Visibility" Value="Collapsed" />
 													</DataTrigger>
-													<DataTrigger Binding="{Binding FitValue}" Value="-5">
+													<DataTrigger Binding="{Binding FitValueColor}" Value="-5">
 														<Setter Property="Foreground" Value="#ffa50a0a" />
 													</DataTrigger>
-													<DataTrigger Binding="{Binding FitValue}" Value="-4">
+													<DataTrigger Binding="{Binding FitValueColor}" Value="-4">
 														<Setter Property="Foreground" Value="#ffa50a0a" />
 													</DataTrigger>
-													<DataTrigger Binding="{Binding FitValue}" Value="-3">
+													<DataTrigger Binding="{Binding FitValueColor}" Value="-3">
 														<Setter Property="Foreground" Value="#ffa50a0a" />
 													</DataTrigger>
-													<DataTrigger Binding="{Binding FitValue}" Value="-2">
+													<DataTrigger Binding="{Binding FitValueColor}" Value="-2">
 														<Setter Property="Foreground" Value="#ffa50a0a" />
 													</DataTrigger>
-													<DataTrigger Binding="{Binding FitValue}" Value="-1">
+													<DataTrigger Binding="{Binding FitValueColor}" Value="-1">
 														<Setter Property="Foreground" Value="#ffa50a0a" />
 													</DataTrigger>
-													<DataTrigger Binding="{Binding FitValue}" Value="1">
+													<DataTrigger Binding="{Binding FitValueColor}" Value="1">
 														<Setter Property="Foreground" Value="#ff62b5f5" />
 													</DataTrigger>
-													<DataTrigger Binding="{Binding FitValue}" Value="2">
+													<DataTrigger Binding="{Binding FitValueColor}" Value="2">
 														<Setter Property="Foreground" Value="#ff62b5f5" />
 													</DataTrigger>
-													<DataTrigger Binding="{Binding FitValue}" Value="3">
+													<DataTrigger Binding="{Binding FitValueColor}" Value="3">
 														<Setter Property="Foreground" Value="#ff62b5f5" />
 													</DataTrigger>
-													<DataTrigger Binding="{Binding FitValue}" Value="4">
+													<DataTrigger Binding="{Binding FitValueColor}" Value="4">
 														<Setter Property="Foreground" Value="#ff62b5f5" />
 													</DataTrigger>
-													<DataTrigger Binding="{Binding FitValue}" Value="5">
+													<DataTrigger Binding="{Binding FitValueColor}" Value="5">
 														<Setter Property="Foreground" Value="#ff62b5f5" />
 													</DataTrigger>
 												</Style.Triggers>
@@ -589,34 +589,34 @@
 										<Setter TargetName="ItemProficiencyBlock" Property="Visibility" Value="Collapsed" />
 									</DataTrigger>
 
-									<DataTrigger Binding="{Binding FitValue}" Value="-5">
+									<DataTrigger Binding="{Binding FitValueColor}" Value="-5">
 										<Setter TargetName="Elements" Property="Background" Value="#52a50a0a" />
 									</DataTrigger>
-									<DataTrigger Binding="{Binding FitValue}" Value="-4">
+									<DataTrigger Binding="{Binding FitValueColor}" Value="-4">
 										<Setter TargetName="Elements" Property="Background" Value="#41a50a0a" />
 									</DataTrigger>
-									<DataTrigger Binding="{Binding FitValue}" Value="-3">
+									<DataTrigger Binding="{Binding FitValueColor}" Value="-3">
 										<Setter TargetName="Elements" Property="Background" Value="#31a50a0a" />
 									</DataTrigger>
-									<DataTrigger Binding="{Binding FitValue}" Value="-2">
+									<DataTrigger Binding="{Binding FitValueColor}" Value="-2">
 										<Setter TargetName="Elements" Property="Background" Value="#21a50a0a" />
 									</DataTrigger>
-									<DataTrigger Binding="{Binding FitValue}" Value="-1">
+									<DataTrigger Binding="{Binding FitValueColor}" Value="-1">
 										<Setter TargetName="Elements" Property="Background" Value="#10a50a0a" />
 									</DataTrigger>
-									<DataTrigger Binding="{Binding FitValue}" Value="1">
+									<DataTrigger Binding="{Binding FitValueColor}" Value="1">
 										<Setter TargetName="Elements" Property="Background" Value="#1057ab7b" />
 									</DataTrigger>
-									<DataTrigger Binding="{Binding FitValue}" Value="2">
+									<DataTrigger Binding="{Binding FitValueColor}" Value="2">
 										<Setter TargetName="Elements" Property="Background" Value="#2157ab7b" />
 									</DataTrigger>
-									<DataTrigger Binding="{Binding FitValue}" Value="3">
+									<DataTrigger Binding="{Binding FitValueColor}" Value="3">
 										<Setter TargetName="Elements" Property="Background" Value="#3157ab7b" />
 									</DataTrigger>
-									<DataTrigger Binding="{Binding FitValue}" Value="4">
+									<DataTrigger Binding="{Binding FitValueColor}" Value="4">
 										<Setter TargetName="Elements" Property="Background" Value="#4157ab7b" />
 									</DataTrigger>
-									<DataTrigger Binding="{Binding FitValue}" Value="5">
+									<DataTrigger Binding="{Binding FitValueColor}" Value="5">
 										<Setter TargetName="Elements" Property="Background" Value="#5257ab7b" />
 									</DataTrigger>
 								</DataTemplate.Triggers>

--- a/source/Grabacr07.KanColleWrapper/Models/Raw/Battle/member_mapinfo.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/Raw/Battle/member_mapinfo.cs
@@ -21,7 +21,7 @@ namespace Grabacr07.KanColleWrapper.Models.Raw
 		public int api_max_maphp { get; set; }
 		public int api_dmg { get; set; }
 		public int api_state { get; set; }
-		public int api_selected_rank { get; set; }
+		public int? api_selected_rank { get; set; }
 		public int api_gauge_type { get; set; }
 	}
 }

--- a/source/Grabacr07.KanColleWrapper/Models/ShipFitClass.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/ShipFitClass.cs
@@ -1193,6 +1193,31 @@ namespace Grabacr07.KanColleWrapper.Models
 						new ShipFitData(245, 0, 0, 0),
 						new ShipFitData(246, 0, 0, 0)
 				}
+			}, {
+				546,
+				new ShipFitData[] {
+					new ShipFitData(7, 0, 0, 0),
+						new ShipFitData(8, 0, 0, 0),
+						new ShipFitData(9, 0, 0, 0),
+						new ShipFitData(76, 0, 0, 0),
+						new ShipFitData(103, 0, 0, 0),
+						new ShipFitData(104, 0, 0, 0),
+						new ShipFitData(105, 0, 0, 0),
+						new ShipFitData(114, 0, 0, 0),
+						new ShipFitData(117, 0, 0, 0),
+						new ShipFitData(128, 0, 0, 0),
+						new ShipFitData(133, 0, 0, 0),
+						new ShipFitData(137, 0, 0, 0),
+						new ShipFitData(161, 0, 0, 0),
+						new ShipFitData(183, 0, 0, 0),
+						new ShipFitData(190, 0, 0, 0),
+						new ShipFitData(192, 0, 0, 0),
+						new ShipFitData(231, 0, 0, 0),
+						new ShipFitData(232, 0, 0, 0),
+						new ShipFitData(236, 0, 0, 0),
+						new ShipFitData(245, 0, 0, 0),
+						new ShipFitData(246, 0, 0, 0)
+				}
 			}
 		};
 		#endregion

--- a/source/Grabacr07.KanColleWrapper/Models/ShipSlot.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/ShipSlot.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -15,6 +15,8 @@ namespace Grabacr07.KanColleWrapper.Models
 		public bool IsAirplane => this.Item.Info.Type.IsNumerable();
 
 		public int FitValue => this.CalculateFit();
+		public int FitValueColor => Math.Min(5, Math.Max(-5, this.FitValue)); // -5 ~ +5
+
 		public string FitValueString
 		{
 			get

--- a/source/Grabacr07.KanColleWrapper/Models/SlotItemIconType.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/SlotItemIconType.cs
@@ -201,43 +201,48 @@ namespace Grabacr07.KanColleWrapper.Models
 		InterceptorFighter = 38,
 
 		/// <summary>
-		/// 噴式戦闘爆撃機
+		/// 噴式戦闘爆撃機。
 		/// </summary>
 		JetPowerededBomber1 = 39,
 
 		/// <summary>
-		/// 噴式戦闘爆撃機
+		/// 噴式戦闘爆撃機。
 		/// </summary>
 		JetPowerededBomber2 = 40,
 
 		/// <summary>
-		/// 輸送機材
+		/// 輸送機材。
 		/// </summary>
 		TransportEquipment = 41,
 
 		/// <summary>
-		/// 潜水艦装備
+		/// 潜水艦装備。
 		/// </summary>
 		SubmarineEquipment = 42,
 
 		/// <summary>
-		/// 水上戦闘機
+		/// 水上戦闘機。
 		/// </summary>
 		SeaplaneFighter = 43,
 
 		/// <summary>
-		/// 陸軍戦闘機
+		/// 陸軍戦闘機。
 		/// </summary>
 		LandBasedFighter = 44,
 
 		/// <summary>
-		/// 夜間戦闘機
+		/// 夜間戦闘機。
 		/// </summary>
 		NightFighter = 45,
 
 		/// <summary>
-		/// 夜間攻撃機
+		/// 夜間攻撃機。
 		/// </summary>
 		NightAttacker = 46,
+
+		/// <summary>
+		/// 陸上対潜機。
+		/// </summary>
+		LandBasedAntiSubmarineAttacker = 47,
 	}
 }

--- a/source/Grabacr07.KanColleWrapper/Translations.cs
+++ b/source/Grabacr07.KanColleWrapper/Translations.cs
@@ -1,3 +1,5 @@
+#define LOG_TRANSLATION
+
 using Grabacr07.KanColleWrapper.Models;
 using Grabacr07.KanColleWrapper.Models.Raw;
 using System;
@@ -293,7 +295,7 @@ namespace Grabacr07.KanColleWrapper
 
 					foreach (XElement el in FoundTranslation)
 					{
-#if DEBUG
+#if DEBUG && LOG_TRANSLATION
 						if (ID >= 0 && el.Element("ID") != null && Convert.ToInt32(el.Element("ID").Value) == ID)
 							Debug.WriteLine(string.Format("Translation: {0,-20} {1,-20} {2}", JPString, el.Element(TRChildElement).Value, ID));
 #endif
@@ -307,7 +309,7 @@ namespace Grabacr07.KanColleWrapper
 					}
 				}
 
-#if DEBUG
+#if DEBUG && LOG_TRANSLATION
 				Debug.WriteLine(string.Format("Can't find Translation: {0,-20} {1}", JPString, ID));
 #endif
 			}

--- a/source/Grabacr07.KanColleWrapper/Translations.cs
+++ b/source/Grabacr07.KanColleWrapper/Translations.cs
@@ -1,4 +1,4 @@
-//#define LOG_TRANSLATION
+#define LOG_TRANSLATION
 
 using Grabacr07.KanColleWrapper.Models;
 using Grabacr07.KanColleWrapper.Models.Raw;


### PR DESCRIPTION
### ↯ 다운로드
- GitHub [다운로드](https://github.com/CirnoV/KanColleViewer/releases/download/v4.2.11r14/KanColleViewer-KR.4.2.11.r14.zip)
- MEGA [다운로드](https://mega.nz/#!75YyiQJJ!60qaswI0F6jnf0O-pv9e7SmeepTP4E75AzSn5BXg7rM)

### 🔗 외부 링크
- VirusTotal [검사 결과](https://www.virustotal.com/ko/file/812d7f7de9e88f86c6cd8778ade8b556c155d599f19209fbf789887b6c0ac914/analysis/1519236586/)
- OpenDB Project Website ([http://swaytwig.com/opendb/](http://swaytwig.com/opendb/))
- 업데이트 페이지 [http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html](http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html)

질문 및 건의사항은 [wolfgangkurzdev@gmail.com](mailto:wolfgangkurzdev@gmail.com) 으로 메일 부탁드립니다.
뷰어 사용중 오류가 발생하는 경우, error.log 혹은 battleinfo_error.log 를 첨부하여 메일로 제보해주시면 해결에 도움이 됩니다.

뷰어를 완전히 삭제하신 후 재설치를 해보시는 것도 방법이 될 수 있습니다.
뷰어의 각종 로그, 함대 프리셋, 전과 데이터 등을 백업하시려면, **뷰어 폴더 내의 csv 파일들과 Record 폴더를 백업**하면 됩니다.

```diff
- 갑자기 혹은 장비목록을 열 때 프로그램이 종료되면, 뷰어 폴더의 KanColleWrapper.dll 을 삭제하시기 바랍니다.
- (lib 폴더 내부에 있는 파일은 삭제하지 마세요)
- 파일이 없거나 삭제 후에도 동일한 증상이 나타난다면 메일로 문의 바랍니다.
```

----
### 💬 공통
- 육상대잠기 아이콘을 추가했습니다.

### 💬 BattleInfoPlugin
- 작동 이상 문제를 수정했습니다.
  * 아군 연합함대 전투시 전투 예보가 작동하지 않던 문제
  * 아군 연합함대 전투시 받은 피해량 계산이 올바르지 않던 문제
  * 아군 연합함대 공습전 전투시 다메콘이 사용될 경우 랭크 예보가 올바르지 않던 문제
  * 심해 연합함대와 전투시 전투 예보가 작동하지 않던 문제
  * 심해 연합함대와 전투시 항공 공격이 적 호위함대에 계산되지 않던 문제
    * 기지항공대 분식강습 페이즈
    * 기지항공대 페이즈
    * 분식강습 페이즈
    * 항공 페이즈
  * 진형 정보가 없을 경우 "없음" 으로 표시되던 문제
- 공습전의 " - 주간전" 텍스트를 제거했습니다.

### 💬 번역
- 일부 함선의 번역이 추가되었습니다.
  * 즈이호改2
  * 즈이호改2乙
- 일부 장비의 번역이 추가되었습니다.
  * 야간 고양이 심해 함상전투기
  * 야간 심해 함상폭격기
  * 야간 복수 심해 함상공격기
