### PR TITLE
v4.2.11 rev18

### DIFF
--- a/source/Grabacr07.KanColleViewer.QuestTracker/Models/Tracker/B/Bq/Bq2.cs
+++ b/source/Grabacr07.KanColleViewer.QuestTracker/Models/Tracker/B/Bq/Bq2.cs
@@ -15,8 +15,6 @@ namespace Grabacr07.KanColleViewer.QuestTracker.Models.Tracker
 	/// </summary>
 	internal class Bq2 : NoOverUnderTracker, ITracker
 	{
-		private QuestProgressType lastProgress = QuestProgressType.None;
-
 		private int progress_2_4;
 		private int progress_6_1;
 		private int progress_6_3;

--- a/source/Grabacr07.KanColleViewer.QuestTracker/Models/Tracker/B/Bq/Bq5.cs
+++ b/source/Grabacr07.KanColleViewer.QuestTracker/Models/Tracker/B/Bq/Bq5.cs
@@ -15,8 +15,6 @@ namespace Grabacr07.KanColleViewer.QuestTracker.Models.Tracker
 	/// </summary>
 	internal class Bq5 : NoOverUnderTracker, ITracker
 	{
-		private QuestProgressType lastProgress = QuestProgressType.None;
-
 		private int progress_3_1;
 		private int progress_3_2;
 		private int progress_3_3;

--- a/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
@@ -15,4 +15,4 @@ using System.Windows;
 	ResourceDictionaryLocation.None,
 	ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("4.2.11.17")]
+[assembly: AssemblyVersion("4.2.11.18")]

--- a/source/Grabacr07.KanColleViewer/ViewModels/Contents/AdmiralViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/Contents/AdmiralViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Linq;

--- a/source/Grabacr07.KanColleViewer/ViewModels/Contents/AdmiralViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/Contents/AdmiralViewModel.cs
@@ -168,7 +168,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents
 				(goal - homeport.Materials.Steel + 2) / 3 * 3,
 				(goal - homeport.Materials.Bauxite + 2) / 3 * 1
 			};
-			if (!times.Any(x => x < 0))
+			if (!times.Any(x => x <= 0))
 			{
 				ResourceLimitRemaining = "--일 --시간 --분"; // 자연회복 없음
 				return;

--- a/source/Grabacr07.KanColleViewer/ViewModels/Contents/Fleets/CombinedFleetViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/Contents/Fleets/CombinedFleetViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -17,9 +17,10 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents.Fleets
 
 		public FleetStateViewModel State { get; }
 
-		public ViewModel QuickStateView => this.Source.State.Situation.HasFlag(FleetSituation.Sortie)
-			? this.State.Sortie
-			: this.State.Homeport as QuickStateViewViewModel;
+		public ViewModel QuickStateView
+			=> this.Source.State.Situation.HasFlag(FleetSituation.Sortie)
+				? this.State.Sortie
+				: this.State.Homeport as QuickStateViewViewModel;
 
 		/// <summary>
 		/// 艦隊に所属している艦娘のコレクションを取得します。

--- a/source/Grabacr07.KanColleViewer/Views/Contents/Fleets.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Contents/Fleets.xaml
@@ -65,8 +65,7 @@
 							   Grid.Row="0"
 							   Grid.RowSpan="2"
 							   HorizontalAlignment="Right"
-							   Margin="10,0,0,0"
-							   ToolTip="{Binding Ship.RequireASW, Mode=OneWay}">
+							   Margin="10,0,0,0">
 						<Run Text="{Binding Ship.Info.ShipType.Name, Mode=OneWay}"
 							 FontSize="14">
 							<Run.Style>
@@ -741,15 +740,15 @@
 								Grid.RowSpan="2"
 								Background="#01000000">
 						<kcvc:ColorIndicator Width="55"
-												LimitedValue="{Binding Ship.Fuel, Mode=OneWay}"
-												Height="6"
-												Columns="5"
-												Margin="0,6,0,7" />
+											 LimitedValue="{Binding Ship.Fuel, Mode=OneWay}"
+											 Height="6"
+											 Columns="5"
+											 Margin="0,6,0,7" />
 						<kcvc:ColorIndicator Width="55"
-												LimitedValue="{Binding Ship.Bull, Mode=OneWay}"
-												Height="6"
-												Columns="5"
-												VerticalAlignment="Top" />
+											 LimitedValue="{Binding Ship.Bull, Mode=OneWay}"
+											 Height="6"
+											 Columns="5"
+											 VerticalAlignment="Top" />
 
 						<StackPanel.ToolTip>
 							<Grid>
@@ -811,15 +810,35 @@
 										   Padding="8,0,0,0"
 										   Style="{DynamicResource DefaultTextStyleKey}"
 										   Text="{Binding Ship.BullText}" />
+
+								<TextBlock Grid.Column="0"
+										   Grid.Row="2"
+										   Style="{DynamicResource DefaultTextStyleKey}"
+										   Text="{Binding Resources.Expedition_Expect_Bauxite, Source={x:Static models:ResourceService.Current}, Mode=OneWay}" />
+								<TextBlock Grid.Column="1"
+										   Grid.Row="2"
+										   Padding="4,0,0,0"
+										   Style="{DynamicResource DefaultTextStyleKey}">
+									<Run Text="{Binding Ship.Bauxite.Current, Mode=OneWay}" />
+									<Run Text="/" />
+									<Run Text="{Binding Ship.Bauxite.Maximum, Mode=OneWay}" />
+								</TextBlock>
+								<TextBlock Grid.Column="2"
+										   Grid.Row="2"
+										   Grid.ColumnSpan="2"
+										   Padding="4,0,0,0"
+										   Style="{DynamicResource DefaultTextStyleKey}"
+										   Foreground="Crimson"
+										   Text="{Binding Ship.UsedBauxite, Mode=OneWay, StringFormat={}({0} 소모)}" />
 							</Grid>
 						</StackPanel.ToolTip>
 					</StackPanel>
 
 					<ItemsControl Grid.Column="7"
-									Grid.Row="0"
-									Grid.RowSpan="2"
-									ItemsSource="{Binding Ship.Slots}"
-									Margin="7,0">
+								  Grid.Row="0"
+								  Grid.RowSpan="2"
+								  ItemsSource="{Binding Ship.Slots}"
+								  Margin="7,0">
 						<ItemsControl.Template>
 							<ControlTemplate TargetType="{x:Type ItemsControl}">
 								<StackPanel IsItemsHost="True"
@@ -829,7 +848,6 @@
 						<ItemsControl.ItemTemplate>
 							<DataTemplate>
 								<Grid x:Name="Elements"
-									  ToolTip="{Binding Tooltip}"
 									  Background="Transparent"
 									  Margin="0,0,1,0">
 									<kcvc:SlotItemIcon x:Name="ItemIcon"
@@ -1034,6 +1052,645 @@
 												Width="Auto"
 												Height="Auto"
 												Padding="1" />
+
+									<Grid.ToolTip>
+										<StackPanel Orientation="Vertical">
+											<StackPanel Orientation="Horizontal"
+														Margin="0,0,0,10">
+												<kcvc:SlotItemIcon Type="{Binding Item.Info.IconType}"
+																   Margin="0,0,3,0"
+																   Width="20"
+																   Height="20"
+																   VerticalAlignment="Center" />
+												<TextBlock VerticalAlignment="Center">
+													<Run Text="{Binding Item.Info.Name, Mode=OneWay}" />
+													<Run>
+														<Run.Style>
+															<Style TargetType="{x:Type Run}">
+																<Setter Property="Text" Value="{Binding Item.Proficiency, Mode=OneWay, StringFormat=+{0}}" />
+																<Setter Property="Foreground" Value="#FFD49C0F" />
+																<Style.Triggers>
+																	<DataTrigger Binding="{Binding Item.Proficiency, Mode=OneWay}" Value="0">
+																		<Setter Property="Text" Value="" />
+																	</DataTrigger>
+																	<DataTrigger Binding="{Binding Item.Proficiency, Mode=OneWay, Converter={StaticResource RangeToBooleanConverter}, ConverterParameter=1-3}" Value="True">
+																		<Setter Property="Foreground" Value="#FF98B3CE" />
+																	</DataTrigger>
+																</Style.Triggers>
+															</Style>
+														</Run.Style>
+													</Run>
+													<Run Text="{Binding Item.LevelText, Mode=OneWay}"
+														 Foreground="#FF45A9A5" />
+												</TextBlock>
+											</StackPanel>
+											
+											<TextBlock Margin="0,2,0,0">
+												<Run Text="화력:" />
+												<Run Text="{Binding Item.Info.Firepower, Mode=OneWay}">
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding Item.Info.Firepower}" Value="0">
+																	<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+												<Run Foreground="#FF45A9A5">
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding Item.ImprovementStats.Firepower, Mode=OneWay, StringFormat={}+{0:N2}}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding Item.ImprovementStats.Firepower}" Value="0">
+																	<Setter Property="Text" Value="" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Style.Triggers>
+															<MultiDataTrigger>
+																<MultiDataTrigger.Conditions>
+																	<Condition Binding="{Binding Item.Info.Firepower}" Value="0" />
+																	<Condition Binding="{Binding Item.ImprovementStats.Firepower}" Value="0" />
+																</MultiDataTrigger.Conditions>
+																<MultiDataTrigger.Setters>
+																	<Setter Property="Visibility" Value="Collapsed" />
+																</MultiDataTrigger.Setters>
+															</MultiDataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+											
+											<TextBlock Margin="0,2,0,0">
+												<Run Text="뇌장:" />
+												<Run Text="{Binding Item.Info.Torpedo, Mode=OneWay}">
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding Item.Info.Torpedo}" Value="0">
+																	<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+												<Run Foreground="#FF45A9A5">
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding Item.ImprovementStats.Torpedo, Mode=OneWay, StringFormat={}+{0:N2}}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding Item.ImprovementStats.Torpedo}" Value="0">
+																	<Setter Property="Text" Value="" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Style.Triggers>
+															<MultiDataTrigger>
+																<MultiDataTrigger.Conditions>
+																	<Condition Binding="{Binding Item.Info.Torpedo}" Value="0" />
+																	<Condition Binding="{Binding Item.ImprovementStats.Torpedo}" Value="0" />
+																</MultiDataTrigger.Conditions>
+																<MultiDataTrigger.Setters>
+																	<Setter Property="Visibility" Value="Collapsed" />
+																</MultiDataTrigger.Setters>
+															</MultiDataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+											<TextBlock Margin="0,2,0,0">
+												<Run Text="뇌격 명중:" />
+												<Run Foreground="#FF45A9A5"
+													 Text="{Binding Item.ImprovementStats.TorpedoHit, Mode=OneWay, StringFormat={}+{0:N2}}" />
+
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding Item.ImprovementStats.TorpedoHit}" Value="0">
+																<Setter Property="Visibility" Value="Collapsed" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+
+											<TextBlock Margin="0,2,0,0">
+												<Run Text="대공:" />
+												<Run Text="{Binding Item.Info.AA, Mode=OneWay}">
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding Item.Info.AA}" Value="0">
+																	<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+												<Run Foreground="#FF45A9A5">
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding Item.ImprovementStats.AA, Mode=OneWay, StringFormat={}+{0:N2}}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding Item.ImprovementStats.AA}" Value="0">
+																	<Setter Property="Text" Value="" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Style.Triggers>
+															<MultiDataTrigger>
+																<MultiDataTrigger.Conditions>
+																	<Condition Binding="{Binding Item.Info.AA}" Value="0" />
+																	<Condition Binding="{Binding Item.ImprovementStats.AA}" Value="0" />
+																</MultiDataTrigger.Conditions>
+																<MultiDataTrigger.Setters>
+																	<Setter Property="Visibility" Value="Collapsed" />
+																</MultiDataTrigger.Setters>
+															</MultiDataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+											<TextBlock Margin="0,2,0,0">
+												<Run Text="함대 방공:" />
+												<Run Foreground="#FF45A9A5"
+													 Text="{Binding Item.ImprovementStats.FleetAA, Mode=OneWay, StringFormat={}+{0:N2}}" />
+
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding Item.ImprovementStats.FleetAA}" Value="0">
+																<Setter Property="Visibility" Value="Collapsed" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+
+											<TextBlock Margin="0,2,0,0">
+												<Run Text="장갑:" />
+												<Run Text="{Binding Item.Info.Armer, Mode=OneWay}">
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding Item.Info.Armer}" Value="0">
+																	<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+												<Run Foreground="#FF45A9A5">
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding Item.ImprovementStats.Armor, Mode=OneWay, StringFormat={}+{0:N2}}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding Item.ImprovementStats.Armor}" Value="0">
+																	<Setter Property="Text" Value="" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Style.Triggers>
+															<MultiDataTrigger>
+																<MultiDataTrigger.Conditions>
+																	<Condition Binding="{Binding Item.Info.Armer}" Value="0" />
+																	<Condition Binding="{Binding Item.ImprovementStats.Armor}" Value="0" />
+																</MultiDataTrigger.Conditions>
+																<MultiDataTrigger.Setters>
+																	<Setter Property="Visibility" Value="Collapsed" />
+																</MultiDataTrigger.Setters>
+															</MultiDataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+											<TextBlock Margin="0,2,0,0">
+												<Run Text="폭장:" />
+												<Run Text="{Binding Item.Info.Bomb, Mode=OneWay}">
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding Item.Info.Bomb}" Value="0">
+																	<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+												<Run Foreground="#FF45A9A5">
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding Item.ImprovementStats.Bomb, Mode=OneWay, StringFormat={}+{0:N2}}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding Item.ImprovementStats.Bomb}" Value="0">
+																	<Setter Property="Text" Value="" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Style.Triggers>
+															<MultiDataTrigger>
+																<MultiDataTrigger.Conditions>
+																	<Condition Binding="{Binding Item.Info.Bomb}" Value="0" />
+																	<Condition Binding="{Binding Item.ImprovementStats.Bomb}" Value="0" />
+																</MultiDataTrigger.Conditions>
+																<MultiDataTrigger.Setters>
+																	<Setter Property="Visibility" Value="Collapsed" />
+																</MultiDataTrigger.Setters>
+															</MultiDataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+
+											<TextBlock Margin="0,2,0,0">
+												<Run Text="대잠:" />
+												<Run Text="{Binding Item.Info.ASW, Mode=OneWay}">
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding Item.Info.ASW}" Value="0">
+																	<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+												<Run Foreground="#FF45A9A5">
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding Item.ImprovementStats.ASW, Mode=OneWay, StringFormat={}+{0:N2}}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding Item.ImprovementStats.ASW}" Value="0">
+																	<Setter Property="Text" Value="" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Style.Triggers>
+															<MultiDataTrigger>
+																<MultiDataTrigger.Conditions>
+																	<Condition Binding="{Binding Item.Info.ASW}" Value="0" />
+																	<Condition Binding="{Binding Item.ImprovementStats.ASW}" Value="0" />
+																</MultiDataTrigger.Conditions>
+																<MultiDataTrigger.Setters>
+																	<Setter Property="Visibility" Value="Collapsed" />
+																</MultiDataTrigger.Setters>
+															</MultiDataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+											<TextBlock Margin="0,2,0,0">
+												<Run Text="대잠 명중:" />
+												<Run Foreground="#FF45A9A5"
+													 Text="{Binding Item.ImprovementStats.ASWHit, Mode=OneWay, StringFormat={}+{0:N2}}" />
+
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding Item.ImprovementStats.ASWHit}" Value="0">
+																<Setter Property="Visibility" Value="Collapsed" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+
+											<TextBlock Margin="0,2,0,0">
+												<InlineUIContainer>
+													<TextBlock>
+														<TextBlock.Style>
+															<Style TargetType="{x:Type TextBlock}">
+																<Setter Property="Text" Value="명중:" />
+																<Style.Triggers>
+																	<DataTrigger Binding="{Binding Item.Info.Type, Mode=OneWay}" Value="局地戦闘機">
+																		<Setter Property="Text" Value="대폭:" />
+																	</DataTrigger>
+																</Style.Triggers>
+															</Style>
+														</TextBlock.Style>
+													</TextBlock>
+												</InlineUIContainer>
+												<Run Text="{Binding Item.Info.Hit, Mode=OneWay}">
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding Item.Info.Hit}" Value="0">
+																	<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+												<Run Foreground="#FF45A9A5">
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding Item.ImprovementStats.Hit, Mode=OneWay, StringFormat={}+{0:N2}}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding Item.ImprovementStats.Hit}" Value="0">
+																	<Setter Property="Text" Value="" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Style.Triggers>
+															<MultiDataTrigger>
+																<MultiDataTrigger.Conditions>
+																	<Condition Binding="{Binding Item.Info.Hit}" Value="0" />
+																	<Condition Binding="{Binding Item.ImprovementStats.Hit}" Value="0" />
+																</MultiDataTrigger.Conditions>
+																<MultiDataTrigger.Setters>
+																	<Setter Property="Visibility" Value="Collapsed" />
+																</MultiDataTrigger.Setters>
+															</MultiDataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+											<TextBlock Margin="0,2,0,0">
+												<InlineUIContainer>
+													<TextBlock>
+														<TextBlock.Style>
+															<Style TargetType="{x:Type TextBlock}">
+																<Setter Property="Text" Value="회피:" />
+																<Style.Triggers>
+																	<DataTrigger Binding="{Binding Item.Info.Type, Mode=OneWay}" Value="局地戦闘機">
+																		<Setter Property="Text" Value="영격:" />
+																	</DataTrigger>
+																</Style.Triggers>
+															</Style>
+														</TextBlock.Style>
+													</TextBlock>
+												</InlineUIContainer>
+												<Run Text="{Binding Item.Info.Evade, Mode=OneWay}">
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding Item.Info.Evade}" Value="0">
+																	<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+												<Run Foreground="#FF45A9A5">
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding Item.ImprovementStats.Evade, Mode=OneWay, StringFormat={}+{0:N2}}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding Item.ImprovementStats.Evade}" Value="0">
+																	<Setter Property="Text" Value="" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Style.Triggers>
+															<MultiDataTrigger>
+																<MultiDataTrigger.Conditions>
+																	<Condition Binding="{Binding Item.Info.Evade}" Value="0" />
+																	<Condition Binding="{Binding Item.ImprovementStats.Evade}" Value="0" />
+																</MultiDataTrigger.Conditions>
+																<MultiDataTrigger.Setters>
+																	<Setter Property="Visibility" Value="Collapsed" />
+																</MultiDataTrigger.Setters>
+															</MultiDataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+
+											<TextBlock Margin="0,2,0,0">
+												<Run Text="색적:" />
+												<Run Text="{Binding Item.Info.ViewRange, Mode=OneWay}">
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding Item.Info.ViewRange}" Value="0">
+																	<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+												<Run Foreground="#FF45A9A5">
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding Item.ImprovementStats.LoS, Mode=OneWay, StringFormat={}+{0:N2}}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding Item.ImprovementStats.LoS}" Value="0">
+																	<Setter Property="Text" Value="" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Style.Triggers>
+															<MultiDataTrigger>
+																<MultiDataTrigger.Conditions>
+																	<Condition Binding="{Binding Item.Info.ViewRange}" Value="0" />
+																	<Condition Binding="{Binding Item.ImprovementStats.LoS}" Value="0" />
+																</MultiDataTrigger.Conditions>
+																<MultiDataTrigger.Setters>
+																	<Setter Property="Visibility" Value="Collapsed" />
+																</MultiDataTrigger.Setters>
+															</MultiDataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+
+											<TextBlock Margin="0,10,0,0">
+												<Run Text="원정 보너스: +" />
+												<Run Text="{Binding Item.Info.ExpeditionBonus, Mode=OneWay}">
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding Item.Info.ExpeditionBonus}" Value="0">
+																	<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+												<Run Foreground="#FF45A9A5">
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding Item.ImprovementStats.ExpeditionBonus, Mode=OneWay, StringFormat={}+{0:N2}}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding Item.ImprovementStats.ExpeditionBonus}" Value="0">
+																	<Setter Property="Text" Value="" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+												<Run Text="%" />
+
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Style.Triggers>
+															<MultiDataTrigger>
+																<MultiDataTrigger.Conditions>
+																	<Condition Binding="{Binding Item.Info.ExpeditionBonus}" Value="0" />
+																	<Condition Binding="{Binding Item.ImprovementStats.ExpeditionBonus}" Value="0" />
+																</MultiDataTrigger.Conditions>
+																<MultiDataTrigger.Setters>
+																	<Setter Property="Visibility" Value="Collapsed" />
+																</MultiDataTrigger.Setters>
+															</MultiDataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+											<TextBlock Margin="0,10,0,0">
+												<Run Text="포대형 특화 계수: 포격전 화력 x (" />
+												<Run Text="{Binding Item.Info.TurrentEfficacy, Mode=OneWay, StringFormat={}{0:N2}}">
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding Item.Info.TurrentEfficacy}" Value="0">
+																	<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+												<Run Foreground="#FF45A9A5">
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Text" Value="{Binding Item.ImprovementStats.TurrentEfficacy, Mode=OneWay, StringFormat={}+{0:N2}}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding Item.ImprovementStats.TurrentEfficacy}" Value="0">
+																	<Setter Property="Text" Value="" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+												<Run Text=")" />
+
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Style.Triggers>
+															<MultiDataTrigger>
+																<MultiDataTrigger.Conditions>
+																	<Condition Binding="{Binding Item.Info.TurrentEfficacy}" Value="0" />
+																	<Condition Binding="{Binding Item.ImprovementStats.TurrentEfficacy}" Value="0" />
+																</MultiDataTrigger.Conditions>
+																<MultiDataTrigger.Setters>
+																	<Setter Property="Visibility" Value="Collapsed" />
+																</MultiDataTrigger.Setters>
+															</MultiDataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+
+											<TextBlock Margin="0,10,0,0">
+												<Run Text="항속거리:" />
+												<Run Text="{Binding Item.Info.Distance, Mode=OneWay}">
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding Item.Info.Distance}" Value="0">
+																	<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding Item.Info.IsNumerable}" Value="False">
+																<Setter Property="Visibility" Value="Collapsed" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+											<TextBlock Margin="0,2,0,0">
+												<Run Text="배치비용:" />
+												<Run Text="{Binding Item.Info.AirBaseCost, Mode=OneWay}">
+													<Run.Style>
+														<Style TargetType="{x:Type Run}">
+															<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding Item.Info.AirBaseCost}" Value="0">
+																	<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Run.Style>
+												</Run>
+
+												<TextBlock.Style>
+													<Style TargetType="{x:Type TextBlock}">
+														<Style.Triggers>
+															<DataTrigger Binding="{Binding Item.Info.IsNumerable}" Value="False">
+																<Setter Property="Visibility" Value="Collapsed" />
+															</DataTrigger>
+														</Style.Triggers>
+													</Style>
+												</TextBlock.Style>
+											</TextBlock>
+										</StackPanel>
+									</Grid.ToolTip>
 								</Grid>
 								<DataTemplate.Triggers>
 									<DataTrigger Binding="{Binding Equipped}" Value="False">
