### PR TITLE
v4.2.11 rev15

### DIFF
--- a/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
@@ -15,4 +15,4 @@ using System.Windows;
 	ResourceDictionaryLocation.None,
 	ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("4.2.11.14")]
+[assembly: AssemblyVersion("4.2.11.15")]

--- a/source/Grabacr07.KanColleViewer/Views/Catalogs/SlotItemCatalogWindow.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Catalogs/SlotItemCatalogWindow.xaml
@@ -272,6 +272,7 @@
 													<s:Int32>37</s:Int32>
 													<s:Int32>38</s:Int32>
 													<s:Int32>44</s:Int32>
+													<s:Int32>47</s:Int32>
 												</x:Array>
 											</metro2:CallMethodButton.MethodParameter>
 										</metro2:CallMethodButton>


### PR DESCRIPTION
### ↯ 다운로드
- GitHub [다운로드](https://github.com/CirnoV/KanColleViewer/releases/download/v4.2.11r15/KanColleViewer-KR.4.2.11.r15.zip)
- MEGA [다운로드](https://mega.nz/#!X55TSazS!sresjqjXcyecAkz56aA3gq6PcTJKsaa1SXArCoSw4PE)

### 🔗 외부 링크
- VirusTotal [검사 결과](https://virustotal.com/ko/file/eb601324c89b25e8afaffcf7f302c73f385fb77c535f19ef7a4478dec00dcb11/analysis/1519238627/)
- OpenDB Project Website ([http://swaytwig.com/opendb/](http://swaytwig.com/opendb/))
- 업데이트 페이지 [http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html](http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html)

질문 및 건의사항은 [wolfgangkurzdev@gmail.com](mailto:wolfgangkurzdev@gmail.com) 으로 메일 부탁드립니다.
뷰어 사용중 오류가 발생하는 경우, error.log 혹은 battleinfo_error.log 를 첨부하여 메일로 제보해주시면 해결에 도움이 됩니다.

뷰어를 완전히 삭제하신 후 재설치를 해보시는 것도 방법이 될 수 있습니다.
뷰어의 각종 로그, 함대 프리셋, 전과 데이터 등을 백업하시려면, **뷰어 폴더 내의 csv 파일들과 Record 폴더를 백업**하면 됩니다.

```diff
- 갑자기 혹은 장비목록을 열 때 프로그램이 종료되면, 뷰어 폴더의 KanColleWrapper.dll 을 삭제하시기 바랍니다.
- (lib 폴더 내부에 있는 파일은 삭제하지 마세요)
- 파일이 없거나 삭제 후에도 동일한 증상이 나타난다면 메일로 문의 바랍니다.
```

----
### 💬 공통
- 육상대잠기 아이콘을 추가했습니다.

### 💬 장비 목록 창
- "기지항공대" 버튼에 "육상대잠기" 연결을 추가했습니다.

### 💬 BattleInfoPlugin
- 작동 이상 문제를 수정했습니다.
  * 아군 연합함대 전투시 전투 예보가 작동하지 않던 문제
  * 아군 연합함대 전투시 받은 피해량 계산이 올바르지 않던 문제
  * 아군 연합함대 공습전 전투시 다메콘이 사용될 경우 랭크 예보가 올바르지 않던 문제
  * 심해 연합함대와 전투시 전투 예보가 작동하지 않던 문제
  * 심해 연합함대와 전투시 항공 공격이 적 호위함대에 계산되지 않던 문제
    * 기지항공대 분식강습 페이즈
    * 기지항공대 페이즈
    * 분식강습 페이즈
    * 항공 페이즈
  * 진형 정보가 없을 경우 "없음" 으로 표시되던 문제
- 공습전의 " - 주간전" 텍스트를 제거했습니다.
- **v4.2.11 rev14 업데이트 이후 표시되지 않던 문제를 수정했습니다.**

### 💬 번역
- 일부 함선의 번역이 추가되었습니다.
  * 즈이호改2
  * 즈이호改2乙
- 일부 장비의 번역이 추가되었습니다.
  * 야간 고양이 심해 함상전투기
  * 야간 심해 함상폭격기
  * 야간 복수 심해 함상공격기
