### PR TITLE
v4.2.11 rev16

### DIFF
--- a/source/Grabacr07.KanColleViewer.QuestTracker/Models/Model/BattleCalcaultor.cs
+++ b/source/Grabacr07.KanColleViewer.QuestTracker/Models/Model/BattleCalcaultor.cs
@@ -552,12 +552,12 @@ namespace Grabacr07.KanColleViewer.QuestTracker.Models.Model
 		/// <summary>
 		/// 아군 연합함대 여부
 		/// </summary>
-		private bool IsCombined => this.AliasSecondShips?.Length > 0;
+		public bool IsCombined => this.AliasSecondShips?.Length > 0;
 
 		/// <summary>
 		/// 적군 연합함대 여부
 		/// </summary>
-		private bool IsEnemyCombined => this.EnemySecondShips?.Length > 0;
+		public bool IsEnemyCombined => this.EnemySecondShips?.Length > 0;
 
 		/// <summary>
 		/// 아군 1함대 MVP
@@ -1336,7 +1336,7 @@ namespace Grabacr07.KanColleViewer.QuestTracker.Models.Model
 				if (idx < 0) continue;
 
 				var _from = (IsEnemyCombined && i >= 6 ? EnemySecondShips[i - 6] : EnemyFirstShips[i]);
-				_from?.Dealt(fydam[i], phase, DamageType.Normal);
+				_from?.Dealt(eydam[i], phase, DamageType.Normal);
 
 				if (IsCombined && idx >= 6)
 					AliasSecondShips[idx - 6]?.Damaged(eydam[i], phase, _from, DamageType.Normal);

--- a/source/Grabacr07.KanColleViewer.QuestTracker/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer.QuestTracker/Properties/AssemblyInfo.cs
@@ -10,5 +10,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("039E4D88-DECD-494D-92D2-407C6403A010")]
 
-[assembly: AssemblyVersion("1.1.1")]
-[assembly: AssemblyInformationalVersion("1.1.1")]
+[assembly: AssemblyVersion("1.1.2")]
+[assembly: AssemblyInformationalVersion("1.1.2")]

--- a/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
@@ -15,4 +15,4 @@ using System.Windows;
 	ResourceDictionaryLocation.None,
 	ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("4.2.11.15")]
+[assembly: AssemblyVersion("4.2.11.16")]

--- a/source/Grabacr07.KanColleViewer/ViewModels/Catalogs/NeedNdockShipCatalogWindowViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/Catalogs/NeedNdockShipCatalogWindowViewModel.cs
@@ -1,4 +1,4 @@
-﻿using Grabacr07.KanColleViewer.Models;
+using Grabacr07.KanColleViewer.Models;
 using Grabacr07.KanColleWrapper;
 using Livet.EventListeners;
 using MetroTrilithon.Mvvm;
@@ -95,7 +95,8 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 					.Select(kvp => kvp.Value)
 					.Where(this.ShipDamagedFilter.Predicate)
 					.Where(x => x.TimeToRepair != TimeSpan.Zero)
-					.Where(x => !x.Situation.HasFlag(KanColleWrapper.Models.ShipSituation.Repair));
+					.Where(x => !x.Situation.HasFlag(KanColleWrapper.Models.ShipSituation.Repair))
+					.ToArray();
 
 				this.Ships = this.SortWorker.Sort(list)
 					.Select((x, i) => new ShipViewModel(i + 1, x, null))

--- a/source/Grabacr07.KanColleViewer/ViewModels/Catalogs/SlotItemEquipTypeViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/Catalogs/SlotItemEquipTypeViewModel.cs
@@ -123,6 +123,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Catalogs
 				{ SlotItemIconType.LandBasedFighter, "육군전투기" },
 				{ SlotItemIconType.NightFighter, "야간전투기" },
 				{ SlotItemIconType.NightAttacker, "야간공격기" },