@@ -1275,7 +1932,6 @@
 									 Padding="12,8"
 									 MethodName="ShowFleetWindow" />
 
-			
 			<Grid Grid.Row="3"
 				  Grid.Column="0"
 				  Grid.ColumnSpan="3"
@@ -1487,8 +2143,9 @@
 																	<ItemsControl.ItemTemplate>
 																		<DataTemplate>
 																			<Grid Margin="3,6">
-																				<StackPanel x:Name="PlaneInfo">
-																					<StackPanel Orientation="Horizontal" ToolTip="{Binding Source.Info.ToolTipData}">
+																				<StackPanel x:Name="PlaneInfo"
+																							Orientation="Vertical">
+																					<StackPanel Orientation="Horizontal">
 																						<kcvc:ConditionIcon ConditionType="{Binding ConditionIcon, Mode=OneWay}"
 																											Margin="0,0,10,0"/>
 																						<kcvc:SlotItemIcon Type="{Binding Source.Info.IconType, Mode=OneWay}"
@@ -1558,6 +2215,645 @@
 																							</TextBlock.Style>
 																						</TextBlock>
 																					</Grid>
+
+																					<StackPanel.ToolTip>
+																						<StackPanel Orientation="Vertical">
+																							<StackPanel Orientation="Horizontal"
+																										Margin="0,0,0,10">
+																								<kcvc:SlotItemIcon Type="{Binding Source.Info.IconType}"
+																												   Margin="0,0,3,0"
+																												   Width="20"
+																												   Height="20"
+																												   VerticalAlignment="Center" />
+																								<TextBlock VerticalAlignment="Center">
+																									<Run Text="{Binding Source.Info.Name, Mode=OneWay}" />
+																									<Run>
+																										<Run.Style>
+																											<Style TargetType="{x:Type Run}">
+																												<Setter Property="Text" Value="{Binding Source.Proficiency, Mode=OneWay, StringFormat=+{0}}" />
+																												<Setter Property="Foreground" Value="#FFD49C0F" />
+																												<Style.Triggers>
+																													<DataTrigger Binding="{Binding Source.Proficiency, Mode=OneWay}" Value="0">
+																														<Setter Property="Text" Value="" />
+																													</DataTrigger>
+																													<DataTrigger Binding="{Binding Source.Proficiency, Mode=OneWay, Converter={StaticResource RangeToBooleanConverter}, ConverterParameter=1-3}" Value="True">
+																														<Setter Property="Foreground" Value="#FF98B3CE" />
+																													</DataTrigger>
+																												</Style.Triggers>
+																											</Style>
+																										</Run.Style>
+																									</Run>
+																									<Run Text="{Binding Source.LevelText, Mode=OneWay}"
+																										 Foreground="#FF45A9A5" />
+																								</TextBlock>
+																							</StackPanel>
+											
+																							<TextBlock Margin="0,2,0,0">
+																								<Run Text="화력:" />
+																								<Run Text="{Binding Source.Info.Firepower, Mode=OneWay}">
+																									<Run.Style>
+																										<Style TargetType="{x:Type Run}">
+																											<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																											<Style.Triggers>
+																												<DataTrigger Binding="{Binding Source.Info.Firepower}" Value="0">
+																													<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																												</DataTrigger>
+																											</Style.Triggers>
+																										</Style>
+																									</Run.Style>
+																								</Run>
+																								<Run Foreground="#FF45A9A5">
+																									<Run.Style>
+																										<Style TargetType="{x:Type Run}">
+																											<Setter Property="Text" Value="{Binding Source.ImprovementStats.Firepower, Mode=OneWay, StringFormat={}+{0:N2}}" />
+																											<Style.Triggers>
+																												<DataTrigger Binding="{Binding Source.ImprovementStats.Firepower}" Value="0">
+																													<Setter Property="Text" Value="" />
+																												</DataTrigger>
+																											</Style.Triggers>
+																										</Style>
+																									</Run.Style>
+																								</Run>
+
+																								<TextBlock.Style>
+																									<Style TargetType="{x:Type TextBlock}">
+																										<Style.Triggers>
+																											<MultiDataTrigger>
+																												<MultiDataTrigger.Conditions>
+																													<Condition Binding="{Binding Source.Info.Firepower}" Value="0" />
+																													<Condition Binding="{Binding Source.ImprovementStats.Firepower}" Value="0" />
+																												</MultiDataTrigger.Conditions>
+																												<MultiDataTrigger.Setters>
+																													<Setter Property="Visibility" Value="Collapsed" />
+																												</MultiDataTrigger.Setters>
+																											</MultiDataTrigger>
+																										</Style.Triggers>
+																									</Style>
+																								</TextBlock.Style>
+																							</TextBlock>
+											
+																							<TextBlock Margin="0,2,0,0">
+																								<Run Text="뇌장:" />
+																								<Run Text="{Binding Source.Info.Torpedo, Mode=OneWay}">
+																									<Run.Style>
+																										<Style TargetType="{x:Type Run}">
+																											<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																											<Style.Triggers>
+																												<DataTrigger Binding="{Binding Source.Info.Torpedo}" Value="0">
+																													<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																												</DataTrigger>
+																											</Style.Triggers>
+																										</Style>
+																									</Run.Style>
+																								</Run>
+																								<Run Foreground="#FF45A9A5">
+																									<Run.Style>
+																										<Style TargetType="{x:Type Run}">
+																											<Setter Property="Text" Value="{Binding Source.ImprovementStats.Torpedo, Mode=OneWay, StringFormat={}+{0:N2}}" />
+																											<Style.Triggers>
+																												<DataTrigger Binding="{Binding Source.ImprovementStats.Torpedo}" Value="0">
+																													<Setter Property="Text" Value="" />
+																												</DataTrigger>
+																											</Style.Triggers>
+																										</Style>
+																									</Run.Style>
+																								</Run>
+
+																								<TextBlock.Style>
+																									<Style TargetType="{x:Type TextBlock}">
+																										<Style.Triggers>
+																											<MultiDataTrigger>
+																												<MultiDataTrigger.Conditions>
+																													<Condition Binding="{Binding Source.Info.Torpedo}" Value="0" />
+																													<Condition Binding="{Binding Source.ImprovementStats.Torpedo}" Value="0" />
+																												</MultiDataTrigger.Conditions>
+																												<MultiDataTrigger.Setters>
+																													<Setter Property="Visibility" Value="Collapsed" />
+																												</MultiDataTrigger.Setters>
+																											</MultiDataTrigger>
+																										</Style.Triggers>
+																									</Style>
+																								</TextBlock.Style>
+																							</TextBlock>
+																							<TextBlock Margin="0,2,0,0">
+																								<Run Text="뇌격 명중:" />
+																								<Run Foreground="#FF45A9A5"
+																									 Text="{Binding Source.ImprovementStats.TorpedoHit, Mode=OneWay, StringFormat={}+{0:N2}}" />
+
+																								<TextBlock.Style>
+																									<Style TargetType="{x:Type TextBlock}">
+																										<Style.Triggers>
+																											<DataTrigger Binding="{Binding Source.ImprovementStats.TorpedoHit}" Value="0">
+																												<Setter Property="Visibility" Value="Collapsed" />
+																											</DataTrigger>
+																										</Style.Triggers>
+																									</Style>
+																								</TextBlock.Style>
+																							</TextBlock>
+
+																							<TextBlock Margin="0,2,0,0">
+																								<Run Text="대공:" />
+																								<Run Text="{Binding Source.Info.AA, Mode=OneWay}">
+																									<Run.Style>
+																										<Style TargetType="{x:Type Run}">
+																											<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																											<Style.Triggers>
+																												<DataTrigger Binding="{Binding Source.Info.AA}" Value="0">
+																													<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																												</DataTrigger>
+																											</Style.Triggers>
+																										</Style>
+																									</Run.Style>
+																								</Run>
+																								<Run Foreground="#FF45A9A5">
+																									<Run.Style>
+																										<Style TargetType="{x:Type Run}">
+																											<Setter Property="Text" Value="{Binding Source.ImprovementStats.AA, Mode=OneWay, StringFormat={}+{0:N2}}" />
+																											<Style.Triggers>
+																												<DataTrigger Binding="{Binding Source.ImprovementStats.AA}" Value="0">
+																													<Setter Property="Text" Value="" />
+																												</DataTrigger>
+																											</Style.Triggers>
+																										</Style>
+																									</Run.Style>
+																								</Run>
+
+																								<TextBlock.Style>
+																									<Style TargetType="{x:Type TextBlock}">
+																										<Style.Triggers>
+																											<MultiDataTrigger>
+																												<MultiDataTrigger.Conditions>
+																													<Condition Binding="{Binding Source.Info.AA}" Value="0" />
+																													<Condition Binding="{Binding Source.ImprovementStats.AA}" Value="0" />
+																												</MultiDataTrigger.Conditions>
+																												<MultiDataTrigger.Setters>
+																													<Setter Property="Visibility" Value="Collapsed" />
+																												</MultiDataTrigger.Setters>
+																											</MultiDataTrigger>
+																										</Style.Triggers>
+																									</Style>
+																								</TextBlock.Style>
+																							</TextBlock>
+																							<TextBlock Margin="0,2,0,0">
+																								<Run Text="함대 방공:" />
+																								<Run Foreground="#FF45A9A5"
+																									 Text="{Binding Source.ImprovementStats.FleetAA, Mode=OneWay, StringFormat={}+{0:N2}}" />
+
+																								<TextBlock.Style>
+																									<Style TargetType="{x:Type TextBlock}">
+																										<Style.Triggers>
+																											<DataTrigger Binding="{Binding Source.ImprovementStats.FleetAA}" Value="0">
+																												<Setter Property="Visibility" Value="Collapsed" />
+																											</DataTrigger>
+																										</Style.Triggers>
+																									</Style>
+																								</TextBlock.Style>
+																							</TextBlock>
+
+																							<TextBlock Margin="0,2,0,0">
+																								<Run Text="장갑:" />
+																								<Run Text="{Binding Source.Info.Armer, Mode=OneWay}">
+																									<Run.Style>
+																										<Style TargetType="{x:Type Run}">
+																											<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																											<Style.Triggers>
+																												<DataTrigger Binding="{Binding Source.Info.Armer}" Value="0">
+																													<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																												</DataTrigger>
+																											</Style.Triggers>
+																										</Style>
+																									</Run.Style>
+																								</Run>
+																								<Run Foreground="#FF45A9A5">
+																									<Run.Style>
+																										<Style TargetType="{x:Type Run}">
+																											<Setter Property="Text" Value="{Binding Source.ImprovementStats.Armor, Mode=OneWay, StringFormat={}+{0:N2}}" />
+																											<Style.Triggers>
+																												<DataTrigger Binding="{Binding Source.ImprovementStats.Armor}" Value="0">
+																													<Setter Property="Text" Value="" />
+																												</DataTrigger>
+																											</Style.Triggers>
+																										</Style>
+																									</Run.Style>
+																								</Run>
+
+																								<TextBlock.Style>
+																									<Style TargetType="{x:Type TextBlock}">
+																										<Style.Triggers>
+																											<MultiDataTrigger>
+																												<MultiDataTrigger.Conditions>
+																													<Condition Binding="{Binding Source.Info.Armer}" Value="0" />
+																													<Condition Binding="{Binding Source.ImprovementStats.Armor}" Value="0" />
+																												</MultiDataTrigger.Conditions>
+																												<MultiDataTrigger.Setters>
+																													<Setter Property="Visibility" Value="Collapsed" />
+																												</MultiDataTrigger.Setters>
+																											</MultiDataTrigger>
+																										</Style.Triggers>
+																									</Style>
+																								</TextBlock.Style>
+																							</TextBlock>
+																							<TextBlock Margin="0,2,0,0">
+																								<Run Text="폭장:" />
+																								<Run Text="{Binding Source.Info.Bomb, Mode=OneWay}">
+																									<Run.Style>
+																										<Style TargetType="{x:Type Run}">
+																											<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																											<Style.Triggers>
+																												<DataTrigger Binding="{Binding Source.Info.Bomb}" Value="0">
+																													<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																												</DataTrigger>
+																											</Style.Triggers>
+																										</Style>
+																									</Run.Style>
+																								</Run>
+																								<Run Foreground="#FF45A9A5">
+																									<Run.Style>
+																										<Style TargetType="{x:Type Run}">
+																											<Setter Property="Text" Value="{Binding Source.ImprovementStats.Bomb, Mode=OneWay, StringFormat={}+{0:N2}}" />
+																											<Style.Triggers>
+																												<DataTrigger Binding="{Binding Source.ImprovementStats.Bomb}" Value="0">
+																													<Setter Property="Text" Value="" />
+																												</DataTrigger>
+																											</Style.Triggers>
+																										</Style>
+																									</Run.Style>
+																								</Run>
+
+																								<TextBlock.Style>
+																									<Style TargetType="{x:Type TextBlock}">
+																										<Style.Triggers>
+																											<MultiDataTrigger>
+																												<MultiDataTrigger.Conditions>
+																													<Condition Binding="{Binding Source.Info.Bomb}" Value="0" />
+																													<Condition Binding="{Binding Source.ImprovementStats.Bomb}" Value="0" />
+																												</MultiDataTrigger.Conditions>
+																												<MultiDataTrigger.Setters>
+																													<Setter Property="Visibility" Value="Collapsed" />
+																												</MultiDataTrigger.Setters>
+																											</MultiDataTrigger>
+																										</Style.Triggers>
+																									</Style>
+																								</TextBlock.Style>
+																							</TextBlock>
+
+																							<TextBlock Margin="0,2,0,0">
+																								<Run Text="대잠:" />
+																								<Run Text="{Binding Source.Info.ASW, Mode=OneWay}">
+																									<Run.Style>
+																										<Style TargetType="{x:Type Run}">
+																											<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																											<Style.Triggers>
+																												<DataTrigger Binding="{Binding Source.Info.ASW}" Value="0">
+																													<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																												</DataTrigger>
+																											</Style.Triggers>
+																										</Style>
+																									</Run.Style>
+																								</Run>
+																								<Run Foreground="#FF45A9A5">
+																									<Run.Style>
+																										<Style TargetType="{x:Type Run}">
+																											<Setter Property="Text" Value="{Binding Source.ImprovementStats.ASW, Mode=OneWay, StringFormat={}+{0:N2}}" />
+																											<Style.Triggers>
+																												<DataTrigger Binding="{Binding Source.ImprovementStats.ASW}" Value="0">
+																													<Setter Property="Text" Value="" />
+																												</DataTrigger>
+																											</Style.Triggers>
+																										</Style>
+																									</Run.Style>
+																								</Run>
+
+																								<TextBlock.Style>
+																									<Style TargetType="{x:Type TextBlock}">
+																										<Style.Triggers>
+																											<MultiDataTrigger>
+																												<MultiDataTrigger.Conditions>
+																													<Condition Binding="{Binding Source.Info.ASW}" Value="0" />
+																													<Condition Binding="{Binding Source.ImprovementStats.ASW}" Value="0" />
+																												</MultiDataTrigger.Conditions>
+																												<MultiDataTrigger.Setters>
+																													<Setter Property="Visibility" Value="Collapsed" />
+																												</MultiDataTrigger.Setters>
+																											</MultiDataTrigger>
+																										</Style.Triggers>
+																									</Style>
+																								</TextBlock.Style>
+																							</TextBlock>
+																							<TextBlock Margin="0,2,0,0">
+																								<Run Text="대잠 명중:" />
+																								<Run Foreground="#FF45A9A5"
+																									 Text="{Binding Source.ImprovementStats.ASWHit, Mode=OneWay, StringFormat={}+{0:N2}}" />
+
+																								<TextBlock.Style>
+																									<Style TargetType="{x:Type TextBlock}">
+																										<Style.Triggers>
+																											<DataTrigger Binding="{Binding Source.ImprovementStats.ASWHit}" Value="0">
+																												<Setter Property="Visibility" Value="Collapsed" />
+																											</DataTrigger>
+																										</Style.Triggers>
+																									</Style>
+																								</TextBlock.Style>
+																							</TextBlock>
+
+																							<TextBlock Margin="0,2,0,0">
+																								<InlineUIContainer>
+																									<TextBlock>
+																										<TextBlock.Style>
+																											<Style TargetType="{x:Type TextBlock}">
+																												<Setter Property="Text" Value="명중:" />
+																												<Style.Triggers>
+																													<DataTrigger Binding="{Binding Source.Info.Type, Mode=OneWay}" Value="局地戦闘機">
+																														<Setter Property="Text" Value="대폭:" />
+																													</DataTrigger>
+																												</Style.Triggers>
+																											</Style>
+																										</TextBlock.Style>
+																									</TextBlock>
+																								</InlineUIContainer>
+																								<Run Text="{Binding Source.Info.Hit, Mode=OneWay}">
+																									<Run.Style>
+																										<Style TargetType="{x:Type Run}">
+																											<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																											<Style.Triggers>
+																												<DataTrigger Binding="{Binding Source.Info.Hit}" Value="0">
+																													<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																												</DataTrigger>
+																											</Style.Triggers>
+																										</Style>
+																									</Run.Style>
+																								</Run>
+																								<Run Foreground="#FF45A9A5">
+																									<Run.Style>
+																										<Style TargetType="{x:Type Run}">
+																											<Setter Property="Text" Value="{Binding Source.ImprovementStats.Hit, Mode=OneWay, StringFormat={}+{0:N2}}" />
+																											<Style.Triggers>
+																												<DataTrigger Binding="{Binding Source.ImprovementStats.Hit}" Value="0">
+																													<Setter Property="Text" Value="" />
+																												</DataTrigger>
+																											</Style.Triggers>
+																										</Style>
+																									</Run.Style>
+																								</Run>
+
+																								<TextBlock.Style>
+																									<Style TargetType="{x:Type TextBlock}">
+																										<Style.Triggers>
+																											<MultiDataTrigger>
+																												<MultiDataTrigger.Conditions>
+																													<Condition Binding="{Binding Source.Info.Hit}" Value="0" />
+																													<Condition Binding="{Binding Source.ImprovementStats.Hit}" Value="0" />
+																												</MultiDataTrigger.Conditions>
+																												<MultiDataTrigger.Setters>
+																													<Setter Property="Visibility" Value="Collapsed" />
+																												</MultiDataTrigger.Setters>
+																											</MultiDataTrigger>
+																										</Style.Triggers>
+																									</Style>
+																								</TextBlock.Style>
+																							</TextBlock>
+																							<TextBlock Margin="0,2,0,0">
+																								<InlineUIContainer>
+																									<TextBlock>
+																										<TextBlock.Style>
+																											<Style TargetType="{x:Type TextBlock}">
+																												<Setter Property="Text" Value="회피:" />
+																												<Style.Triggers>
+																													<DataTrigger Binding="{Binding Source.Info.Type, Mode=OneWay}" Value="局地戦闘機">
+																														<Setter Property="Text" Value="영격:" />
+																													</DataTrigger>
+																												</Style.Triggers>
+																											</Style>
+																										</TextBlock.Style>
+																									</TextBlock>
+																								</InlineUIContainer>
+																								<Run Text="{Binding Source.Info.Evade, Mode=OneWay}">
+																									<Run.Style>
+																										<Style TargetType="{x:Type Run}">
+																											<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																											<Style.Triggers>
+																												<DataTrigger Binding="{Binding Source.Info.Evade}" Value="0">
+																													<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																												</DataTrigger>
+																											</Style.Triggers>
+																										</Style>
+																									</Run.Style>
+																								</Run>
+																								<Run Foreground="#FF45A9A5">
+																									<Run.Style>
+																										<Style TargetType="{x:Type Run}">
+																											<Setter Property="Text" Value="{Binding Source.ImprovementStats.Evade, Mode=OneWay, StringFormat={}+{0:N2}}" />
+																											<Style.Triggers>
+																												<DataTrigger Binding="{Binding Source.ImprovementStats.Evade}" Value="0">
+																													<Setter Property="Text" Value="" />
+																												</DataTrigger>
+																											</Style.Triggers>
+																										</Style>
+																									</Run.Style>
+																								</Run>
+
+																								<TextBlock.Style>
+																									<Style TargetType="{x:Type TextBlock}">
+																										<Style.Triggers>
+																											<MultiDataTrigger>
+																												<MultiDataTrigger.Conditions>
+																													<Condition Binding="{Binding Source.Info.Evade}" Value="0" />
+																													<Condition Binding="{Binding Source.ImprovementStats.Evade}" Value="0" />
+																												</MultiDataTrigger.Conditions>
+																												<MultiDataTrigger.Setters>
+																													<Setter Property="Visibility" Value="Collapsed" />
+																												</MultiDataTrigger.Setters>
+																											</MultiDataTrigger>
+																										</Style.Triggers>
+																									</Style>
+																								</TextBlock.Style>
+																							</TextBlock>
+
+																							<TextBlock Margin="0,2,0,0">
+																								<Run Text="색적:" />
+																								<Run Text="{Binding Source.Info.ViewRange, Mode=OneWay}">
+																									<Run.Style>
+																										<Style TargetType="{x:Type Run}">
+																											<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																											<Style.Triggers>
+																												<DataTrigger Binding="{Binding Source.Info.ViewRange}" Value="0">
+																													<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																												</DataTrigger>
+																											</Style.Triggers>
+																										</Style>
+																									</Run.Style>
+																								</Run>
+																								<Run Foreground="#FF45A9A5">
+																									<Run.Style>
+																										<Style TargetType="{x:Type Run}">
+																											<Setter Property="Text" Value="{Binding Source.ImprovementStats.LoS, Mode=OneWay, StringFormat={}+{0:N2}}" />
+																											<Style.Triggers>
+																												<DataTrigger Binding="{Binding Source.ImprovementStats.LoS}" Value="0">
+																													<Setter Property="Text" Value="" />
+																												</DataTrigger>
+																											</Style.Triggers>
+																										</Style>
+																									</Run.Style>
+																								</Run>
+
+																								<TextBlock.Style>
+																									<Style TargetType="{x:Type TextBlock}">
+																										<Style.Triggers>
+																											<MultiDataTrigger>
+																												<MultiDataTrigger.Conditions>
+																													<Condition Binding="{Binding Source.Info.ViewRange}" Value="0" />
+																													<Condition Binding="{Binding Source.ImprovementStats.LoS}" Value="0" />
+																												</MultiDataTrigger.Conditions>
+																												<MultiDataTrigger.Setters>
+																													<Setter Property="Visibility" Value="Collapsed" />
+																												</MultiDataTrigger.Setters>
+																											</MultiDataTrigger>
+																										</Style.Triggers>
+																									</Style>
+																								</TextBlock.Style>
+																							</TextBlock>
+
+																							<TextBlock Margin="0,10,0,0">
+																								<Run Text="원정 보너스: +" />
+																								<Run Text="{Binding Source.Info.ExpeditionBonus, Mode=OneWay}">
+																									<Run.Style>
+																										<Style TargetType="{x:Type Run}">
+																											<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																											<Style.Triggers>
+																												<DataTrigger Binding="{Binding Source.Info.ExpeditionBonus}" Value="0">
+																													<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																												</DataTrigger>
+																											</Style.Triggers>
+																										</Style>
+																									</Run.Style>
+																								</Run>
+																								<Run Foreground="#FF45A9A5">
+																									<Run.Style>
+																										<Style TargetType="{x:Type Run}">
+																											<Setter Property="Text" Value="{Binding Source.ImprovementStats.ExpeditionBonus, Mode=OneWay, StringFormat={}+{0:N2}}" />
+																											<Style.Triggers>
+																												<DataTrigger Binding="{Binding Source.ImprovementStats.ExpeditionBonus}" Value="0">
+																													<Setter Property="Text" Value="" />
+																												</DataTrigger>
+																											</Style.Triggers>
+																										</Style>
+																									</Run.Style>
+																								</Run>
+																								<Run Text="%" />
+
+																								<TextBlock.Style>
+																									<Style TargetType="{x:Type TextBlock}">
+																										<Style.Triggers>
+																											<MultiDataTrigger>
+																												<MultiDataTrigger.Conditions>
+																													<Condition Binding="{Binding Source.Info.ExpeditionBonus}" Value="0" />
+																													<Condition Binding="{Binding Source.ImprovementStats.ExpeditionBonus}" Value="0" />
+																												</MultiDataTrigger.Conditions>
+																												<MultiDataTrigger.Setters>
+																													<Setter Property="Visibility" Value="Collapsed" />
+																												</MultiDataTrigger.Setters>
+																											</MultiDataTrigger>
+																										</Style.Triggers>
+																									</Style>
+																								</TextBlock.Style>
+																							</TextBlock>
+																							<TextBlock Margin="0,10,0,0">
+																								<Run Text="포대형 특화 계수: 포격전 화력 x (" />
+																								<Run Text="{Binding Source.Info.TurrentEfficacy, Mode=OneWay, StringFormat={}{0:N2}}">
+																									<Run.Style>
+																										<Style TargetType="{x:Type Run}">
+																											<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																											<Style.Triggers>
+																												<DataTrigger Binding="{Binding Source.Info.TurrentEfficacy}" Value="0">
+																													<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																												</DataTrigger>
+																											</Style.Triggers>
+																										</Style>
+																									</Run.Style>
+																								</Run>
+																								<Run Foreground="#FF45A9A5">
+																									<Run.Style>
+																										<Style TargetType="{x:Type Run}">
+																											<Setter Property="Text" Value="{Binding Source.ImprovementStats.TurrentEfficacy, Mode=OneWay, StringFormat={}+{0:N2}}" />
+																											<Style.Triggers>
+																												<DataTrigger Binding="{Binding Source.ImprovementStats.TurrentEfficacy}" Value="0">
+																													<Setter Property="Text" Value="" />
+																												</DataTrigger>
+																											</Style.Triggers>
+																										</Style>
+																									</Run.Style>
+																								</Run>
+																								<Run Text=")" />
+
+																								<TextBlock.Style>
+																									<Style TargetType="{x:Type TextBlock}">
+																										<Style.Triggers>
+																											<MultiDataTrigger>
+																												<MultiDataTrigger.Conditions>
+																													<Condition Binding="{Binding Source.Info.TurrentEfficacy}" Value="0" />
+																													<Condition Binding="{Binding Source.ImprovementStats.TurrentEfficacy}" Value="0" />
+																												</MultiDataTrigger.Conditions>
+																												<MultiDataTrigger.Setters>
+																													<Setter Property="Visibility" Value="Collapsed" />
+																												</MultiDataTrigger.Setters>
+																											</MultiDataTrigger>
+																										</Style.Triggers>
+																									</Style>
+																								</TextBlock.Style>
+																							</TextBlock>
+
+																							<TextBlock Margin="0,10,0,0">
+																								<Run Text="항속거리:" />
+																								<Run Text="{Binding Source.Info.Distance, Mode=OneWay}">
+																									<Run.Style>
+																										<Style TargetType="{x:Type Run}">
+																											<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																											<Style.Triggers>
+																												<DataTrigger Binding="{Binding Source.Info.Distance}" Value="0">
+																													<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																												</DataTrigger>
+																											</Style.Triggers>
+																										</Style>
+																									</Run.Style>
+																								</Run>
+
+																								<TextBlock.Style>
+																									<Style TargetType="{x:Type TextBlock}">
+																										<Style.Triggers>
+																											<DataTrigger Binding="{Binding Source.Info.IsNumerable}" Value="False">
+																												<Setter Property="Visibility" Value="Collapsed" />
+																											</DataTrigger>
+																										</Style.Triggers>
+																									</Style>
+																								</TextBlock.Style>
+																							</TextBlock>
+																							<TextBlock Margin="0,2,0,0">
+																								<Run Text="배치비용:" />
+																								<Run Text="{Binding Source.Info.AirBaseCost, Mode=OneWay}">
+																									<Run.Style>
+																										<Style TargetType="{x:Type Run}">
+																											<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																											<Style.Triggers>
+																												<DataTrigger Binding="{Binding Source.Info.AirBaseCost}" Value="0">
+																													<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																												</DataTrigger>
+																											</Style.Triggers>
+																										</Style>
+																									</Run.Style>
+																								</Run>
+
+																								<TextBlock.Style>
+																									<Style TargetType="{x:Type TextBlock}">
+																										<Style.Triggers>
+																											<DataTrigger Binding="{Binding Source.Info.IsNumerable}" Value="False">
+																												<Setter Property="Visibility" Value="Collapsed" />
+																											</DataTrigger>
+																										</Style.Triggers>
+																									</Style>
+																								</TextBlock.Style>
+																							</TextBlock>
+																						</StackPanel>
+																					</StackPanel.ToolTip>
 																				</StackPanel>
 
 																				<Grid x:Name="PlaneStatus" Visibility="Collapsed">

--- a/source/Grabacr07.KanColleViewer/Views/Contents/Fleets.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Contents/Fleets.xaml
@@ -86,7 +86,8 @@
 					<TextBlock Grid.Column="2"
 							   Grid.Row="0"
 							   Grid.RowSpan="2"
-							   Margin="4,0,10,0">
+							   Margin="4,0,10,0"
+							   ToolTipService.ShowDuration="600000">
 						<Run Text="{Binding Ship.Info.Name, Mode=OneWay}"
 							 FontSize="22"
 							 Style="{DynamicResource EmphaticTextElementStyleKey}" />
@@ -97,6 +98,9 @@
 									<ColumnDefinition Width="Auto" SharedSizeGroup="NameTooltipCol1" />
 									<ColumnDefinition Width="Auto" />
 									<ColumnDefinition Width="Auto" SharedSizeGroup="NameTooltipCol2" />
+
+									<ColumnDefinition Width="Auto" />
+									<ColumnDefinition Width="Auto" />
 								</Grid.ColumnDefinitions>
 								<Grid.RowDefinitions>
 									<RowDefinition Height="Auto" />
@@ -106,6 +110,7 @@
 									<RowDefinition Height="Auto" />
 									<RowDefinition Height="Auto" />
 									<RowDefinition Height="Auto" />