+				{ SlotItemIconType.LandBasedAntiSubmarineAttacker, "육상대잠기" },
 			};
 			IconAliasNamable = new Dictionary<SlotItemIconType, SlotItemIconType>
 			{

--- a/source/Grabacr07.KanColleViewer/Views/Contents/Fleets.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Contents/Fleets.xaml
@@ -110,6 +110,7 @@
 
 								<TextBlock Grid.Column="0"
 										   Grid.Row="0"
+										   Grid.ColumnSpan="4"
 										   Margin="0,0,0,10">
  									<Run Text="{Binding Ship.Info.Name, Mode=OneWay}" 
 										 Style="{DynamicResource EmphaticTextElementStyleKey}" 

--- a/source/Grabacr07.KanColleViewer/Views/Contents/Fleets.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Contents/Fleets.xaml
@@ -91,13 +91,228 @@
 							 FontSize="22"
 							 Style="{DynamicResource EmphaticTextElementStyleKey}" />
 						<TextBlock.ToolTip>
-							<TextBlock Margin="0,-2,0,0"> 
- 								<Run Text="{Binding Ship.Info.Name, Mode=OneWay}" 
-									 Style="{DynamicResource EmphaticTextElementStyleKey}" 
-									 FontSize="22"/>
-								<Run Text="{Binding Ship.Info.JPName,Mode=OneWay}"
-									 FontSize="15"/>
-							</TextBlock>
+							<Grid Margin="0,-2,0,0">
+								<Grid.ColumnDefinitions>
+									<ColumnDefinition Width="Auto" />
+									<ColumnDefinition Width="Auto" SharedSizeGroup="NameTooltipCol1" />
+									<ColumnDefinition Width="Auto" />
+									<ColumnDefinition Width="Auto" SharedSizeGroup="NameTooltipCol2" />
+								</Grid.ColumnDefinitions>
+								<Grid.RowDefinitions>
+									<RowDefinition Height="Auto" />
+									<RowDefinition Height="Auto" />
+									<RowDefinition Height="Auto" />
+									<RowDefinition Height="Auto" />
+									<RowDefinition Height="Auto" />
+									<RowDefinition Height="Auto" />
+									<RowDefinition Height="Auto" />
+								</Grid.RowDefinitions>
+
+								<TextBlock Grid.Column="0"
+										   Grid.Row="0"
+										   Margin="0,0,0,10">
+ 									<Run Text="{Binding Ship.Info.Name, Mode=OneWay}" 
+										 Style="{DynamicResource EmphaticTextElementStyleKey}" 
+										 FontSize="22"/>
+									<Run Text="{Binding Ship.Info.JPName,Mode=OneWay}"
+										 FontSize="15"/>
+								</TextBlock>
+
+								<TextBlock Grid.Column="0"
+										   Grid.Row="1"
+										   Margin="0,2,5,0"
+										   FontSize="15"
+										   Text="내구" />
+								<TextBlock Grid.Column="1"
+										   Grid.Row="1"
+										   Margin="0,2,5,0"
+										   Style="{DynamicResource EmphaticTextStyleKey}"
+										   FontSize="15"
+										   TextAlignment="Right"
+										   Text="{Binding Ship.HP.Maximum, Mode=OneWay}" />
+								<TextBlock Grid.Column="2"
+										   Grid.Row="1"
+										   Margin="10,2,5,0"
+										   FontSize="15"
+										   Text="화력" />
+								<TextBlock Grid.Column="3"
+										   Grid.Row="1"
+										   Margin="0,2,5,0"
+										   Style="{DynamicResource EmphaticTextStyleKey}"
+										   FontSize="15"
+										   TextAlignment="Right"
+										   Text="{Binding Ship.SumFirepower, Mode=OneWay}" />
+
+								<TextBlock Grid.Column="0"
+										   Grid.Row="2"
+										   Margin="0,2,5,0"
+										   FontSize="15"
+										   Text="장갑" />
+								<TextBlock Grid.Column="1"
+										   Grid.Row="2"
+										   Margin="0,2,5,0"
+										   Style="{DynamicResource EmphaticTextStyleKey}"
+										   FontSize="15"
+										   TextAlignment="Right"
+										   Text="{Binding Ship.SumArmor, Mode=OneWay}" />
+								<TextBlock Grid.Column="2"
+										   Grid.Row="2"
+										   Margin="10,2,5,0"
+										   FontSize="15"
+										   Text="뇌장" />
+								<TextBlock Grid.Column="3"
+										   Grid.Row="2"
+										   Margin="0,2,5,0"
+										   Style="{DynamicResource EmphaticTextStyleKey}"
+										   FontSize="15"
+										   TextAlignment="Right"
+										   Text="{Binding Ship.SumTorpedo, Mode=OneWay}" />
+
+								<TextBlock Grid.Column="0"
+										   Grid.Row="3"
+										   Margin="0,2,5,0"
+										   FontSize="15"
+										   Text="회피" />
+								<TextBlock Grid.Column="1"
+										   Grid.Row="3"
+										   Margin="0,2,5,0"
+										   Style="{DynamicResource EmphaticTextStyleKey}"
+										   FontSize="15"
+										   TextAlignment="Right"
+										   Text="{Binding Ship.SumEvade, Mode=OneWay}" />
+								<TextBlock Grid.Column="2"
+										   Grid.Row="3"
+										   Margin="10,2,5,0"
+										   FontSize="15"
+										   Text="대공" />
+								<TextBlock Grid.Column="3"
+										   Grid.Row="3"
+										   Margin="0,2,5,0"
+										   Style="{DynamicResource EmphaticTextStyleKey}"
+										   FontSize="15"
+										   TextAlignment="Right"
+										   Text="{Binding Ship.SumAA, Mode=OneWay}" />
+
+								<TextBlock Grid.Column="0"
+										   Grid.Row="4"
+										   Margin="0,2,5,0"
+										   FontSize="15"
+										   Text="탑재" />
+								<TextBlock Grid.Column="1"
+										   Grid.Row="4"
+										   Margin="0,2,5,0"
+										   Style="{DynamicResource EmphaticTextStyleKey}"
+										   FontSize="15"
+										   TextAlignment="Right"
+										   Text="{Binding Ship.SumCarry, Mode=OneWay}" />
+								<TextBlock Grid.Column="2"
+										   Grid.Row="4"
+										   Margin="10,2,5,0"
+										   FontSize="15"
+										   Text="대잠" />
+								<TextBlock Grid.Column="3"
+										   Grid.Row="4"
+										   Margin="0,2,5,0"
+										   Style="{DynamicResource EmphaticTextStyleKey}"
+										   FontSize="15"
+										   TextAlignment="Right"
+										   Text="{Binding Ship.SumASW, Mode=OneWay}" />
+
+								<TextBlock Grid.Column="0"
+										   Grid.Row="5"
+										   Margin="0,2,5,0"
+										   FontSize="15"
+										   Text="속력" />
+								<TextBlock Grid.Column="1"
+										   Grid.Row="5"
+										   Margin="0,2,5,0"
+										   Style="{DynamicResource EmphaticTextStyleKey}"
+										   FontSize="15"
+										   TextAlignment="Center">
+									<Run>
+										<Run.Style>
+											<Style TargetType="{x:Type Run}">
+												<Setter Property="Text" Value="???" />
+												<Style.Triggers>
+													<DataTrigger Binding="{Binding Ship.Speed, Mode=OneWay}" Value="Immovable">
+														<Setter Property="Text" Value="기지" />
+													</DataTrigger>
+													<DataTrigger Binding="{Binding Ship.Speed, Mode=OneWay}" Value="Slow">
+														<Setter Property="Text" Value="저속" />
+													</DataTrigger>
+													<DataTrigger Binding="{Binding Ship.Speed, Mode=OneWay}" Value="Fast">
+														<Setter Property="Text" Value="고속" />
+													</DataTrigger>
+													<DataTrigger Binding="{Binding Ship.Speed, Mode=OneWay}" Value="Faster">
+														<Setter Property="Text" Value="고속+" />
+													</DataTrigger>
+													<DataTrigger Binding="{Binding Ship.Speed, Mode=OneWay}" Value="Fatest">
+														<Setter Property="Text" Value="초고속" />
+													</DataTrigger>
+												</Style.Triggers>
+											</Style>
+										</Run.Style>
+									</Run>
+								</TextBlock>
+								<TextBlock Grid.Column="2"
+										   Grid.Row="5"
+										   Margin="10,2,5,0"
+										   FontSize="15"
+										   Text="색적" />
+								<TextBlock Grid.Column="3"
+										   Grid.Row="5"
+										   Margin="0,2,5,0"
+										   Style="{DynamicResource EmphaticTextStyleKey}"
+										   FontSize="15"
+										   TextAlignment="Right"
+										   Text="{Binding Ship.SumLOS, Mode=OneWay}" />
+
+								<TextBlock Grid.Column="0"
+										   Grid.Row="6"
+										   Margin="0,2,5,0"
+										   FontSize="15"
+										   Text="사거리" />
+								<TextBlock Grid.Column="1"
+										   Grid.Row="6"
+										   Margin="0,2,5,0"
+										   Style="{DynamicResource EmphaticTextStyleKey}"
+										   FontSize="15"
+										   TextAlignment="Center">
+									<Run>
+										<Run.Style>
+											<Style TargetType="{x:Type Run}">
+												<Setter Property="Text" Value="???" />
+												<Style.Triggers>
+													<DataTrigger Binding="{Binding Ship.Range, Mode=OneWay}" Value="1">
+														<Setter Property="Text" Value="단" />
+													</DataTrigger>
+													<DataTrigger Binding="{Binding Ship.Range, Mode=OneWay}" Value="2">
+														<Setter Property="Text" Value="중" />
+													</DataTrigger>
+													<DataTrigger Binding="{Binding Ship.Range, Mode=OneWay}" Value="3">
+														<Setter Property="Text" Value="장" />
+													</DataTrigger>
+													<DataTrigger Binding="{Binding Ship.Range, Mode=OneWay}" Value="4">
+														<Setter Property="Text" Value="초장" />
+													</DataTrigger>
+												</Style.Triggers>
+											</Style>
+										</Run.Style>
+									</Run>
+								</TextBlock>
+								<TextBlock Grid.Column="2"
+										   Grid.Row="6"
+										   Margin="10,2,5,0"
+										   FontSize="15"
+										   Text="운" />
+								<TextBlock Grid.Column="3"
+										   Grid.Row="6"
+										   Margin="0,2,5,0"
+										   Style="{DynamicResource EmphaticTextStyleKey}"
+										   FontSize="15"
+										   TextAlignment="Right"
+										   Text="{Binding Ship.Luck.Current, Mode=OneWay}" />
+							</Grid>
 						</TextBlock.ToolTip> 
 					</TextBlock>
 

--- a/source/Grabacr07.KanColleWrapper/KanColleProxy.Endpoints.cs
+++ b/source/Grabacr07.KanColleWrapper/KanColleProxy.Endpoints.cs
@@ -375,6 +375,14 @@ namespace Grabacr07.KanColleWrapper
 		}
 
 		/// <summary>
+		/// エンド ポイント "/kcsapi/api_req_sortie/goback_port" からのセッションを配信します。
+		/// </summary>
+		public IObservable<Session> api_req_sortie_goback_port
+		{
+			get { return this.ApiSessionSource.Where(x => x.Request.PathAndQuery == "/kcsapi/api_req_sortie/goback_port"); }
+		}
+
+		/// <summary>
 		/// エンド ポイント "/kcsapi/api_get_member/require_info" からのセッションを配信します。
 		/// </summary>
 		public IObservable<Session> api_get_member_require_info

--- a/source/Grabacr07.KanColleWrapper/KanColleProxy.Endpoints.tt
+++ b/source/Grabacr07.KanColleWrapper/KanColleProxy.Endpoints.tt
@@ -53,6 +53,7 @@
 		"/kcsapi/api_req_combined_battle/airbattle",
 		"/kcsapi/api_req_combined_battle/battleresult",
 		"/kcsapi/api_req_combined_battle/goback_port",
+		"/kcsapi/api_req_sortie/goback_port",
 		"/kcsapi/api_get_member/require_info",
 	};
 #>

--- a/source/Grabacr07.KanColleWrapper/Models/Ship.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/Ship.cs
@@ -522,8 +522,18 @@ namespace Grabacr07.KanColleWrapper.Models
 
 		#endregion
 