+									<RowDefinition Height="*" />
 								</Grid.RowDefinitions>
 
 								<TextBlock Grid.Column="0"
@@ -122,113 +127,113 @@
 								<TextBlock Grid.Column="0"
 										   Grid.Row="1"
 										   Margin="0,2,5,0"
-										   FontSize="15"
+										   FontSize="12"
 										   Text="내구" />
 								<TextBlock Grid.Column="1"
 										   Grid.Row="1"
 										   Margin="0,2,5,0"
 										   Style="{DynamicResource EmphaticTextStyleKey}"
-										   FontSize="15"
+										   FontSize="12"
 										   TextAlignment="Right"
 										   Text="{Binding Ship.HP.Maximum, Mode=OneWay}" />
 								<TextBlock Grid.Column="2"
 										   Grid.Row="1"
 										   Margin="10,2,5,0"
-										   FontSize="15"
+										   FontSize="12"
 										   Text="화력" />
 								<TextBlock Grid.Column="3"
 										   Grid.Row="1"
 										   Margin="0,2,5,0"
 										   Style="{DynamicResource EmphaticTextStyleKey}"
-										   FontSize="15"
+										   FontSize="12"
 										   TextAlignment="Right"
 										   Text="{Binding Ship.SumFirepower, Mode=OneWay}" />
 
 								<TextBlock Grid.Column="0"
 										   Grid.Row="2"
 										   Margin="0,2,5,0"