-		public int SlotsASW => this.Slots.Sum(x => x.Item.Info.ASW) + (this.ExSlot?.Item.Info.ASW ?? 0);
+		public int SlotsASW => this.EquippedItems.Sum(x => x.Item.Info.ASW);
 		public int SumASW => this.ASW.Current + this.SlotsASW;
+
+		public int SumFirepower => this.Firepower.Current + this.EquippedItems.Sum(x => x.Item.Info.Firepower);
+		public int SumTorpedo => this.Torpedo.Current + this.EquippedItems.Sum(x => x.Item.Info.Torpedo);
+		public int SumAA => this.AA.Current + this.EquippedItems.Sum(x => x.Item.Info.AA);
+		public int SumLOS => this.ViewRange + this.EquippedItems.Sum(x => x.Item.Info.ViewRange);
+		public int SumArmor => this.Armer.Current + this.EquippedItems.Sum(x => x.Item.Info.Armer);
+		public int SumEvade => this.RawData.api_kaihi[0] + this.EquippedItems.Sum(x => x.Item.Info.Evade);
+		public int SumCarry => this.Slots.Sum(x => x.Maximum);
+
+		public int Range => this.Info.RawData.api_leng;
 
 		// 선제대잠 가능 여부
 		public bool OpeningASW

--- a/source/Grabacr07.KanColleWrapper/Organization.cs
+++ b/source/Grabacr07.KanColleWrapper/Organization.cs
@@ -442,6 +442,15 @@ namespace Grabacr07.KanColleWrapper
 			int[] evacuationOfferedShipIds = null;
 			int[] towOfferedShipIds = null;
 