-										   FontSize="15"
+										   FontSize="12"
 										   Text="장갑" />
 								<TextBlock Grid.Column="1"
 										   Grid.Row="2"
 										   Margin="0,2,5,0"
 										   Style="{DynamicResource EmphaticTextStyleKey}"
-										   FontSize="15"
+										   FontSize="12"
 										   TextAlignment="Right"
 										   Text="{Binding Ship.SumArmor, Mode=OneWay}" />
 								<TextBlock Grid.Column="2"
 										   Grid.Row="2"
 										   Margin="10,2,5,0"
-										   FontSize="15"
+										   FontSize="12"
 										   Text="뇌장" />
 								<TextBlock Grid.Column="3"
 										   Grid.Row="2"
 										   Margin="0,2,5,0"
 										   Style="{DynamicResource EmphaticTextStyleKey}"
-										   FontSize="15"
+										   FontSize="12"
 										   TextAlignment="Right"
 										   Text="{Binding Ship.SumTorpedo, Mode=OneWay}" />
 
 								<TextBlock Grid.Column="0"
 										   Grid.Row="3"
 										   Margin="0,2,5,0"
-										   FontSize="15"
+										   FontSize="12"
 										   Text="회피" />
 								<TextBlock Grid.Column="1"
 										   Grid.Row="3"
 										   Margin="0,2,5,0"
 										   Style="{DynamicResource EmphaticTextStyleKey}"
-										   FontSize="15"
+										   FontSize="12"
 										   TextAlignment="Right"
 										   Text="{Binding Ship.SumEvade, Mode=OneWay}" />
 								<TextBlock Grid.Column="2"
 										   Grid.Row="3"
 										   Margin="10,2,5,0"
-										   FontSize="15"
+										   FontSize="12"
 										   Text="대공" />
 								<TextBlock Grid.Column="3"
 										   Grid.Row="3"
 										   Margin="0,2,5,0"
 										   Style="{DynamicResource EmphaticTextStyleKey}"
-										   FontSize="15"
+										   FontSize="12"
 										   TextAlignment="Right"
 										   Text="{Binding Ship.SumAA, Mode=OneWay}" />
 
 								<TextBlock Grid.Column="0"
 										   Grid.Row="4"
 										   Margin="0,2,5,0"
-										   FontSize="15"
+										   FontSize="12"
 										   Text="탑재" />
 								<TextBlock Grid.Column="1"
 										   Grid.Row="4"
 										   Margin="0,2,5,0"
 										   Style="{DynamicResource EmphaticTextStyleKey}"
-										   FontSize="15"
+										   FontSize="12"
 										   TextAlignment="Right"
 										   Text="{Binding Ship.SumCarry, Mode=OneWay}" />
 								<TextBlock Grid.Column="2"
 										   Grid.Row="4"
 										   Margin="10,2,5,0"
-										   FontSize="15"
+										   FontSize="12"
 										   Text="대잠" />
 								<TextBlock Grid.Column="3"
 										   Grid.Row="4"
 										   Margin="0,2,5,0"
 										   Style="{DynamicResource EmphaticTextStyleKey}"
-										   FontSize="15"
+										   FontSize="12"
 										   TextAlignment="Right"
 										   Text="{Binding Ship.SumASW, Mode=OneWay}" />
 
 								<TextBlock Grid.Column="0"
 										   Grid.Row="5"
 										   Margin="0,2,5,0"
-										   FontSize="15"
+										   FontSize="12"
 										   Text="속력" />
 								<TextBlock Grid.Column="1"
 										   Grid.Row="5"
 										   Margin="0,2,5,0"
 										   Style="{DynamicResource EmphaticTextStyleKey}"
-										   FontSize="15"
+										   FontSize="12"
 										   TextAlignment="Center">
 									<Run>
 										<Run.Style>
@@ -258,26 +263,26 @@
 								<TextBlock Grid.Column="2"
 										   Grid.Row="5"
 										   Margin="10,2,5,0"
-										   FontSize="15"
+										   FontSize="12"
 										   Text="색적" />
 								<TextBlock Grid.Column="3"
 										   Grid.Row="5"
 										   Margin="0,2,5,0"
 										   Style="{DynamicResource EmphaticTextStyleKey}"
-										   FontSize="15"
+										   FontSize="12"
 										   TextAlignment="Right"
 										   Text="{Binding Ship.SumLOS, Mode=OneWay}" />
 
 								<TextBlock Grid.Column="0"
 										   Grid.Row="6"
 										   Margin="0,2,5,0"
-										   FontSize="15"
+										   FontSize="12"
 										   Text="사거리" />
 								<TextBlock Grid.Column="1"
 										   Grid.Row="6"
 										   Margin="0,2,5,0"
 										   Style="{DynamicResource EmphaticTextStyleKey}"
-										   FontSize="15"
+										   FontSize="12"
 										   TextAlignment="Center">
 									<Run>
 										<Run.Style>
@@ -304,15 +309,275 @@
 								<TextBlock Grid.Column="2"
 										   Grid.Row="6"
 										   Margin="10,2,5,0"
-										   FontSize="15"
+										   FontSize="12"
 										   Text="운" />
 								<TextBlock Grid.Column="3"
 										   Grid.Row="6"
 										   Margin="0,2,5,0"
 										   Style="{DynamicResource EmphaticTextStyleKey}"
-										   FontSize="15"
+										   FontSize="12"
 										   TextAlignment="Right"
 										   Text="{Binding Ship.Luck.Current, Mode=OneWay}" />
+
+								<Rectangle Grid.Column="4"
+										   Grid.Row="1"
+										   Grid.RowSpan="7"
+										   Width="1"
+										   Margin="4,3"
+										   Style="{DynamicResource SeparatorRectangleStyleKey}" />
+
+								<Grid Grid.Column="5"
+									  Grid.Row="1"
+									  Grid.RowSpan="7"
+									  Margin="5,0,0,0">
+									<Grid.ColumnDefinitions>
+										<ColumnDefinition Width="Auto" SharedSizeGroup="NameTooltipCapCol1" />
+										<ColumnDefinition Width="Auto" SharedSizeGroup="NameTooltipCapCol2" />
+										<ColumnDefinition Width="*" />
+									</Grid.ColumnDefinitions>
+									<Grid.RowDefinitions>
+										<RowDefinition Height="Auto" />
+										<RowDefinition Height="Auto" />
+										<RowDefinition Height="Auto" />
+
+										<RowDefinition Height="Auto" />
+										<RowDefinition Height="Auto" />
+										<RowDefinition Height="Auto" />
+
+										<RowDefinition Height="Auto" />
+										<RowDefinition Height="Auto" />
+
+										<RowDefinition Height="Auto" />
+									</Grid.RowDefinitions>
+
+									<TextBlock Margin="0,2,5,0"
+											   Grid.Column="0"
+											   Grid.Row="0"
+											   Grid.ColumnSpan="2"
+											   FontSize="12"
+											   Text="적이 통상함대일 때" />
+									<TextBlock Margin="10,2,5,0"
+											   Grid.Column="0"
+											   Grid.Row="1"
+											   FontSize="12"
+											   Text="주간 화력:" />
+									<TextBlock Margin="10,2,5,0"
+											   Grid.Column="0"
+											   Grid.Row="2"
+											   FontSize="12"
+											   Text="야전 화력:" />
+
+									<TextBlock Margin="0,2,5,0"
+											   Grid.Column="1"
+											   Grid.Row="1"
+											   Foreground="{DynamicResource ActiveForegroundBrushKey}"
+											   TextAlignment="Left"
+											   FontSize="12">
+										<Run Text="{Binding Ship.DmgCap_Day, Mode=OneWay}">
+											<Run.Style>
+												<Style TargetType="Run">
+													<Style.Triggers>
+														<DataTrigger Binding="{Binding Ship.DmgCap_DayOver, Mode=OneWay}" Value="True">
+															<Setter Property="Foreground" Value="Gold" />
+															<Setter Property="FontWeight" Value="Bold" />
+														</DataTrigger>
+													</Style.Triggers>
+												</Style>
+											</Run.Style>
+										</Run>
+										<Run Text="/"
+											 FontSize="11"
+											 Foreground="{DynamicResource ForegroundBrushKey}" />
+										<Run Text="{Binding Ship.DmgCap_Day_HeadOn, Mode=OneWay}">
+											<Run.Style>
+												<Style TargetType="Run">
+													<Style.Triggers>
+														<DataTrigger Binding="{Binding Ship.DmgCap_Day_HeadOnOver, Mode=OneWay}" Value="True">
+															<Setter Property="Foreground" Value="Gold" />
+															<Setter Property="FontWeight" Value="Bold" />
+														</DataTrigger>
+													</Style.Triggers>
+												</Style>
+											</Run.Style>
+										</Run>
+									</TextBlock>
+									<TextBlock Margin="0,2,5,0"
+											   Grid.Column="1"
+											   Grid.Row="2"
+											   Foreground="{DynamicResource ActiveForegroundBrushKey}"
+											   TextAlignment="Left"
+											   FontSize="12">
+										<Run Text="{Binding Ship.DmgCap_Night, Mode=OneWay}">
+											<Run.Style>
+												<Style TargetType="Run">
+													<Style.Triggers>
+														<DataTrigger Binding="{Binding Ship.DmgCap_NightOver, Mode=OneWay}" Value="True">
+															<Setter Property="Foreground" Value="Gold" />
+															<Setter Property="FontWeight" Value="Bold" />
+														</DataTrigger>
+													</Style.Triggers>
+												</Style>
+											</Run.Style>
+										</Run>
+										<Run Text="/"
+											 FontSize="11"
+											 Foreground="{DynamicResource ForegroundBrushKey}" />
+										<Run Text="{Binding Ship.DmgCap_Night_HeadOn, Mode=OneWay}">
+											<Run.Style>
+												<Style TargetType="Run">
+													<Style.Triggers>
+														<DataTrigger Binding="{Binding Ship.DmgCap_Night_HeadOnOver, Mode=OneWay}" Value="True">
+															<Setter Property="Foreground" Value="Gold" />
+															<Setter Property="FontWeight" Value="Bold" />
+														</DataTrigger>
+													</Style.Triggers>
+												</Style>
+											</Run.Style>
+										</Run>
+									</TextBlock>
+
+									<TextBlock Margin="0,10,5,0"
+											   Grid.Column="0"
+											   Grid.Row="3"
+											   Grid.ColumnSpan="2"
+											   FontSize="12"
+											   Text="적이 연합함대일 때" />
+									<TextBlock Margin="10,2,5,0"
+											   Grid.Column="0"
+											   Grid.Row="4"
+											   FontSize="12"
+											   Text="주간 화력:" />
+									<TextBlock Margin="10,2,5,0"
+											   Grid.Column="0"
+											   Grid.Row="5"
+											   FontSize="12"
+											   Text="야전 화력:" />
+
+									<TextBlock Margin="0,2,5,0"
+											   Grid.Column="1"
+											   Grid.Row="4"
+											   Foreground="{DynamicResource ActiveForegroundBrushKey}"
+											   TextAlignment="Left"
+											   FontSize="12">
+										<Run Text="{Binding Ship.DmgCap_Combined_Day, Mode=OneWay}">
+											<Run.Style>
+												<Style TargetType="Run">
+													<Style.Triggers>
+														<DataTrigger Binding="{Binding Ship.DmgCap_Combined_DayOver, Mode=OneWay}" Value="True">
+															<Setter Property="Foreground" Value="Gold" />
+															<Setter Property="FontWeight" Value="Bold" />
+														</DataTrigger>
+													</Style.Triggers>
+												</Style>
+											</Run.Style>
+										</Run>
+										<Run Text="/"
+											 FontSize="11"
+											 Foreground="{DynamicResource ForegroundBrushKey}" />
+										<Run Text="{Binding Ship.DmgCap_Combined_Day_HeadOn, Mode=OneWay}">
+											<Run.Style>
+												<Style TargetType="Run">
+													<Style.Triggers>
+														<DataTrigger Binding="{Binding Ship.DmgCap_Combined_Day_HeadOnOver, Mode=OneWay}" Value="True">
+															<Setter Property="Foreground" Value="Gold" />
+															<Setter Property="FontWeight" Value="Bold" />
+														</DataTrigger>
+													</Style.Triggers>
+												</Style>
+											</Run.Style>
+										</Run>
+									</TextBlock>
+									<TextBlock Margin="0,2,5,0"
+											   Grid.Column="1"
+											   Grid.Row="5"
+											   Foreground="{DynamicResource ActiveForegroundBrushKey}"
+											   TextAlignment="Left"
+											   FontSize="12">
+										<Run Text="{Binding Ship.DmgCap_Combined_Night, Mode=OneWay}">
+											<Run.Style>
+												<Style TargetType="Run">
+													<Style.Triggers>
+														<DataTrigger Binding="{Binding Ship.DmgCap_Combined_NightOver, Mode=OneWay}" Value="True">
+															<Setter Property="Foreground" Value="Gold" />
+															<Setter Property="FontWeight" Value="Bold" />
+														</DataTrigger>
+													</Style.Triggers>
+												</Style>
+											</Run.Style>
+										</Run>
+										<Run Text="/"
+											 FontSize="11"
+											 Foreground="{DynamicResource ForegroundBrushKey}" />
+										<Run Text="{Binding Ship.DmgCap_Combined_Night_HeadOn, Mode=OneWay}">
+											<Run.Style>
+												<Style TargetType="Run">
+													<Style.Triggers>
+														<DataTrigger Binding="{Binding Ship.DmgCap_Combined_Night_HeadOnOver, Mode=OneWay}" Value="True">
+															<Setter Property="Foreground" Value="Gold" />
+															<Setter Property="FontWeight" Value="Bold" />
+														</DataTrigger>
+													</Style.Triggers>
+												</Style>
+											</Run.Style>
+										</Run>
+									</TextBlock>
+
+
+									<TextBlock Margin="0,10,5,0"
+											   Grid.Column="0"
+											   Grid.Row="6"
+											   Grid.ColumnSpan="2"
+											   FontSize="12"
+											   Text="지원함대로 사용할 때" />
+									<TextBlock Margin="10,2,5,0"
+											   Grid.Column="0"
+											   Grid.Row="7"
+											   FontSize="12"
+											   Text="화력:" />
+
+									<TextBlock Margin="0,2,5,0"
+											   Grid.Column="1"
+											   Grid.Row="7"
+											   Foreground="{DynamicResource ActiveForegroundBrushKey}"
+											   TextAlignment="Left"
+											   FontSize="12">
+										<Run Text="{Binding Ship.DmgCap_Support, Mode=OneWay}">
+											<Run.Style>
+												<Style TargetType="Run">
+													<Style.Triggers>
+														<DataTrigger Binding="{Binding Ship.DmgCap_SupportOver, Mode=OneWay}" Value="True">
+															<Setter Property="Foreground" Value="Gold" />
+															<Setter Property="FontWeight" Value="Bold" />
+														</DataTrigger>
+													</Style.Triggers>
+												</Style>
+											</Run.Style>
+										</Run>
+										<Run Text="/"
+											 FontSize="11"
+											 Foreground="{DynamicResource ForegroundBrushKey}" />
+										<Run Text="{Binding Ship.DmgCap_Support_HeadOn, Mode=OneWay}">
+											<Run.Style>
+												<Style TargetType="Run">
+													<Style.Triggers>
+														<DataTrigger Binding="{Binding Ship.DmgCap_Support_HeadOnOver, Mode=OneWay}" Value="True">
+															<Setter Property="Foreground" Value="Gold" />
+															<Setter Property="FontWeight" Value="Bold" />
+														</DataTrigger>
+													</Style.Triggers>
+												</Style>
+											</Run.Style>
+										</Run>
+									</TextBlock>
+
+									<TextBlock Grid.Row="8"
+											   Grid.ColumnSpan="3"
+											   Style="{DynamicResource DefaultTextStyleKey}"
+											   TextWrapping="WrapWithOverflow"
+											   Margin="0,10,5,0">
+										※ 수치는 "동항전 / 반항전"입니다.
+									</TextBlock>
+								</Grid>
 							</Grid>
 						</TextBlock.ToolTip> 
 					</TextBlock>

--- a/source/Grabacr07.KanColleWrapper/Homeport.cs
+++ b/source/Grabacr07.KanColleWrapper/Homeport.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -83,6 +83,7 @@ namespace Grabacr07.KanColleWrapper
 				this.Repairyard.Update(x.Data.api_ndock);
 				this.Organization.Update(x.Data.api_deck_port);
 				this.Organization.Combined = x.Data.api_combined_flag != 0;
+				this.Organization.CombinedType = (CombinedFleetType)x.Data.api_combined_flag;
 				this.Materials.Update(x.Data.api_material);
 			});
 			proxy.api_get_member_basic.TryParse<kcsapi_basic>().Subscribe(x => this.UpdateAdmiral(x.Data));

--- a/source/Grabacr07.KanColleWrapper/Internal/Extensions.cs
+++ b/source/Grabacr07.KanColleWrapper/Internal/Extensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -10,7 +10,11 @@ namespace Grabacr07.KanColleWrapper.Internal
 	{
 		public static string GetResponseAsJson(this Session session)
 		{
-			return session.Response.BodyAsString.Replace("svdata=", "");
+			// return session.Response.BodyAsString.Replace("svdata=", "");
+			var body = session.Response.BodyAsString;
+			return body.StartsWith("svdata=")
+				? body.Substring(7)
+				: body;
 		}
 
 		/// <summary>

--- a/source/Grabacr07.KanColleWrapper/Internal/SlotItemExtensions.cs
+++ b/source/Grabacr07.KanColleWrapper/Internal/SlotItemExtensions.cs
@@ -1,0 +1,268 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Grabacr07.KanColleWrapper.Models;
+
+namespace Grabacr07.KanColleWrapper.Internal
+{
+	internal static class SlotItemExtensions
+	{
+		/// <summary>
+		/// 개수에 의한 추가 수치를 계산합니다.
+		/// </summary>
+		/// <param name="item"></param>
+		/// <returns></returns>
+		internal static SlotItemStat GetImprovementBonus(this SlotItem item)
+		{
+			var output = new SlotItemStat();
+			var id = item.Info.Id;
+			var sqLevel = Math.Sqrt(item.Level);
+			var level = item.Level;
+
+			switch (item.Info.IconType)
+			{
+				// 전투기 계열 (대공 x0.2) - 함상전투기, 수상전투기, 국지전투기, 육군전투기
+				case SlotItemIconType.Fighter:
+				case SlotItemIconType.SeaplaneFighter:
+				case SlotItemIconType.InterceptorFighter:
+				case SlotItemIconType.LandBasedFighter:
+					output.AA = level * 0.2;
+					break;
+
+				// 폭격기 (대공 x0.25) - 아직까진 개수 되는 것이 폭전밖에 없으므로 대충 작성
+				case SlotItemIconType.DiveBomber:
+					output.AA = level * 0.25;
+					break;
+
+				// 정찰기 (색적 √x1.2)
+				case SlotItemIconType.ReconPlane:
+					output.LoS = sqLevel * 1.2;
+					break;
+
+				// 소구경 주포, 중구경 주포 (화력, 명중 √x1.0)
+				case SlotItemIconType.MainCanonLight:
+				case SlotItemIconType.MainCanonMedium:
+					output.Firepower = sqLevel * 1.0;
+					output.Hit = sqLevel * 1.0;
+					break;
+
+				// 대구경 주포 (화력 √x1.5, 야전화력 √x1.0, 명중 √x1.0)
+				case SlotItemIconType.MainCanonHeavy:
+					output.Firepower = sqLevel * 1.5;
+					output.NightFirepower = sqLevel * 1.0;
+					output.Hit = sqLevel * 1.0;
+					break;
+
+				// 부포 (화력, 명중 √x1.0) - 노란색 아이콘
+				case SlotItemIconType.SecondaryCanon:
+					// 15.5cm 삼연장포(부포), 15.5cm 삼연장부포改
+					// 화력 x0.3, 야전 화력 √x1.0
+					if (new int[] { 12, 234 }.Contains(id))
+					{
+						output.Firepower = level * 0.3;
+						output.NightFirepower = sqLevel * 1.0;
+						output.Hit = sqLevel * 1.0;
+					}
+					// 그 외 부포
+					else
+					{
+						// 화력, 명중 √x1.0
+						output.Firepower = sqLevel * 1.0;
+						output.Hit = sqLevel * 1.0;
+					}
+					break;
+
+				// 고각포 (화력, 명중 √x1.0, 대공 √x0.7, 함대방공 √x3.0)
+				case SlotItemIconType.HighAngleGun:
+					// 12.7cm 연장고각포, 8cm 고각포, 8cm 고각포改+증설기총
+					// 화력 x0.2, 야전화력 √x1.0, 대공 √x0.7, 함대방공 √x2.0
+					if (new int[] { 10, 66, 220 }.Contains(id))
+					{
+						output.Firepower = level * 0.2;
+						output.NightFirepower = sqLevel * 1.0;
+						output.AA = sqLevel * 0.7;
+						output.FleetAA = sqLevel * 2.0;
+					}
+					// 그 외 고각포
+					else
+					{
+						output.Firepower = sqLevel * 1.0;
+						output.Hit = sqLevel * 1.0;
+						output.AA = sqLevel * 0.7;
+						output.FleetAA = sqLevel * 3.0;
+					}
+					break;
+
+				// 어뢰 (뇌장 √x1.2, 야전 화력 √x1.0, 뇌격 명중 √x2.0)
+				case SlotItemIconType.Torpedo:
+					output.Torpedo = sqLevel * 1.2;
+					output.NightFirepower = sqLevel * 1.0;
+					output.TorpedoHit = sqLevel * 2.0;
+					break;
+
+				// 전파탐신기
+				// - 대공전탐:   색적 √x1.25, 명중 √x1.0, 함대방공 √x1.5
+				// - 대수상전탐: 색적 √x1.0, 명중 √x2.0
+				// - 잠수함전탐: ???
+				case SlotItemIconType.Rader:
+					// 잠수함전탐
+					// ???
+					if (new int[] { 210, 211 }.Contains(id))
+					{
+					}
+					// 대공전탐
+					// 색적 √x1.25, 명중 √x1.0, 함대방공 √x1.5
+					else if (new int[] { 27, 30, 32, 89, 106, 124, 142, 278, 279 }.Contains(id))
+					{
+						output.LoS = sqLevel * 1.25;
+						output.Hit = sqLevel * 1.0;
+						output.FleetAA = sqLevel * 1.5;
+					}
+					// 대수상전탐
+					// 색적 √x1.0, 명중 √x2.0
+					else
+					{
+						output.LoS = sqLevel * 1.0;
+						output.Hit = sqLevel * 2.0;
+					}
+					break;
+
+				// 소나 (화력 √x0.75, 대잠 √x6÷9, 대잠 명중 √x1.3, 뇌격 명중 √x1.5)
+				case SlotItemIconType.Soner:
+					output.Firepower = sqLevel * 0.75;
+					output.ASW = sqLevel * 6.0 / 9.0;
+					output.ASWHit = sqLevel * 1.3;
+					output.TorpedoHit = sqLevel * 1.5;
+					break;
+
+				// 폭뢰/폭뢰투사기
+				// - 폭뢰:       대잠 √x6÷9
+				// - 폭뢰투사기: 대잠 √x6÷9, 화력 √x0.75
+				case SlotItemIconType.ASW:
+					// 폭뢰
+					// 대잠 √x6÷9
+					if (new int[] { 226, 227 }.Contains(id))
+					{
+						output.ASW = sqLevel * 6.0 / 9.0;
+					}
+					// 폭뢰투사기
+					// 대잠 √x6÷9, 화력 √x0.75
+					else
+					{
+						output.Firepower = sqLevel * 0.75;
+						output.ASW = sqLevel * 6.0 / 9.0;
+					}
+					break;
+
+				// 철갑탄 (화력, 명중 √x1.0)
+				case SlotItemIconType.APShell:
+					output.Firepower = sqLevel * 1.0;
+					output.Hit = sqLevel * 1.0;
+					break;
+
+				// 대공기총 (대공 √x0.7, 화력 √x1.0, 뇌장 √x1.2, 뇌장 명중 ???)
+				case SlotItemIconType.AAGun:
+					output.Firepower = sqLevel * 1.0;
+					output.AA = sqLevel * 0.7;
+					output.Torpedo = sqLevel * 1.2;
+					break;
+
+				// 고사장치 (화력 √x1.0, 명중 √x1.0, 대공 √x0.7, 함대방공 √x2.0)
+				case SlotItemIconType.AntiAircraftFireDirector:
+					output.Firepower = sqLevel * 1.0;
+					output.Hit = sqLevel * 1.0;
+					output.AA = sqLevel * 0.7;
+					output.FleetAA = sqLevel * 2.0;
+					break;
+
+				// 기관부강화 (회피 √x1.5)
+				case SlotItemIconType.EngineImprovement:
+					output.Evade = sqLevel * 1.5;
+					break;
+
+				// 증설벌지
+				// - 중형벌지 : 장갑 x0.2
+				// - 대형벌지 : 장갑 x0.3
+				case SlotItemIconType.AntiTorpedoBulge:
+					// 중형벌지
+					// 장갑 x0.2
+					if (new int[] { 72, 203 }.Contains(id))
+					{
+						output.Armor = level * 0.2;
+					}
+					// 대형벌지
+					// 장갑 x0.3
+					else
+					{
+						output.Armor = level * 0.3;
+					}
+					break;
+
+				// 탐조등 (화력 √x1.0, 피탄확률 ???, 적 컷인 확률 ???)
+				case SlotItemIconType.Searchlight:
+					output.Firepower = sqLevel * 1.0;
+					break;
+
+				// 수상폭격기 (폭장 x0.2, 색적 √x1.15)
+				// 수상정찰기 (색적 √x1.2)
+				case SlotItemIconType.ReconSeaplane:
+					// 수상폭격기
+					// 폭장 x0.2, 색적 √x1.15
+					if (new int[] { 26, 79, 237 }.Contains(id))
+					{
+						output.Bomb = level * 0.2;
+						output.LoS = sqLevel * 1.15;
+					}
+					// 수상정찰기
+					// 색적 √x1.2
+					else
+					{
+						output.LoS = sqLevel * 1.2;
+					}
+					break;
+
+				// 상륙정, 내화정 (화력 √x1.0)
+				// - 대발동정:         원정 보수 x0.05, 포대 특효 x0.04
+				// - 대발동정(육전대): 원정 보수 x0.02, 포대 특효 x0.044
+				// - 특대발동정:       원정 보수 x0.05
+				// - 2식 내화정:       원정 보수 x0.01, 포대 특효 x0.08
+				case SlotItemIconType.LandingCraft:
+				case SlotItemIconType.AmphibiousLandingCraft:
+					output.Firepower = sqLevel * 1.0;
+
+					// 대발동정
+					// 원정 보수 x0.05, 포대 특효 x0.04
+					if (id == 68)
+					{
+						output.ExpeditionBonus = level * 0.05;
+						output.TurrentEfficacy = level * 0.04;
+					}
+					// 대발동정(육전대)
+					// 원정 보수 x0.02, 포대 특효 x0.044
+					else if (id == 166)
+					{
+						output.ExpeditionBonus = level * 0.02;
+						output.TurrentEfficacy = level * 0.044;
+					}
+					// 특대발동정
+					// 원정 보수 x0.05
+					else if (id == 193)
+					{
+						output.ExpeditionBonus = level * 0.05;
+					}
+					// 2식 내화정
+					// 원정 보수 x0.01, 포대 특효 x0.08
+					else if (id == 167)
+					{
+						output.ExpeditionBonus = level * 0.01;
+						output.TurrentEfficacy = level * 0.08;
+					}
+					break;
+			}
+			return output;
+		}
+	}
+}

--- a/source/Grabacr07.KanColleWrapper/KanColleWrapper.csproj
+++ b/source/Grabacr07.KanColleWrapper/KanColleWrapper.csproj
@@ -122,6 +122,7 @@
     <Compile Include="Logger.cs" />
     <Compile Include="Models\ASWCalculator.cs" />
     <Compile Include="Models\CombinedFleet.cs" />
+    <Compile Include="Models\CombinedFleetType.cs" />
     <Compile Include="Models\FleetSpeed.cs" />
     <Compile Include="Models\FleetState.cs" />
     <Compile Include="Models\LogDataList.cs" />

--- a/source/Grabacr07.KanColleWrapper/KanColleWrapper.csproj
+++ b/source/Grabacr07.KanColleWrapper/KanColleWrapper.csproj
@@ -109,6 +109,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Internal\SlotItemExtensions.cs" />
     <Compile Include="Models\AirBase.cs" />
     <Compile Include="Models\AirSuperiorityPotential.cs" />
     <Compile Include="Annotations\DarkAttribute.cs" />
@@ -181,6 +182,7 @@
     <Compile Include="Models\ShipSituation.cs" />
     <Compile Include="Models\ShipSlot.cs" />
     <Compile Include="Models\SlotItemEquipType.cs" />
+    <Compile Include="Models\SlotItemStat.cs" />
     <Compile Include="Models\SlotItemType.cs" />
     <Compile Include="Models\TranslationType.cs" />
     <Compile Include="Models\ViewRange.cs" />

--- a/source/Grabacr07.KanColleWrapper/Models/CombinedFleetType.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/CombinedFleetType.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Grabacr07.KanColleWrapper.Models
+{
+	public enum CombinedFleetType
+	{
+		/// <summary>
+		/// 연합 없음
+		/// </summary>
+		None = 0,
+
+		/// <summary>
+		/// 기동연합부대
+		/// </summary>
+		CarrierTaskForce = 1,
+
+		/// <summary>
+		/// 수상타격부대
+		/// </summary>
+		SurfaceTaskForce = 2,
+
+		/// <summary>
+		/// 수송연합부대
+		/// </summary>
+		TransportEscort = 3,
+	}
+}

--- a/source/Grabacr07.KanColleWrapper/Models/Ship.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/Ship.cs
@@ -699,7 +699,13 @@ namespace Grabacr07.KanColleWrapper.Models
 
 			if (abyssalCombined)
 			{
-				if (fleetId == 2) return -5;
+				if (fleetId == 2)
+				{
+					if (type == CombinedFleetType.None)
+						return 5;
+					else
+						return -5;
+				}
 
 				switch (type)
 				{
@@ -711,6 +717,9 @@ namespace Grabacr07.KanColleWrapper.Models
 
 					case CombinedFleetType.TransportEscort:
 						return -5;
+
+					default:
+						return 5;
 				}
 			}
 			else

--- a/source/Grabacr07.KanColleWrapper/Models/Ship.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/Ship.cs
@@ -208,6 +208,21 @@ namespace Grabacr07.KanColleWrapper.Models
 		}
 		#endregion
 