+			proxy.api_req_sortie_battleresult
+				.TryParse<kcsapi_battle_result>()
+				.Where(x => x.Data.api_escape != null)
+				.Select(x => x.Data)
+				.Subscribe(x =>
+				{
+					var ships = this.CombinedFleet.Fleets.SelectMany(f => f.Ships).ToArray();
+					evacuationOfferedShipIds = x.api_escape.api_escape_idx.Select(idx => ships[idx - 1].Id).ToArray();
+				});
 			proxy.api_req_combined_battle_battleresult
 				.TryParse<kcsapi_battle_result>()
 				.Where(x => x.Data.api_escape != null)
@@ -464,6 +473,16 @@ namespace Grabacr07.KanColleWrapper
 					{
 						this.evacuatedShipsIds.Add(evacuationOfferedShipIds[0]);
 						this.towShipIds.Add(towOfferedShipIds[0]);
+					}
+				});
+			proxy.api_req_sortie_goback_port
+				.Subscribe(_ =>
+				{
+					if (KanColleClient.Current.IsInSortie
+						&& evacuationOfferedShipIds != null
+						&& evacuationOfferedShipIds.Length >= 1)
+					{
+						this.evacuatedShipsIds.Add(evacuationOfferedShipIds[0]);
 					}
 				});
 			proxy.api_get_member_ship_deck

--- a/source/Grabacr07.KanColleWrapper/Organization.cs
+++ b/source/Grabacr07.KanColleWrapper/Organization.cs
@@ -408,17 +408,20 @@ namespace Grabacr07.KanColleWrapper
 					.Split(',')
 					.Select(x => int.Parse(x));
 
+				var slot_dest = svd.Request["api_slot_dest_flag"] != "0";
+
 				foreach (var ship_idx in ships)
 				{
 					var ship = this.Ships[ship_idx];
 					if (ship != null)
 					{
-						this.homeport.Itemyard.RemoveFromShip(ship);
+						if (slot_dest)
+							this.homeport.Itemyard.RemoveFromShip(ship);
 
 						this.Ships.Remove(ship);
-						this.RaiseShipsChanged();
 					}
 				}