+		#region Bauxite 変更通知プロパティ
+		public LimitedValue Bauxite
+			=> this.ExSlot != null
+				? new LimitedValue(
+						(this.Slots.Sum(x => x.Current) + this.ExSlot.Current) * 5,
+						(this.Slots.Sum(x => x.Maximum) + this.ExSlot.Maximum) * 5,
+						0
+					)
+				: new LimitedValue(
+						this.Slots.Sum(x => x.Current) * 5,
+						this.Slots.Sum(x => x.Maximum) * 5,
+						0
+					);
+		#endregion
+
 		#region Firepower 変更通知プロパティ
 
 		private ModernizableStatus _Firepower;
@@ -421,9 +436,10 @@ namespace Grabacr07.KanColleWrapper.Models
 
 		#endregion
 
-		#region UsedFuel UsedBull / FuelText BullText
+		#region UsedFuel UsedBull UsedBauxite / FuelText BullText
 		public int UsedFuel => (int)((this.Level <= 99 ? 1.0f : 0.85f) * (this.Fuel.Maximum - this.Fuel.Current));
 		public int UsedBull => (int)((this.Level <= 99 ? 1.0f : 0.85f) * (this.Bull.Maximum - this.Bull.Current));
+		public int UsedBauxite => this.Bauxite.Maximum - this.Bauxite.Current;
 
 		public string FuelText
 		{
@@ -538,13 +554,13 @@ namespace Grabacr07.KanColleWrapper.Models
 		public bool DmgCap_DayOver => this.DmgCap_Day >= 180;
 
 		public int DmgCap_Day_HeadOn => this.CalcDamageCap(0.8, 180, false);
-		public bool DmgCap_Day_HeadOnOver => this.DmgCap_Day >= 180;
+		public bool DmgCap_Day_HeadOnOver => this.DmgCap_Day_HeadOn >= 180;
 
 		public int DmgCap_Night => this.CalcDamageCap(1.0, 300, false);
-		public bool DmgCap_NightOver => this.DmgCap_Day >= 300;
+		public bool DmgCap_NightOver => this.DmgCap_Night >= 300;
 
 		public int DmgCap_Night_HeadOn => this.CalcDamageCap(0.8, 300, false);
-		public bool DmgCap_Night_HeadOnOver => this.DmgCap_Day >= 300;
+		public bool DmgCap_Night_HeadOnOver => this.DmgCap_Night_HeadOn >= 300;
 
 		//
 
@@ -552,21 +568,21 @@ namespace Grabacr07.KanColleWrapper.Models
 		public bool DmgCap_Combined_DayOver => this.DmgCap_Combined_Day >= 180;
 
 		public int DmgCap_Combined_Day_HeadOn => this.CalcDamageCap(0.8, 180, true);
-		public bool DmgCap_Combined_Day_HeadOnOver => this.DmgCap_Combined_Day >= 180;
+		public bool DmgCap_Combined_Day_HeadOnOver => this.DmgCap_Combined_Day_HeadOn >= 180;
 
 		public int DmgCap_Combined_Night => this.CalcDamageCap(1.0, 300, true);
-		public bool DmgCap_Combined_NightOver => this.DmgCap_Combined_Day >= 300;
+		public bool DmgCap_Combined_NightOver => this.DmgCap_Combined_Night >= 300;
 
 		public int DmgCap_Combined_Night_HeadOn => this.CalcDamageCap(0.8, 300, true);
-		public bool DmgCap_Combined_Night_HeadOnOver => this.DmgCap_Combined_Day >= 300;
+		public bool DmgCap_Combined_Night_HeadOnOver => this.DmgCap_Combined_Night_HeadOn >= 300;
 
 		//
 
 		public int DmgCap_Support => this.CalcDamageCap(1.0, 150, false, true);
-		public bool DmgCap_SupportOver => this.DmgCap_Day >= 150;
+		public bool DmgCap_SupportOver => this.DmgCap_Support >= 150;
 
 		public int DmgCap_Support_HeadOn => this.CalcDamageCap(0.8, 150, false, true);
-		public bool DmgCap_Support_HeadOnOver => this.DmgCap_Day >= 150;
+		public bool DmgCap_Support_HeadOnOver => this.DmgCap_Support_HeadOn >= 150;
 		#endregion
 
 		public int Range => this.Info.RawData.api_leng;
@@ -578,27 +594,6 @@ namespace Grabacr07.KanColleWrapper.Models
 				: this.Info.ShipType.Id == 7 && this.Speed == ShipSpeed.Slow ? SumASW >= 65 // 저속 경공모
 				: SumASW >= 100;
 
-		// 선제 대잠에 필요한 장비 추천
-		private string _RequireASW { get; set; } = null;
-		public string RequireASW
-		{
-			get
-			{
-				if (_RequireASW == null)
-				{
-					_RequireASW = "계산중...";
-
-					new Thread(() =>
-					{
-						this._RequireASW = ASWCalculator.GetASWTooltip(this);
-						this.RaisePropertyChanged(nameof(this.RequireASW));
-					}).Start();
-				}
-
-				return _RequireASW;
-			}
-		}
-
 		internal Ship(Homeport parent, kcsapi_ship2 rawData)
 			: base(rawData)
 		{
@@ -609,9 +604,6 @@ namespace Grabacr07.KanColleWrapper.Models
 		internal void Update(kcsapi_ship2 rawData)
 		{
 			this.UpdateRawData(rawData);
-
-			this._RequireASW = null;
-			this.RaisePropertyChanged(nameof(this.RequireASW));
 
 			this.Info = KanColleClient.Current.Master.Ships[rawData.api_ship_id] ?? ShipInfo.Dummy;
 			this.HP = new LimitedValue(this.RawData.api_nowhp, this.RawData.api_maxhp, 0);
@@ -752,6 +744,7 @@ namespace Grabacr07.KanColleWrapper.Models
 			double power = 0;
 
 			var shipType = this.Info.ShipType.Id;
+			// 항모계열
 			if (shipType == 7 || shipType == 11 || shipType == 18)
 			{
 				power =
@@ -759,20 +752,21 @@ namespace Grabacr07.KanColleWrapper.Models
 					(
 						(
 							this.Firepower.Current
-							+ this.EquippedItems.Sum(x => x.Item.Info.Firepower)
+							+ this.EquippedItems.Sum(x => x.Item.ResultFirepower)
 							+ this.Torpedo.Current
-							+ this.EquippedItems.Sum(x => x.Item.Info.Torpedo)
-							+ this.EquippedItems.Sum(x => (int)(x.Item.Info.Bomb * 1.3))
+							+ this.EquippedItems.Sum(x => x.Item.ResultTorpedo)
+							+ this.EquippedItems.Sum(x => (int)(x.Item.ResultBomb * 1.3))
 							+ (forSupport ? -1 : combinedFleetFactor)
 						)
 						* 1.5
 					)
 					+ 55;
 			}
+			// 그 외 함선
 			else
 			{
 				power = this.Firepower.Current
-					+ this.EquippedItems.Sum(x => x.Item.Info.Firepower)
+					+ this.EquippedItems.Sum(x => x.Item.ResultFirepower)
 					+ (forSupport ? -1 : combinedFleetFactor)
 					+ 5;
 			}

--- a/source/Grabacr07.KanColleWrapper/Models/SlotItem.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/SlotItem.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -22,6 +22,9 @@ namespace Grabacr07.KanColleWrapper.Models
 
 		public bool Locked => this.RawData.api_locked == 1;
 
+		public double AfterFirepower => this.Info.Firepower + this.GetImprovementBonus(false);
+		public double AfterTorpedo => this.Info.Torpedo + this.GetImprovementBonus(true);
+
 		internal SlotItem(kcsapi_slotitem rawData)
 			: base(rawData)
 		{
@@ -43,6 +46,43 @@ namespace Grabacr07.KanColleWrapper.Models
 			return $"ID = {this.Id}, Name = \"{this.Info.Name}\", Level = {this.Level}, Proficiency = {this.Proficiency}";
 		}
 
+		internal double GetImprovementBonusFactor(bool isTorpedo)
+		{
+			switch (this.Info.IconType)
+			{
+				case SlotItemIconType.MainCanonLight:
+				case SlotItemIconType.MainCanonMedium:
+				case SlotItemIconType.SecondaryCanon:
+				case SlotItemIconType.HighAngleGun:
+				case SlotItemIconType.APShell:
+				case SlotItemIconType.AntiAircraftFireDirector:
+				case SlotItemIconType.Searchlight:
+				case SlotItemIconType.LandingCraft:
+				case SlotItemIconType.AmphibiousLandingCraft:
+					if (!isTorpedo) return 1;
+					break;
+
+				case SlotItemIconType.MainCanonHeavy:
+					if (!isTorpedo) return 1.5;
+					break;
+
+				case SlotItemIconType.Torpedo:
+					if (isTorpedo) return 1.2;
+					break;
+
+				case SlotItemIconType.Soner:
+				case SlotItemIconType.ASW:
+					if (!isTorpedo) return 0.75;
+					break;
+
+				case SlotItemIconType.AAGun:
+					if (!isTorpedo) return 1;
+					return 1.2;
+			}
+			return 0;
+		}
+		internal double GetImprovementBonus(bool isTorpedo)
+			=> this.GetImprovementBonusFactor(isTorpedo) * Math.Sqrt(this.Level);
 
 		public static SlotItem Dummy { get; } = new SlotItem(new kcsapi_slotitem { api_slotitem_id = -1, });
 	}

--- a/source/Grabacr07.KanColleWrapper/Models/SlotItemInfo.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/SlotItemInfo.cs
@@ -73,9 +73,81 @@ namespace Grabacr07.KanColleWrapper.Models
 		public int ViewRange => this.RawData.api_saku;
 
 		/// <summary>
+		/// 원정 보너스 +%
+		/// </summary>
+		public int ExpeditionBonus
+		{
+			get
+			{
+				switch (this.Id)
+				{
+					case 68: // 대발동정
+						return 5;
+					case 166: // 대발동정(육전대)
+						return 2;
+					case 167: // 2식 내화정
+						return 1;
+					case 193: // 특대발동정
+						return 7;
+					default:
+						return 0;
+				}
+			}
+		}
+
+		/// <summary>
+		/// 포대형 특화 계수
+		/// </summary>
+		public double TurrentEfficacy
+		{
+			get
+			{
+				switch (this.Id)
+				{
+					case 68: // 대발동정
+						return 1.80;
+					case 166: // 대발동정(육전대)
+						return 2.15;
+					case 167: // 2식 내화정
+						return 2.40;
+					default:
+						return 0;
+				}
+			}
+		}
+
+		/// <summary>
 		/// 基地航空隊の航続距離値を取得します。
 		/// </summary>
 		public int Distance => this.RawData.api_distance;
+
+		/// <summary>
+		/// 기지항공대 배치 코스트
+		/// </summary>
+		public int AirBaseCost
+		{
+			get
+			{
+				var cost = this.RawData.api_cost;
+				if (cost == -1) return cost;
+
+				var type = this.Type;
+				if (type == SlotItemType.None) return cost;
+
+				switch (type)
+				{
+					case SlotItemType.艦上偵察機:
+					case SlotItemType.水上偵察機:
+					case SlotItemType.噴式偵察機:
+					case SlotItemType.大型飛行艇:
+						return cost * 4;
+
+					default:
+						return cost * 12;
+				}
+			}
+		}
+
 
 		public bool IsNumerable => this.Type.IsNumerable();
 
@@ -109,30 +181,6 @@ namespace Grabacr07.KanColleWrapper.Models
 								   || this.Type == SlotItemType.水上偵察機;
 
 		public double SecondEncounter => this.ViewRange * 0.07;
-
-		public int AirBaseCost
-		{
-			get
-			{
-				var cost = this.RawData.api_cost;
-				if (cost == -1) return cost;
-
-				var type = this.Type;
-				if (type == SlotItemType.None) return cost;
-
-				switch (type)
-				{
-					case SlotItemType.艦上偵察機:
-					case SlotItemType.水上偵察機:
-					case SlotItemType.噴式偵察機:
-					case SlotItemType.大型飛行艇:
-						return cost * 4;
-
-					default:
-						return cost * 12;
-				}
-			}
-		}
 
 		public SlotItemEquipType EquipType { get; }
 

--- a/source/Grabacr07.KanColleWrapper/Models/SlotItemStat.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/SlotItemStat.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Grabacr07.KanColleWrapper.Models
+{
+	public class SlotItemStat
+	{
+		/// <summary>
+		/// 화력 수치
+		/// </summary>
+		public double Firepower { get; set; }
+
+		/// <summary>
+		/// 야전 화력 수치
+		/// </summary>
+		public double NightFirepower { get; set; }
+
+		/// <summary>
+		/// 명중 수치
+		/// </summary>
+		public double Hit { get; set; }
+
+		/// <summary>
+		/// 뇌장 수치
+		/// </summary>
+		public double Torpedo { get; set; }
+
+		/// <summary>
+		/// 뇌격 명중 수치
+		/// </summary>
+		public double TorpedoHit { get; set; }
+
+		/// <summary>
+		/// 대공 수치
+		/// </summary>
+		public double AA { get; set; }
+
+		/// <summary>
+		/// 함대 방공 수치
+		/// </summary>
+		public double FleetAA { get; set; }
+
+		/// <summary>
+		/// 색적 수치
+		/// </summary>
+		public double LoS { get; set; }
+
+		/// <summary>
+		/// 대잠 수치
+		/// </summary>
+		public double ASW { get; set; }
+
+		/// <summary>
+		/// 대잠 명중 수치
+		/// </summary>
+		public double ASWHit { get; set; }
+
+		/// <summary>
+		/// 장갑 수치
+		/// </summary>
+		public double Armor { get; set; }
+
+		/// <summary>
+		/// 회피 수치
+		/// </summary>
+		public double Evade { get; set; }
+
+		/// <summary>
+		/// 폭장 수치
+		/// </summary>
+		public double Bomb { get; set; }
+
+		/// <summary>
+		/// 원정 보너스
+		/// </summary>
+		public double ExpeditionBonus { get; set; }
+
+		/// <summary>
+		/// 포대 특효 수치
+		/// </summary>
+		public double TurrentEfficacy { get; set; }
+
+		#region 알려지지 않은 수치
+		/// <summary>
+		/// 피격 확률
+		/// </summary>
+		public double DamageChance { get; set; }
+
+		/// <summary>
+		/// 적 컷인 확률
+		/// </summary>
+		public double EnemyCutInChance { get; set; }
+		#endregion
+	}
+}

--- a/source/Grabacr07.KanColleWrapper/Models/ViewRange.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/ViewRange.cs
@@ -73,7 +73,7 @@ namespace Grabacr07.KanColleWrapper.Models
 		public override string Description =>
 			@"((각 장비의 색적값 + 개수 효과) × 장비 타입 보너스)의 합 × "
 			+ this.Cn + @"(√ 각 함의 색적값)의 합
-- (사령부 레벨 × 0.4)의 소수점 이하 올림 + 함대 여유 × 2
+- (사령부 레벨 × 0.4)의 소수점 이하 올림 + (6 - 함선 수) × 2
 ※ 대피한 함선 제외";
 
 		public override bool HasCombinedSettings { get; } = true;

--- a/source/Grabacr07.KanColleWrapper/Organization.cs
+++ b/source/Grabacr07.KanColleWrapper/Organization.cs
@@ -86,6 +86,28 @@ namespace Grabacr07.KanColleWrapper
 
 		#endregion
 
+		#region CombinedType 変更通知プロパティ
+
+		private CombinedFleetType _CombinedType;
+
+		/// <summary>
+		/// 제1, 제2 함대의 연합함대 형식
+		/// </summary>
+		public CombinedFleetType CombinedType
+		{
+			get { return this._CombinedType; }
+			set
+			{
+				if (this._CombinedType != value)
+				{
+					this._CombinedType = value;
+					this.RaisePropertyChanged();
+				}
+			}
+		}
+
+		#endregion
+
 		#region CombinedFleet 変更通知プロパティ
 
 		private CombinedFleet _CombinedFleet;
@@ -141,7 +163,14 @@ namespace Grabacr07.KanColleWrapper
 			proxy.api_req_member_updatedeckname.TryParse().Subscribe(this.UpdateFleetName);
 
 			proxy.api_req_hensei_combined.TryParse<kcsapi_hensei_combined>()
-				.Subscribe(x => this.Combined = x.Data.api_combined != 0);
+				.Subscribe(x =>
+				{
+					this.Combined = x.Data.api_combined != 0;
+
+					int type;
+					if (int.TryParse(x.Request["api_combined_type"], out type))
+						this.CombinedType = (CombinedFleetType)type;
+				});
 
 			this.SubscribeSortieSessions(proxy);
 		}

--- a/source/Grabacr07.KanColleWrapper/Organization.cs
+++ b/source/Grabacr07.KanColleWrapper/Organization.cs
@@ -279,13 +279,13 @@ namespace Grabacr07.KanColleWrapper
 			try
 			{
 				var fleet = this.Fleets[int.Parse(data.Request["api_id"])];
-				fleet.RaiseShipsUpdated();
 
 				var index = int.Parse(data.Request["api_ship_idx"]);
 				if (index == -1)
 				{
 					// 旗艦以外をすべて外すケース
 					fleet.UnsetAll();
+					fleet.RaiseShipsUpdated();
 					return;
 				}
 
@@ -294,6 +294,7 @@ namespace Grabacr07.KanColleWrapper
 				{
 					// 艦を外すケース
 					fleet.Unset(index);
+					fleet.RaiseShipsUpdated();
 					return;
 				}
 
@@ -302,6 +303,7 @@ namespace Grabacr07.KanColleWrapper
 				{
 					// ship が、現状どの艦隊にも所属していないケース
 					fleet.Change(index, ship);
+					fleet.RaiseShipsUpdated();
 					return;
 				}
 
@@ -312,6 +314,7 @@ namespace Grabacr07.KanColleWrapper
 				// Fleet.Change(int, Ship) は、変更前の艦を返す (= old) ので、
 				// ship の移動元 (currentFleet + currentIndex) に old を書き込みにいく
 				currentFleet.Change(currentIndex, old);
+				fleet.RaiseShipsUpdated();
 			}
 			catch (Exception ex)
 			{

--- a/source/Grabacr07.KanColleWrapper/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleWrapper/Properties/AssemblyInfo.cs
@@ -10,5 +10,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("8C42F9E0-E2C9-4741-8F98-653A4D275798")]
 
-[assembly: AssemblyVersion("1.7.18")]
-[assembly: AssemblyInformationalVersion("1.7.18")]
+[assembly: AssemblyVersion("1.7.19")]
+[assembly: AssemblyInformationalVersion("1.7.19")]


### PR DESCRIPTION
### ↯ 다운로드
- GitHub [다운로드](https://github.com/CirnoV/KanColleViewer/releases/download/v4.2.11r18/KanColleViewer-KR.4.2.11.r18.zip)
- MEGA [다운로드](https://mega.nz/#!CkA3yKZL!7E8aOH48FuUTMPN_uffwWs9qwNmCKN9ZhE2vigSE3UI)

### 🔗 외부 링크
- VirusTotal [검사 결과](https://www.virustotal.com/ko/file/4630e1052a3f7462d774f2282c891db7fe09a3c0d0bc267b1e42cc07ae910356/analysis/1523108643/)
- OpenDB Project Website ([http://swaytwig.com/opendb/](http://swaytwig.com/opendb/))
- 업데이트 페이지 [http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html](http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html)

질문 및 건의사항은 [wolfgangkurzdev@gmail.com](mailto:wolfgangkurzdev@gmail.com) 으로 메일 부탁드립니다.
뷰어 사용중 오류가 발생하는 경우, error.log 혹은 battleinfo_error.log 를 첨부하여 메일로 제보해주시면 해결에 도움이 됩니다.

뷰어를 완전히 삭제하신 후 재설치를 해보시는 것도 방법이 될 수 있습니다.
뷰어의 각종 로그, 함대 프리셋, 전과 데이터 등을 백업하시려면, **뷰어 폴더 내의 csv 파일들과 Record 폴더를 백업**하면 됩니다.

```diff
- 갑자기 혹은 장비목록을 열 때 프로그램이 종료되면, 뷰어 폴더의 KanColleWrapper.dll 을 삭제하시기 바랍니다.
- (lib 폴더 내부에 있는 파일은 삭제하지 마세요)
- 파일이 없거나 삭제 후에도 동일한 증상이 나타난다면 메일로 문의 바랍니다.
```

----
### 💬 사령부 정보 영역
- 자연 회복 수치를 넘어섰을 때에, 자연 회복까지 남은 시간이 음수로 표시되던 문제를 수정했습니다.

### 💬 함대 탭
- 함선 툴팁의 정보 표시를 수정했습니다.
  * 색적 수치가 잘못 표시되던 것을 수정했습니다.
  * 함선의 현재 화력을 표시합니다.
    * 현재 장비의 개수를 포함한 화력 수치를 계산하여 각 상황에 맞게 표시합니다.
    * 주간전/야전 화력 캡에 도달한 경우, 강조되어 표시됩니다.
- 함선이 장비중인 장비의 툴팁이 개선되었습니다.
  * 개수했을 때의 상승 수치 정보를 표시합니다.
  * 기지항공대 탭에서도 동일한 툴팁을 표시합니다.

### 💬 설정 탭
- 일부 설정의 표기가 수정되었습니다.
  * Cn 색적식 설명의 "함대 여유" 부분이 "(6 - 함선 수)" 로 수정되었습니다.

### 💬 BattleInfoPlugin
- 기항대 방공 이후 맵이 확장되는 경우의 기믹 발동 표시를 추가했습니다.
- 일부 전투에서 제대로 예보가 작동하지 않는 문제를 수정했습니다.
- 연합함대일 때, 2함대의 기함은 대파 판단에 포함되지 않도록 수정했습니다.
  * 2함대 기함은 굉침하지 않습니다.
- "대파 진격"시의 행동 설정을 추가했습니다.
  * 알림 - 유저에게 알림을 표시합니다.
  * 무시 - 유저에게 알림을 표시하지 않습니다.
  * 새로고침 - 유저에게 알림을 표시하고, 강제로 새로고침을 실시합니다.

### 💬 번역
- 일부 함선의 번역을 추가했습니다.
  * 하마카제乙改
  * 이소카제乙改
  * 아라레改2
- 일부 장비의 번역을 추가했습니다.
  * 5inch 단장포 Mk.30
  * 심해 14inch 연장포改
  * 심해 16inch 삼연장포改
- 일부 임무의 번역을 추가했습니다.
  * 근해에 돌입하여 적 잠수함을 제압하라!
  * 북방 해역 경비를 실시하라!
  * 구축대, 훈련 시작!
  * 정예 「제18구축대」를 편성하라!
- 일부 장비의 번역을 수정했습니다.
  * SK+SG 레이더
- 일부 원정의 조건을 수정했습니다.
  * 대표적으로 항공모함이 포함되는 원정에서 항공모함을 "정규 항공모함", "경 항공모함", "수상기모함" 으로 대체될 수 있는 점 등, 대체될 수 있는 모든 조건을 검사하도록 하였습니다.
  * 함대의 스탯이 조건에 포함되는 원정을 검사하도록 하였습니다.
    * 화력
    * 대잠
    * 대공
    * 색적