+				this.RaiseShipsChanged();
 			}
 			catch (Exception ex)
 			{

--- a/source/Grabacr07.KanColleWrapper/Organization.cs
+++ b/source/Grabacr07.KanColleWrapper/Organization.cs
@@ -448,7 +448,7 @@ namespace Grabacr07.KanColleWrapper
 				.Select(x => x.Data)
 				.Subscribe(x =>
 				{
-					var ships = this.CombinedFleet.Fleets.SelectMany(f => f.Ships).ToArray();
+					var ships = this.Fleets.Where(f => f.Value.IsInSortie).SelectMany(f => f.Value.Ships).ToArray();
 					evacuationOfferedShipIds = x.api_escape.api_escape_idx.Select(idx => ships[idx - 1].Id).ToArray();
 				});
 			proxy.api_req_combined_battle_battleresult

--- a/source/Grabacr07.KanColleWrapper/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleWrapper/Properties/AssemblyInfo.cs
@@ -10,5 +10,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("8C42F9E0-E2C9-4741-8F98-653A4D275798")]
 
-[assembly: AssemblyVersion("1.7.17")]
-[assembly: AssemblyInformationalVersion("1.7.17")]
+[assembly: AssemblyVersion("1.7.18")]
+[assembly: AssemblyInformationalVersion("1.7.18")]


### PR DESCRIPTION
### ↯ 다운로드
- GitHub [다운로드](https://github.com/CirnoV/KanColleViewer/releases/download/v4.2.11r16/KanColleViewer-KR.4.2.11.r16.zip)
- MEGA [다운로드](https://mega.nz/#!z5AXgDbY!0HqitH9q-20hZ4hs7QpPcaJShJTKYGGAfVawbxN27Qk)

### 🔗 외부 링크
- VirusTotal [검사 결과](https://virustotal.com/ko/file/1b142661b50f16f05a1306a7bb32ed5a34eed61544f803963e97a153b769771a/analysis/1519434669/)
- OpenDB Project Website ([http://swaytwig.com/opendb/](http://swaytwig.com/opendb/))
- 업데이트 페이지 [http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html](http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html)

질문 및 건의사항은 [wolfgangkurzdev@gmail.com](mailto:wolfgangkurzdev@gmail.com) 으로 메일 부탁드립니다.
뷰어 사용중 오류가 발생하는 경우, error.log 혹은 battleinfo_error.log 를 첨부하여 메일로 제보해주시면 해결에 도움이 됩니다.

뷰어를 완전히 삭제하신 후 재설치를 해보시는 것도 방법이 될 수 있습니다.
뷰어의 각종 로그, 함대 프리셋, 전과 데이터 등을 백업하시려면, **뷰어 폴더 내의 csv 파일들과 Record 폴더를 백업**하면 됩니다.

```diff
- 갑자기 혹은 장비목록을 열 때 프로그램이 종료되면, 뷰어 폴더의 KanColleWrapper.dll 을 삭제하시기 바랍니다.
- (lib 폴더 내부에 있는 파일은 삭제하지 마세요)
- 파일이 없거나 삭제 후에도 동일한 증상이 나타난다면 메일로 문의 바랍니다.
```

----
### 💬 공통
- 해체시 장비 보존을 할 경우 장비 수가 줄어들게 표시되던 문제를 수정했습니다.
- 유격부대 사령부시설 아이템을 이용한 단함 퇴피가 인식되지 않던 문제를 수정했습니다.

### 💬 함선 탭
- 함선 이름에 마우스를 올려두면 해당 함선의 현재 스테이터스가 툴팁으로 표시됩니다.

### 💬 장비 목록 창
- "육상대잠기"가 표시되지 않던 문제를 수정했습니다.

### 💬 수리 목록 창
- 수리 목록 창을 열어둔 상태로 다중 해체를 하면 프로그램이 중지되는 문제를 수정했습니다.

### 💬 EventMapHPPlugin
- 이제 제 3 함대의 수송력도 표시됩니다.

### 💬 BattleInfoPlugin
- 작동 이상 문제를 수정했습니다.
  * 심해 연합함대와의 전투에서 작동이 중지되는 문제
  * 심해 연합함대와의 전투 기록을 열람하려고 하면 프로그램이 중지되는 문제
  * 유격부대 사령부시설 아이템을 이용한 단함 퇴피가 인식되지 않던 문제
- 맵 노드 알파벳 추가
  * E-5
  * E-6
  * E-7
