### PR TITLE
v4.2.12 rev3

### DIFF
--- a/source/Grabacr07.KanColleViewer/Application.xaml
+++ b/source/Grabacr07.KanColleViewer/Application.xaml
@@ -1,8 +1,9 @@
-﻿<Application x:Class="Grabacr07.KanColleViewer.Application"
+<Application x:Class="Grabacr07.KanColleViewer.Application"
 			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 			 xmlns:s="clr-namespace:System;assembly=mscorlib"
-			 xmlns:converters="http://schemes.grabacr.net/winfx/2015/personal/converters">
+			 xmlns:converters="http://schemes.grabacr.net/winfx/2015/personal/converters"
+			 xmlns:converters2="clr-namespace:Grabacr07.KanColleViewer.Views.Converters">
 	<Application.Resources>
 		<ResourceDictionary>
 			<ResourceDictionary.MergedDictionaries>
@@ -18,6 +19,7 @@
 			</ResourceDictionary.MergedDictionaries>
 
 			<BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+			<converters2:RangeToBooleanConverter x:Key="RangeToBooleanConverter" />
 			<converters:UniversalBooleanToVisibilityConverter x:Key="UniversalBooleanToVisibilityConverter" />
 			<converters:StringToVisiblityConverter x:Key="StringToVisiblityConverter" />
 			<converters:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />

--- a/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
@@ -15,4 +15,4 @@ using System.Windows;
 	ResourceDictionaryLocation.None,
 	ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("4.2.12.2")]
+[assembly: AssemblyVersion("4.2.12.3")]

--- a/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
@@ -15,4 +15,4 @@ using System.Windows;
 	ResourceDictionaryLocation.None,
 	ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("4.2.12.1")]
+[assembly: AssemblyVersion("4.2.12.2")]

--- a/source/Grabacr07.KanColleViewer/ViewModels/Contents/Fleets/ExpeditionViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/Contents/Fleets/ExpeditionViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -34,9 +34,11 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents.Fleets
 
 				var start = source.ReturnTime.Value.Subtract(TimeSpan.FromMinutes(source.Mission.RawData.api_time));
 				var value = (int)DateTimeOffset.Now.Subtract(start).TotalSeconds;
-				return new LimitedValue(value, source.Mission.RawData.api_time * 60, 0);
+				return new LimitedValue(value, source.Mission.RawData.api_time * 60, 0, 0);
 			}
 		}
+
+		public ExpeditionResult ExpeditionResult => this.source.ExpeditionResult;
 
 		public ExpeditionViewModel(Expedition expedition)
 		{
@@ -45,8 +47,8 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents.Fleets
 			this.CompositeDisposable.Add(new PropertyChangedEventListener(expedition)
 				{
 					{nameof(expedition.Remaining), (sender, args) => {
-						this.RaisePropertyChanged("Returned");
-						this.RaisePropertyChanged("Progress");
+						this.RaisePropertyChanged(nameof(Returned));
+						this.RaisePropertyChanged(nameof(Progress));
 					} }
 				}
 			);

--- a/source/Grabacr07.KanColleViewer/ViewModels/Contents/Fleets/FleetViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/Contents/Fleets/FleetViewModel.cs
@@ -149,7 +149,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents.Fleets
 
 				this.IsPossible = !this.IsPassed
 					? ExpeditionPossible.NotAccepted
-					: this.Source.Ships.Where(x => (x.Fuel.Current != x.Fuel.Maximum) || x.Bull.Current != x.Bull.Maximum).Count() > 0
+					: this.Source.Ships.Any(x => (x.Fuel.Current != x.Fuel.Maximum) || (x.Bull.Current != x.Bull.Maximum))
 						? ExpeditionPossible.NotSupplied
 						: ExpeditionPossible.Possible;
 				this.GreatChance = this.IsPossible == ExpeditionPossible.Possible
@@ -401,6 +401,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents.Fleets
 						this.RaisePropertyChanged(nameof(this.UsedFuel));
 						this.RaisePropertyChanged(nameof(this.UsedAmmo));
 						this.RaisePropertyChanged(nameof(this.UsedBauxite));
+						this.ExpeditionId = this.ExpeditionId;
 					}
 				},
 				{  nameof(fleet.State.UsedBull), (sender,args) =>
@@ -408,6 +409,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents.Fleets
 						this.RaisePropertyChanged(nameof(this.UsedFuel));
 						this.RaisePropertyChanged(nameof(this.UsedAmmo));
 						this.RaisePropertyChanged(nameof(this.UsedBauxite));
+						this.ExpeditionId = this.ExpeditionId;
 					}
 				}
 			});

--- a/source/Grabacr07.KanColleViewer/Views/Catalogs/ResourceLogWindow.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Catalogs/ResourceLogWindow.xaml
@@ -1,4 +1,4 @@
-﻿<metro:MetroWindow x:Class="Grabacr07.KanColleViewer.Views.Catalogs.ResourceLogWindow"
+<metro:MetroWindow x:Class="Grabacr07.KanColleViewer.Views.Catalogs.ResourceLogWindow"
 				   x:Name="GlowMetroWindow"
 				   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 				   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -147,11 +147,11 @@
 					<CheckBox Grid.Column="3" Grid.Row="1" Content="개수자재" Foreground="#FFCCCCCC" IsChecked="{Binding ImprovementMaterialVisible}" />
 				</Grid>
 
-				<metro2:CallMethodButton
-							Grid.Column="3"
-							Margin="5,5,5,5"
-							MethodName="Refresh"
-							Content="새로고침" />
+				<metro2:CallMethodButton Grid.Column="3"
+										 Margin="5,5,5,5"
+										 MethodName="Refresh"
+										 IsEnabled="{Binding ChartLoaded, Mode=OneWay}"
+										 Content="새로고침" />
 			</Grid>
 
 			<ScrollViewer Grid.Row="1"
@@ -194,14 +194,22 @@
 					<Grid Grid.Row="1"
 						  MinHeight="80"
 						  Margin="5,5,5,5">
-						<controls:GraphControl Width="{Binding ElementName=root, Path=ActualWidth}" 
-													Height="{Binding ElementName=root, Path=ActualHeight}"
-													ElementToDraw="{Binding ElementToDraw1, Mode=OneWay}"
-													Data="{Binding ResourceList, Mode=OneWay}"
-													BeginDate="{Binding BeginDate, Mode=OneWay}"
-													EndDate="{Binding EndDate, Mode=OneWay}"
-													YMin="{Binding YMin1, Mode=OneWay}"
-													YMax="{Binding YMax1, Mode=OneWay}" />
+						<controls:GraphControl Width="{Binding ElementName=root, Path=ActualWidth}"
+											   Height="{Binding ElementName=root, Path=ActualHeight}"
+											   ElementToDraw="{Binding ElementToDraw1, Mode=OneWay}"
+											   GuideLine="{Binding GuideLine, Mode=OneWay}"
+											   Data="{Binding ResourceList, Mode=OneWay}"
+											   BeginDate="{Binding BeginDate, Mode=OneWay}"
+											   EndDate="{Binding EndDate, Mode=OneWay}"
+											   YMin="{Binding YMin1, Mode=OneWay}"
+											   YMax="{Binding YMax1, Mode=OneWay}" />
+
+						<Grid Background="#60000000"
+							  Visibility="{Binding ChartLoading, Converter={StaticResource BooleanToVisibilityConverter}}">
+							<TextBlock HorizontalAlignment="Center"
+									   VerticalAlignment="Center"
+									   Text="자원 기록을 불러오고 있습니다..."/>
+						</Grid>
 					</Grid>
 
 					<TextBlock Grid.Row="3"
@@ -227,14 +235,21 @@
 					<Grid Grid.Row="4"
 						  MinHeight="80"
 						  Margin="5,5,5,5">
-						<controls:GraphControl Width="{Binding ElementName=root, Path=ActualWidth}" 
-													Height="{Binding ElementName=root, Path=ActualHeight}"
-													ElementToDraw="{Binding ElementToDraw2, Mode=OneWay}"
-													Data="{Binding ResourceList, Mode=OneWay}"
-													BeginDate="{Binding BeginDate, Mode=OneWay}"
-													EndDate="{Binding EndDate, Mode=OneWay}"
-													YMin="{Binding YMin2, Mode=OneWay}"
-													YMax="{Binding YMax2, Mode=OneWay}" />
+						<controls:GraphControl Width="{Binding ElementName=root, Path=ActualWidth}"
+											   Height="{Binding ElementName=root, Path=ActualHeight}"
+											   ElementToDraw="{Binding ElementToDraw2, Mode=OneWay}"
+											   Data="{Binding ResourceList, Mode=OneWay}"
+											   BeginDate="{Binding BeginDate, Mode=OneWay}"
+											   EndDate="{Binding EndDate, Mode=OneWay}"
+											   YMin="{Binding YMin2, Mode=OneWay}"
+											   YMax="{Binding YMax2, Mode=OneWay}" />
+
+						<Grid Background="#60000000"
+							  Visibility="{Binding ChartLoading, Converter={StaticResource BooleanToVisibilityConverter}}">
+							<TextBlock HorizontalAlignment="Center"
+									   VerticalAlignment="Center"
+									   Text="자원 기록을 불러오고 있습니다..."/>
+						</Grid>
 					</Grid>
 				</Grid>
 			</ScrollViewer>

--- a/source/Grabacr07.KanColleViewer/Views/Catalogs/ShipCatalogWindow.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Catalogs/ShipCatalogWindow.xaml
@@ -1134,7 +1134,6 @@
 												<ItemsControl.ItemTemplate>
 													<DataTemplate>
 														<Border x:Name="Elements"
-																ToolTip="{Binding Item.NameWithLevel}"
 																Background="Transparent"
 																Height="20"
 																Padding="0,1">
@@ -1142,6 +1141,645 @@
 																<kcvc:SlotItemIcon Type="{Binding Item.Info.IconType}"
 																				   Margin="0,0,4,0" />
 															</Viewbox>
+															<Border.ToolTip>
+																<StackPanel Orientation="Vertical">
+																	<StackPanel Orientation="Horizontal"
+																				Margin="0,0,0,10">
+																		<kcvc:SlotItemIcon Type="{Binding Item.Info.IconType}"
+																						   Margin="0,0,3,0"
+																						   Width="20"
+																						   Height="20"
+																						   VerticalAlignment="Center" />
+																		<TextBlock VerticalAlignment="Center">
+																			<Run Text="{Binding Item.Info.Name, Mode=OneWay}" />
+																			<Run>
+																				<Run.Style>
+																					<Style TargetType="{x:Type Run}">
+																						<Setter Property="Text" Value="{Binding Item.Proficiency, Mode=OneWay, StringFormat=+{0}}" />
+																						<Setter Property="Foreground" Value="#FFD49C0F" />
+																						<Style.Triggers>
+																							<DataTrigger Binding="{Binding Item.Proficiency, Mode=OneWay}" Value="0">
+																								<Setter Property="Text" Value="" />
+																							</DataTrigger>
+																							<DataTrigger Binding="{Binding Item.Proficiency, Mode=OneWay, Converter={StaticResource RangeToBooleanConverter}, ConverterParameter=1-3}" Value="True">
+																								<Setter Property="Foreground" Value="#FF98B3CE" />
+																							</DataTrigger>
+																						</Style.Triggers>
+																					</Style>
+																				</Run.Style>
+																			</Run>
+																			<Run Text="{Binding Item.LevelText, Mode=OneWay}"
+																				 Foreground="#FF45A9A5" />
+																		</TextBlock>
+																	</StackPanel>
+											
+																	<TextBlock Margin="0,2,0,0">
+																		<Run Text="화력:" />
+																		<Run Text="{Binding Item.Info.Firepower, Mode=OneWay}">
+																			<Run.Style>
+																				<Style TargetType="{x:Type Run}">
+																					<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																					<Style.Triggers>
+																						<DataTrigger Binding="{Binding Item.Info.Firepower}" Value="0">
+																							<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																						</DataTrigger>
+																					</Style.Triggers>
+																				</Style>
+																			</Run.Style>
+																		</Run>
+																		<Run Foreground="#FF45A9A5">
+																			<Run.Style>
+																				<Style TargetType="{x:Type Run}">
+																					<Setter Property="Text" Value="{Binding Item.ImprovementStats.Firepower, Mode=OneWay, StringFormat={}+{0:N2}}" />
+																					<Style.Triggers>
+																						<DataTrigger Binding="{Binding Item.ImprovementStats.Firepower}" Value="0">
+																							<Setter Property="Text" Value="" />
+																						</DataTrigger>
+																					</Style.Triggers>
+																				</Style>
+																			</Run.Style>
+																		</Run>
+
+																		<TextBlock.Style>
+																			<Style TargetType="{x:Type TextBlock}">
+																				<Style.Triggers>
+																					<MultiDataTrigger>
+																						<MultiDataTrigger.Conditions>
+																							<Condition Binding="{Binding Item.Info.Firepower}" Value="0" />
+																							<Condition Binding="{Binding Item.ImprovementStats.Firepower}" Value="0" />
+																						</MultiDataTrigger.Conditions>
+																						<MultiDataTrigger.Setters>
+																							<Setter Property="Visibility" Value="Collapsed" />
+																						</MultiDataTrigger.Setters>
+																					</MultiDataTrigger>
+																				</Style.Triggers>
+																			</Style>
+																		</TextBlock.Style>
+																	</TextBlock>
+											
+																	<TextBlock Margin="0,2,0,0">
+																		<Run Text="뇌장:" />
+																		<Run Text="{Binding Item.Info.Torpedo, Mode=OneWay}">
+																			<Run.Style>
+																				<Style TargetType="{x:Type Run}">
+																					<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																					<Style.Triggers>
+																						<DataTrigger Binding="{Binding Item.Info.Torpedo}" Value="0">
+																							<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																						</DataTrigger>
+																					</Style.Triggers>
+																				</Style>
+																			</Run.Style>
+																		</Run>
+																		<Run Foreground="#FF45A9A5">
+																			<Run.Style>
+																				<Style TargetType="{x:Type Run}">
+																					<Setter Property="Text" Value="{Binding Item.ImprovementStats.Torpedo, Mode=OneWay, StringFormat={}+{0:N2}}" />
+																					<Style.Triggers>
+																						<DataTrigger Binding="{Binding Item.ImprovementStats.Torpedo}" Value="0">
+																							<Setter Property="Text" Value="" />
+																						</DataTrigger>
+																					</Style.Triggers>
+																				</Style>
+																			</Run.Style>
+																		</Run>
+
+																		<TextBlock.Style>
+																			<Style TargetType="{x:Type TextBlock}">
+																				<Style.Triggers>
+																					<MultiDataTrigger>
+																						<MultiDataTrigger.Conditions>
+																							<Condition Binding="{Binding Item.Info.Torpedo}" Value="0" />
+																							<Condition Binding="{Binding Item.ImprovementStats.Torpedo}" Value="0" />
+																						</MultiDataTrigger.Conditions>
+																						<MultiDataTrigger.Setters>
+																							<Setter Property="Visibility" Value="Collapsed" />
+																						</MultiDataTrigger.Setters>
+																					</MultiDataTrigger>
+																				</Style.Triggers>
+																			</Style>
+																		</TextBlock.Style>
+																	</TextBlock>
+																	<TextBlock Margin="0,2,0,0">
+																		<Run Text="뇌격 명중:" />
+																		<Run Foreground="#FF45A9A5"
+																			 Text="{Binding Item.ImprovementStats.TorpedoHit, Mode=OneWay, StringFormat={}+{0:N2}}" />
+
+																		<TextBlock.Style>
+																			<Style TargetType="{x:Type TextBlock}">
+																				<Style.Triggers>
+																					<DataTrigger Binding="{Binding Item.ImprovementStats.TorpedoHit}" Value="0">
+																						<Setter Property="Visibility" Value="Collapsed" />
+																					</DataTrigger>
+																				</Style.Triggers>
+																			</Style>
+																		</TextBlock.Style>
+																	</TextBlock>
+
+																	<TextBlock Margin="0,2,0,0">
+																		<Run Text="대공:" />
+																		<Run Text="{Binding Item.Info.AA, Mode=OneWay}">
+																			<Run.Style>
+																				<Style TargetType="{x:Type Run}">
+																					<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																					<Style.Triggers>
+																						<DataTrigger Binding="{Binding Item.Info.AA}" Value="0">
+																							<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																						</DataTrigger>
+																					</Style.Triggers>
+																				</Style>
+																			</Run.Style>
+																		</Run>
+																		<Run Foreground="#FF45A9A5">
+																			<Run.Style>
+																				<Style TargetType="{x:Type Run}">
+																					<Setter Property="Text" Value="{Binding Item.ImprovementStats.AA, Mode=OneWay, StringFormat={}+{0:N2}}" />
+																					<Style.Triggers>
+																						<DataTrigger Binding="{Binding Item.ImprovementStats.AA}" Value="0">
+																							<Setter Property="Text" Value="" />
+																						</DataTrigger>
+																					</Style.Triggers>
+																				</Style>
+																			</Run.Style>
+																		</Run>
+
+																		<TextBlock.Style>
+																			<Style TargetType="{x:Type TextBlock}">
+																				<Style.Triggers>
+																					<MultiDataTrigger>
+																						<MultiDataTrigger.Conditions>
+																							<Condition Binding="{Binding Item.Info.AA}" Value="0" />
+																							<Condition Binding="{Binding Item.ImprovementStats.AA}" Value="0" />
+																						</MultiDataTrigger.Conditions>
+																						<MultiDataTrigger.Setters>
+																							<Setter Property="Visibility" Value="Collapsed" />
+																						</MultiDataTrigger.Setters>
+																					</MultiDataTrigger>
+																				</Style.Triggers>
+																			</Style>
+																		</TextBlock.Style>
+																	</TextBlock>
+																	<TextBlock Margin="0,2,0,0">
+																		<Run Text="함대 방공:" />
+																		<Run Foreground="#FF45A9A5"
+																			 Text="{Binding Item.ImprovementStats.FleetAA, Mode=OneWay, StringFormat={}+{0:N2}}" />
+
+																		<TextBlock.Style>
+																			<Style TargetType="{x:Type TextBlock}">
+																				<Style.Triggers>
+																					<DataTrigger Binding="{Binding Item.ImprovementStats.FleetAA}" Value="0">
+																						<Setter Property="Visibility" Value="Collapsed" />
+																					</DataTrigger>
+																				</Style.Triggers>
+																			</Style>
+																		</TextBlock.Style>
+																	</TextBlock>
+
+																	<TextBlock Margin="0,2,0,0">
+																		<Run Text="장갑:" />
+																		<Run Text="{Binding Item.Info.Armer, Mode=OneWay}">
+																			<Run.Style>
+																				<Style TargetType="{x:Type Run}">
+																					<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																					<Style.Triggers>
+																						<DataTrigger Binding="{Binding Item.Info.Armer}" Value="0">
+																							<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																						</DataTrigger>
+																					</Style.Triggers>
+																				</Style>
+																			</Run.Style>
+																		</Run>
+																		<Run Foreground="#FF45A9A5">
+																			<Run.Style>
+																				<Style TargetType="{x:Type Run}">
+																					<Setter Property="Text" Value="{Binding Item.ImprovementStats.Armor, Mode=OneWay, StringFormat={}+{0:N2}}" />
+																					<Style.Triggers>
+																						<DataTrigger Binding="{Binding Item.ImprovementStats.Armor}" Value="0">
+																							<Setter Property="Text" Value="" />
+																						</DataTrigger>
+																					</Style.Triggers>
+																				</Style>
+																			</Run.Style>
+																		</Run>
+
+																		<TextBlock.Style>
+																			<Style TargetType="{x:Type TextBlock}">
+																				<Style.Triggers>
+																					<MultiDataTrigger>
+																						<MultiDataTrigger.Conditions>
+																							<Condition Binding="{Binding Item.Info.Armer}" Value="0" />
+																							<Condition Binding="{Binding Item.ImprovementStats.Armor}" Value="0" />
+																						</MultiDataTrigger.Conditions>
+																						<MultiDataTrigger.Setters>
+																							<Setter Property="Visibility" Value="Collapsed" />
+																						</MultiDataTrigger.Setters>
+																					</MultiDataTrigger>
+																				</Style.Triggers>
+																			</Style>
+																		</TextBlock.Style>
+																	</TextBlock>
+																	<TextBlock Margin="0,2,0,0">
+																		<Run Text="폭장:" />
+																		<Run Text="{Binding Item.Info.Bomb, Mode=OneWay}">
+																			<Run.Style>
+																				<Style TargetType="{x:Type Run}">
+																					<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																					<Style.Triggers>
+																						<DataTrigger Binding="{Binding Item.Info.Bomb}" Value="0">
+																							<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																						</DataTrigger>
+																					</Style.Triggers>
+																				</Style>
+																			</Run.Style>
+																		</Run>
+																		<Run Foreground="#FF45A9A5">
+																			<Run.Style>
+																				<Style TargetType="{x:Type Run}">
+																					<Setter Property="Text" Value="{Binding Item.ImprovementStats.Bomb, Mode=OneWay, StringFormat={}+{0:N2}}" />
+																					<Style.Triggers>
+																						<DataTrigger Binding="{Binding Item.ImprovementStats.Bomb}" Value="0">
+																							<Setter Property="Text" Value="" />
+																						</DataTrigger>
+																					</Style.Triggers>
+																				</Style>
+																			</Run.Style>
+																		</Run>
+
+																		<TextBlock.Style>
+																			<Style TargetType="{x:Type TextBlock}">
+																				<Style.Triggers>
+																					<MultiDataTrigger>
+																						<MultiDataTrigger.Conditions>
+																							<Condition Binding="{Binding Item.Info.Bomb}" Value="0" />
+																							<Condition Binding="{Binding Item.ImprovementStats.Bomb}" Value="0" />
+																						</MultiDataTrigger.Conditions>
+																						<MultiDataTrigger.Setters>
+																							<Setter Property="Visibility" Value="Collapsed" />
+																						</MultiDataTrigger.Setters>
+																					</MultiDataTrigger>
+																				</Style.Triggers>
+																			</Style>
+																		</TextBlock.Style>
+																	</TextBlock>
+
+																	<TextBlock Margin="0,2,0,0">
+																		<Run Text="대잠:" />
+																		<Run Text="{Binding Item.Info.ASW, Mode=OneWay}">
+																			<Run.Style>
+																				<Style TargetType="{x:Type Run}">
+																					<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																					<Style.Triggers>
+																						<DataTrigger Binding="{Binding Item.Info.ASW}" Value="0">
+																							<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																						</DataTrigger>
+																					</Style.Triggers>
+																				</Style>
+																			</Run.Style>
+																		</Run>
+																		<Run Foreground="#FF45A9A5">
+																			<Run.Style>
+																				<Style TargetType="{x:Type Run}">
+																					<Setter Property="Text" Value="{Binding Item.ImprovementStats.ASW, Mode=OneWay, StringFormat={}+{0:N2}}" />
+																					<Style.Triggers>
+																						<DataTrigger Binding="{Binding Item.ImprovementStats.ASW}" Value="0">
+																							<Setter Property="Text" Value="" />
+																						</DataTrigger>
+																					</Style.Triggers>
+																				</Style>
+																			</Run.Style>
+																		</Run>
+
+																		<TextBlock.Style>
+																			<Style TargetType="{x:Type TextBlock}">
+																				<Style.Triggers>
+																					<MultiDataTrigger>
+																						<MultiDataTrigger.Conditions>
+																							<Condition Binding="{Binding Item.Info.ASW}" Value="0" />
+																							<Condition Binding="{Binding Item.ImprovementStats.ASW}" Value="0" />
+																						</MultiDataTrigger.Conditions>
+																						<MultiDataTrigger.Setters>
+																							<Setter Property="Visibility" Value="Collapsed" />
+																						</MultiDataTrigger.Setters>
+																					</MultiDataTrigger>
+																				</Style.Triggers>
+																			</Style>
+																		</TextBlock.Style>
+																	</TextBlock>
+																	<TextBlock Margin="0,2,0,0">
+																		<Run Text="대잠 명중:" />
+																		<Run Foreground="#FF45A9A5"
+																			 Text="{Binding Item.ImprovementStats.ASWHit, Mode=OneWay, StringFormat={}+{0:N2}}" />
+
+																		<TextBlock.Style>
+																			<Style TargetType="{x:Type TextBlock}">
+																				<Style.Triggers>
+																					<DataTrigger Binding="{Binding Item.ImprovementStats.ASWHit}" Value="0">
+																						<Setter Property="Visibility" Value="Collapsed" />
+																					</DataTrigger>
+																				</Style.Triggers>
+																			</Style>
+																		</TextBlock.Style>
+																	</TextBlock>
+
+																	<TextBlock Margin="0,2,0,0">
+																		<InlineUIContainer>
+																			<TextBlock>
+																				<TextBlock.Style>
+																					<Style TargetType="{x:Type TextBlock}">
+																						<Setter Property="Text" Value="명중:" />
+																						<Style.Triggers>
+																							<DataTrigger Binding="{Binding Item.Info.Type, Mode=OneWay}" Value="局地戦闘機">
+																								<Setter Property="Text" Value="대폭:" />
+																							</DataTrigger>
+																						</Style.Triggers>
+																					</Style>
+																				</TextBlock.Style>
+																			</TextBlock>
+																		</InlineUIContainer>
+																		<Run Text="{Binding Item.Info.Hit, Mode=OneWay}">
+																			<Run.Style>
+																				<Style TargetType="{x:Type Run}">
+																					<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																					<Style.Triggers>
+																						<DataTrigger Binding="{Binding Item.Info.Hit}" Value="0">
+																							<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																						</DataTrigger>
+																					</Style.Triggers>
+																				</Style>
+																			</Run.Style>
+																		</Run>
+																		<Run Foreground="#FF45A9A5">
+																			<Run.Style>
+																				<Style TargetType="{x:Type Run}">
+																					<Setter Property="Text" Value="{Binding Item.ImprovementStats.Hit, Mode=OneWay, StringFormat={}+{0:N2}}" />
+																					<Style.Triggers>
+																						<DataTrigger Binding="{Binding Item.ImprovementStats.Hit}" Value="0">
+																							<Setter Property="Text" Value="" />
+																						</DataTrigger>
+																					</Style.Triggers>
+																				</Style>
+																			</Run.Style>
+																		</Run>
+
+																		<TextBlock.Style>
+																			<Style TargetType="{x:Type TextBlock}">
+																				<Style.Triggers>
+																					<MultiDataTrigger>
+																						<MultiDataTrigger.Conditions>
+																							<Condition Binding="{Binding Item.Info.Hit}" Value="0" />
+																							<Condition Binding="{Binding Item.ImprovementStats.Hit}" Value="0" />
+																						</MultiDataTrigger.Conditions>
+																						<MultiDataTrigger.Setters>
+																							<Setter Property="Visibility" Value="Collapsed" />
+																						</MultiDataTrigger.Setters>
+																					</MultiDataTrigger>
+																				</Style.Triggers>
+																			</Style>
+																		</TextBlock.Style>
+																	</TextBlock>
+																	<TextBlock Margin="0,2,0,0">
+																		<InlineUIContainer>
+																			<TextBlock>
+																				<TextBlock.Style>
+																					<Style TargetType="{x:Type TextBlock}">
+																						<Setter Property="Text" Value="회피:" />
+																						<Style.Triggers>
+																							<DataTrigger Binding="{Binding Item.Info.Type, Mode=OneWay}" Value="局地戦闘機">
+																								<Setter Property="Text" Value="영격:" />
+																							</DataTrigger>
+																						</Style.Triggers>
+																					</Style>
+																				</TextBlock.Style>
+																			</TextBlock>
+																		</InlineUIContainer>
+																		<Run Text="{Binding Item.Info.Evade, Mode=OneWay}">
+																			<Run.Style>
+																				<Style TargetType="{x:Type Run}">
+																					<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																					<Style.Triggers>
+																						<DataTrigger Binding="{Binding Item.Info.Evade}" Value="0">
+																							<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																						</DataTrigger>
+																					</Style.Triggers>
+																				</Style>
+																			</Run.Style>
+																		</Run>
+																		<Run Foreground="#FF45A9A5">
+																			<Run.Style>
+																				<Style TargetType="{x:Type Run}">
+																					<Setter Property="Text" Value="{Binding Item.ImprovementStats.Evade, Mode=OneWay, StringFormat={}+{0:N2}}" />
+																					<Style.Triggers>
+																						<DataTrigger Binding="{Binding Item.ImprovementStats.Evade}" Value="0">
+																							<Setter Property="Text" Value="" />
+																						</DataTrigger>
+																					</Style.Triggers>
+																				</Style>
+																			</Run.Style>
+																		</Run>
+
+																		<TextBlock.Style>
+																			<Style TargetType="{x:Type TextBlock}">
+																				<Style.Triggers>
+																					<MultiDataTrigger>
+																						<MultiDataTrigger.Conditions>
+																							<Condition Binding="{Binding Item.Info.Evade}" Value="0" />
+																							<Condition Binding="{Binding Item.ImprovementStats.Evade}" Value="0" />
+																						</MultiDataTrigger.Conditions>
+																						<MultiDataTrigger.Setters>
+																							<Setter Property="Visibility" Value="Collapsed" />
+																						</MultiDataTrigger.Setters>
+																					</MultiDataTrigger>
+																				</Style.Triggers>
+																			</Style>
+																		</TextBlock.Style>
+																	</TextBlock>
+
+																	<TextBlock Margin="0,2,0,0">
+																		<Run Text="색적:" />
+																		<Run Text="{Binding Item.Info.ViewRange, Mode=OneWay}">
+																			<Run.Style>
+																				<Style TargetType="{x:Type Run}">
+																					<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																					<Style.Triggers>
+																						<DataTrigger Binding="{Binding Item.Info.ViewRange}" Value="0">
+																							<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																						</DataTrigger>
+																					</Style.Triggers>
+																				</Style>
+																			</Run.Style>
+																		</Run>
+																		<Run Foreground="#FF45A9A5">
+																			<Run.Style>
+																				<Style TargetType="{x:Type Run}">
+																					<Setter Property="Text" Value="{Binding Item.ImprovementStats.LoS, Mode=OneWay, StringFormat={}+{0:N2}}" />
+																					<Style.Triggers>
+																						<DataTrigger Binding="{Binding Item.ImprovementStats.LoS}" Value="0">
+																							<Setter Property="Text" Value="" />
+																						</DataTrigger>
+																					</Style.Triggers>
+																				</Style>
+																			</Run.Style>
+																		</Run>
+
+																		<TextBlock.Style>
+																			<Style TargetType="{x:Type TextBlock}">
+																				<Style.Triggers>
+																					<MultiDataTrigger>
+																						<MultiDataTrigger.Conditions>
+																							<Condition Binding="{Binding Item.Info.ViewRange}" Value="0" />
+																							<Condition Binding="{Binding Item.ImprovementStats.LoS}" Value="0" />
+																						</MultiDataTrigger.Conditions>
+																						<MultiDataTrigger.Setters>
+																							<Setter Property="Visibility" Value="Collapsed" />
+																						</MultiDataTrigger.Setters>
+																					</MultiDataTrigger>
+																				</Style.Triggers>
+																			</Style>
+																		</TextBlock.Style>
+																	</TextBlock>
+
+																	<TextBlock Margin="0,10,0,0">
+																		<Run Text="원정 보너스: +" />
+																		<Run Text="{Binding Item.Info.ExpeditionBonus, Mode=OneWay}">
+																			<Run.Style>
+																				<Style TargetType="{x:Type Run}">
+																					<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																					<Style.Triggers>
+																						<DataTrigger Binding="{Binding Item.Info.ExpeditionBonus}" Value="0">
+																							<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																						</DataTrigger>
+																					</Style.Triggers>
+																				</Style>
+																			</Run.Style>
+																		</Run>
+																		<Run Foreground="#FF45A9A5">
+																			<Run.Style>
+																				<Style TargetType="{x:Type Run}">
+																					<Setter Property="Text" Value="{Binding Item.ImprovementStats.ExpeditionBonus, Mode=OneWay, StringFormat={}+{0:N2}}" />
+																					<Style.Triggers>
+																						<DataTrigger Binding="{Binding Item.ImprovementStats.ExpeditionBonus}" Value="0">
+																							<Setter Property="Text" Value="" />
+																						</DataTrigger>
+																					</Style.Triggers>
+																				</Style>
+																			</Run.Style>
+																		</Run>
+																		<Run Text="%" />
+
+																		<TextBlock.Style>
+																			<Style TargetType="{x:Type TextBlock}">
+																				<Style.Triggers>
+																					<MultiDataTrigger>
+																						<MultiDataTrigger.Conditions>
+																							<Condition Binding="{Binding Item.Info.ExpeditionBonus}" Value="0" />
+																							<Condition Binding="{Binding Item.ImprovementStats.ExpeditionBonus}" Value="0" />
+																						</MultiDataTrigger.Conditions>
+																						<MultiDataTrigger.Setters>
+																							<Setter Property="Visibility" Value="Collapsed" />
+																						</MultiDataTrigger.Setters>
+																					</MultiDataTrigger>
+																				</Style.Triggers>
+																			</Style>
+																		</TextBlock.Style>
+																	</TextBlock>
+																	<TextBlock Margin="0,10,0,0">
+																		<Run Text="포대형 특화 계수: 포격전 화력 x (" />
+																		<Run Text="{Binding Item.Info.TurrentEfficacy, Mode=OneWay, StringFormat={}{0:N2}}">
+																			<Run.Style>
+																				<Style TargetType="{x:Type Run}">
+																					<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																					<Style.Triggers>
+																						<DataTrigger Binding="{Binding Item.Info.TurrentEfficacy}" Value="0">
+																							<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																						</DataTrigger>
+																					</Style.Triggers>
+																				</Style>
+																			</Run.Style>
+																		</Run>
+																		<Run Foreground="#FF45A9A5">
+																			<Run.Style>
+																				<Style TargetType="{x:Type Run}">
+																					<Setter Property="Text" Value="{Binding Item.ImprovementStats.TurrentEfficacy, Mode=OneWay, StringFormat={}+{0:N2}}" />
+																					<Style.Triggers>
+																						<DataTrigger Binding="{Binding Item.ImprovementStats.TurrentEfficacy}" Value="0">
+																							<Setter Property="Text" Value="" />
+																						</DataTrigger>
+																					</Style.Triggers>
+																				</Style>
+																			</Run.Style>
+																		</Run>
+																		<Run Text=")" />
+
+																		<TextBlock.Style>
+																			<Style TargetType="{x:Type TextBlock}">
+																				<Style.Triggers>
+																					<MultiDataTrigger>
+																						<MultiDataTrigger.Conditions>
+																							<Condition Binding="{Binding Item.Info.TurrentEfficacy}" Value="0" />
+																							<Condition Binding="{Binding Item.ImprovementStats.TurrentEfficacy}" Value="0" />
+																						</MultiDataTrigger.Conditions>
+																						<MultiDataTrigger.Setters>
+																							<Setter Property="Visibility" Value="Collapsed" />
+																						</MultiDataTrigger.Setters>
+																					</MultiDataTrigger>
+																				</Style.Triggers>
+																			</Style>
+																		</TextBlock.Style>
+																	</TextBlock>
+
+																	<TextBlock Margin="0,10,0,0">
+																		<Run Text="항속거리:" />
+																		<Run Text="{Binding Item.Info.Distance, Mode=OneWay}">
+																			<Run.Style>
+																				<Style TargetType="{x:Type Run}">
+																					<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																					<Style.Triggers>
+																						<DataTrigger Binding="{Binding Item.Info.Distance}" Value="0">
+																							<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																						</DataTrigger>
+																					</Style.Triggers>
+																				</Style>
+																			</Run.Style>
+																		</Run>
+
+																		<TextBlock.Style>
+																			<Style TargetType="{x:Type TextBlock}">
+																				<Style.Triggers>
+																					<DataTrigger Binding="{Binding Item.Info.IsNumerable}" Value="False">
+																						<Setter Property="Visibility" Value="Collapsed" />
+																					</DataTrigger>
+																				</Style.Triggers>
+																			</Style>
+																		</TextBlock.Style>
+																	</TextBlock>
+																	<TextBlock Margin="0,2,0,0">
+																		<Run Text="배치비용:" />
+																		<Run Text="{Binding Item.Info.AirBaseCost, Mode=OneWay}">
+																			<Run.Style>
+																				<Style TargetType="{x:Type Run}">
+																					<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																					<Style.Triggers>
+																						<DataTrigger Binding="{Binding Item.Info.AirBaseCost}" Value="0">
+																							<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																						</DataTrigger>
+																					</Style.Triggers>
+																				</Style>
+																			</Run.Style>
+																		</Run>
+
+																		<TextBlock.Style>
+																			<Style TargetType="{x:Type TextBlock}">
+																				<Style.Triggers>
+																					<DataTrigger Binding="{Binding Item.Info.IsNumerable}" Value="False">
+																						<Setter Property="Visibility" Value="Collapsed" />
+																					</DataTrigger>
+																				</Style.Triggers>
+																			</Style>
+																		</TextBlock.Style>
+																	</TextBlock>
+																</StackPanel>
+
+															</Border.ToolTip>
 														</Border>
 														<DataTemplate.Triggers>
 															<DataTrigger Binding="{Binding Equipped}"
@@ -1159,11 +1797,649 @@
 												<Rectangle Width="1"
 														   Style="{DynamicResource SeparatorRectangleStyleKey}"
 														   Margin="12,1,0,1" />
-												<Border ToolTip="{Binding Ship.ExSlot.Item.NameWithLevel}"
-														Padding="4,1">
+												<Border Padding="4,1">
 													<Viewbox>
 														<kcvc:SlotItemIcon Type="{Binding Ship.ExSlot.Item.Info.IconType}" />
 													</Viewbox>
+													<Border.ToolTip>
+														<StackPanel Orientation="Vertical"
+																	DataContext="{Binding Ship.ExSlot}">
+															<StackPanel Orientation="Horizontal"
+																		Margin="0,0,0,10">
+																<kcvc:SlotItemIcon Type="{Binding Item.Info.IconType}"
+																				   Margin="0,0,3,0"
+																				   Width="20"
+																				   Height="20"
+																				   VerticalAlignment="Center" />
+																<TextBlock VerticalAlignment="Center">
+																	<Run Text="{Binding Item.Info.Name, Mode=OneWay}" />
+																	<Run>
+																		<Run.Style>
+																			<Style TargetType="{x:Type Run}">
+																				<Setter Property="Text" Value="{Binding Item.Proficiency, Mode=OneWay, StringFormat=+{0}}" />
+																				<Setter Property="Foreground" Value="#FFD49C0F" />
+																				<Style.Triggers>
+																					<DataTrigger Binding="{Binding Item.Proficiency, Mode=OneWay}" Value="0">
+																						<Setter Property="Text" Value="" />
+																					</DataTrigger>
+																					<DataTrigger Binding="{Binding Item.Proficiency, Mode=OneWay, Converter={StaticResource RangeToBooleanConverter}, ConverterParameter=1-3}" Value="True">
+																						<Setter Property="Foreground" Value="#FF98B3CE" />
+																					</DataTrigger>
+																				</Style.Triggers>
+																			</Style>
+																		</Run.Style>
+																	</Run>
+																	<Run Text="{Binding Item.LevelText, Mode=OneWay}"
+																		 Foreground="#FF45A9A5" />
+																</TextBlock>
+															</StackPanel>
+											
+															<TextBlock Margin="0,2,0,0">
+																<Run Text="화력:" />
+																<Run Text="{Binding Item.Info.Firepower, Mode=OneWay}">
+																	<Run.Style>
+																		<Style TargetType="{x:Type Run}">
+																			<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																			<Style.Triggers>
+																				<DataTrigger Binding="{Binding Item.Info.Firepower}" Value="0">
+																					<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																				</DataTrigger>
+																			</Style.Triggers>
+																		</Style>
+																	</Run.Style>
+																</Run>
+																<Run Foreground="#FF45A9A5">
+																	<Run.Style>
+																		<Style TargetType="{x:Type Run}">
+																			<Setter Property="Text" Value="{Binding Item.ImprovementStats.Firepower, Mode=OneWay, StringFormat={}+{0:N2}}" />
+																			<Style.Triggers>
+																				<DataTrigger Binding="{Binding Item.ImprovementStats.Firepower}" Value="0">
+																					<Setter Property="Text" Value="" />
+																				</DataTrigger>
+																			</Style.Triggers>
+																		</Style>
+																	</Run.Style>
+																</Run>
+
+																<TextBlock.Style>
+																	<Style TargetType="{x:Type TextBlock}">
+																		<Style.Triggers>
+																			<MultiDataTrigger>
+																				<MultiDataTrigger.Conditions>
+																					<Condition Binding="{Binding Item.Info.Firepower}" Value="0" />
+																					<Condition Binding="{Binding Item.ImprovementStats.Firepower}" Value="0" />
+																				</MultiDataTrigger.Conditions>
+																				<MultiDataTrigger.Setters>
+																					<Setter Property="Visibility" Value="Collapsed" />
+																				</MultiDataTrigger.Setters>
+																			</MultiDataTrigger>
+																		</Style.Triggers>
+																	</Style>
+																</TextBlock.Style>
+															</TextBlock>
+											
+															<TextBlock Margin="0,2,0,0">
+																<Run Text="뇌장:" />
+																<Run Text="{Binding Item.Info.Torpedo, Mode=OneWay}">
+																	<Run.Style>
+																		<Style TargetType="{x:Type Run}">
+																			<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																			<Style.Triggers>
+																				<DataTrigger Binding="{Binding Item.Info.Torpedo}" Value="0">
+																					<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																				</DataTrigger>
+																			</Style.Triggers>
+																		</Style>
+																	</Run.Style>
+																</Run>
+																<Run Foreground="#FF45A9A5">
+																	<Run.Style>
+																		<Style TargetType="{x:Type Run}">
+																			<Setter Property="Text" Value="{Binding Item.ImprovementStats.Torpedo, Mode=OneWay, StringFormat={}+{0:N2}}" />
+																			<Style.Triggers>
+																				<DataTrigger Binding="{Binding Item.ImprovementStats.Torpedo}" Value="0">
+																					<Setter Property="Text" Value="" />
+																				</DataTrigger>
+																			</Style.Triggers>
+																		</Style>
+																	</Run.Style>
+																</Run>
+
+																<TextBlock.Style>
+																	<Style TargetType="{x:Type TextBlock}">
+																		<Style.Triggers>
+																			<MultiDataTrigger>
+																				<MultiDataTrigger.Conditions>
+																					<Condition Binding="{Binding Item.Info.Torpedo}" Value="0" />
+																					<Condition Binding="{Binding Item.ImprovementStats.Torpedo}" Value="0" />
+																				</MultiDataTrigger.Conditions>
+																				<MultiDataTrigger.Setters>
+																					<Setter Property="Visibility" Value="Collapsed" />
+																				</MultiDataTrigger.Setters>
+																			</MultiDataTrigger>
+																		</Style.Triggers>
+																	</Style>
+																</TextBlock.Style>
+															</TextBlock>
+															<TextBlock Margin="0,2,0,0">
+																<Run Text="뇌격 명중:" />
+																<Run Foreground="#FF45A9A5"
+																	 Text="{Binding Item.ImprovementStats.TorpedoHit, Mode=OneWay, StringFormat={}+{0:N2}}" />
+
+																<TextBlock.Style>
+																	<Style TargetType="{x:Type TextBlock}">
+																		<Style.Triggers>
+																			<DataTrigger Binding="{Binding Item.ImprovementStats.TorpedoHit}" Value="0">
+																				<Setter Property="Visibility" Value="Collapsed" />
+																			</DataTrigger>
+																		</Style.Triggers>
+																	</Style>
+																</TextBlock.Style>
+															</TextBlock>
+
+															<TextBlock Margin="0,2,0,0">
+																<Run Text="대공:" />
+																<Run Text="{Binding Item.Info.AA, Mode=OneWay}">
+																	<Run.Style>
+																		<Style TargetType="{x:Type Run}">
+																			<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																			<Style.Triggers>
+																				<DataTrigger Binding="{Binding Item.Info.AA}" Value="0">
+																					<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																				</DataTrigger>
+																			</Style.Triggers>
+																		</Style>
+																	</Run.Style>
+																</Run>
+																<Run Foreground="#FF45A9A5">
+																	<Run.Style>
+																		<Style TargetType="{x:Type Run}">
+																			<Setter Property="Text" Value="{Binding Item.ImprovementStats.AA, Mode=OneWay, StringFormat={}+{0:N2}}" />
+																			<Style.Triggers>
+																				<DataTrigger Binding="{Binding Item.ImprovementStats.AA}" Value="0">
+																					<Setter Property="Text" Value="" />
+																				</DataTrigger>
+																			</Style.Triggers>
+																		</Style>
+																	</Run.Style>
+																</Run>
+
+																<TextBlock.Style>
+																	<Style TargetType="{x:Type TextBlock}">
+																		<Style.Triggers>
+																			<MultiDataTrigger>
+																				<MultiDataTrigger.Conditions>
+																					<Condition Binding="{Binding Item.Info.AA}" Value="0" />
+																					<Condition Binding="{Binding Item.ImprovementStats.AA}" Value="0" />
+																				</MultiDataTrigger.Conditions>
+																				<MultiDataTrigger.Setters>
+																					<Setter Property="Visibility" Value="Collapsed" />
+																				</MultiDataTrigger.Setters>
+																			</MultiDataTrigger>
+																		</Style.Triggers>
+																	</Style>
+																</TextBlock.Style>
+															</TextBlock>
+															<TextBlock Margin="0,2,0,0">
+																<Run Text="함대 방공:" />
+																<Run Foreground="#FF45A9A5"
+																	 Text="{Binding Item.ImprovementStats.FleetAA, Mode=OneWay, StringFormat={}+{0:N2}}" />
+
+																<TextBlock.Style>
+																	<Style TargetType="{x:Type TextBlock}">
+																		<Style.Triggers>
+																			<DataTrigger Binding="{Binding Item.ImprovementStats.FleetAA}" Value="0">
+																				<Setter Property="Visibility" Value="Collapsed" />
+																			</DataTrigger>
+																		</Style.Triggers>
+																	</Style>
+																</TextBlock.Style>
+															</TextBlock>
+
+															<TextBlock Margin="0,2,0,0">
+																<Run Text="장갑:" />
+																<Run Text="{Binding Item.Info.Armer, Mode=OneWay}">
+																	<Run.Style>
+																		<Style TargetType="{x:Type Run}">
+																			<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																			<Style.Triggers>
+																				<DataTrigger Binding="{Binding Item.Info.Armer}" Value="0">
+																					<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																				</DataTrigger>
+																			</Style.Triggers>
+																		</Style>
+																	</Run.Style>
+																</Run>
+																<Run Foreground="#FF45A9A5">
+																	<Run.Style>
+																		<Style TargetType="{x:Type Run}">
+																			<Setter Property="Text" Value="{Binding Item.ImprovementStats.Armor, Mode=OneWay, StringFormat={}+{0:N2}}" />
+																			<Style.Triggers>
+																				<DataTrigger Binding="{Binding Item.ImprovementStats.Armor}" Value="0">
+																					<Setter Property="Text" Value="" />
+																				</DataTrigger>
+																			</Style.Triggers>
+																		</Style>
+																	</Run.Style>
+																</Run>
+
+																<TextBlock.Style>
+																	<Style TargetType="{x:Type TextBlock}">
+																		<Style.Triggers>
+																			<MultiDataTrigger>
+																				<MultiDataTrigger.Conditions>
+																					<Condition Binding="{Binding Item.Info.Armer}" Value="0" />
+																					<Condition Binding="{Binding Item.ImprovementStats.Armor}" Value="0" />
+																				</MultiDataTrigger.Conditions>
+																				<MultiDataTrigger.Setters>
+																					<Setter Property="Visibility" Value="Collapsed" />
+																				</MultiDataTrigger.Setters>
+																			</MultiDataTrigger>
+																		</Style.Triggers>
+																	</Style>
+																</TextBlock.Style>
+															</TextBlock>
+															<TextBlock Margin="0,2,0,0">
+																<Run Text="폭장:" />
+																<Run Text="{Binding Item.Info.Bomb, Mode=OneWay}">
+																	<Run.Style>
+																		<Style TargetType="{x:Type Run}">
+																			<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																			<Style.Triggers>
+																				<DataTrigger Binding="{Binding Item.Info.Bomb}" Value="0">
+																					<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																				</DataTrigger>
+																			</Style.Triggers>
+																		</Style>
+																	</Run.Style>
+																</Run>
+																<Run Foreground="#FF45A9A5">
+																	<Run.Style>
+																		<Style TargetType="{x:Type Run}">
+																			<Setter Property="Text" Value="{Binding Item.ImprovementStats.Bomb, Mode=OneWay, StringFormat={}+{0:N2}}" />
+																			<Style.Triggers>
+																				<DataTrigger Binding="{Binding Item.ImprovementStats.Bomb}" Value="0">
+																					<Setter Property="Text" Value="" />
+																				</DataTrigger>
+																			</Style.Triggers>
+																		</Style>
+																	</Run.Style>
+																</Run>
+
+																<TextBlock.Style>
+																	<Style TargetType="{x:Type TextBlock}">
+																		<Style.Triggers>
+																			<MultiDataTrigger>
+																				<MultiDataTrigger.Conditions>
+																					<Condition Binding="{Binding Item.Info.Bomb}" Value="0" />
+																					<Condition Binding="{Binding Item.ImprovementStats.Bomb}" Value="0" />
+																				</MultiDataTrigger.Conditions>
+																				<MultiDataTrigger.Setters>
+																					<Setter Property="Visibility" Value="Collapsed" />
+																				</MultiDataTrigger.Setters>
+																			</MultiDataTrigger>
+																		</Style.Triggers>
+																	</Style>
+																</TextBlock.Style>
+															</TextBlock>
+
+															<TextBlock Margin="0,2,0,0">
+																<Run Text="대잠:" />
+																<Run Text="{Binding Item.Info.ASW, Mode=OneWay}">
+																	<Run.Style>
+																		<Style TargetType="{x:Type Run}">
+																			<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																			<Style.Triggers>
+																				<DataTrigger Binding="{Binding Item.Info.ASW}" Value="0">
+																					<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																				</DataTrigger>
+																			</Style.Triggers>
+																		</Style>
+																	</Run.Style>
+																</Run>
+																<Run Foreground="#FF45A9A5">
+																	<Run.Style>
+																		<Style TargetType="{x:Type Run}">
+																			<Setter Property="Text" Value="{Binding Item.ImprovementStats.ASW, Mode=OneWay, StringFormat={}+{0:N2}}" />
+																			<Style.Triggers>
+																				<DataTrigger Binding="{Binding Item.ImprovementStats.ASW}" Value="0">
+																					<Setter Property="Text" Value="" />
+																				</DataTrigger>
+																			</Style.Triggers>
+																		</Style>
+																	</Run.Style>
+																</Run>
+
+																<TextBlock.Style>
+																	<Style TargetType="{x:Type TextBlock}">
+																		<Style.Triggers>
+																			<MultiDataTrigger>
+																				<MultiDataTrigger.Conditions>
+																					<Condition Binding="{Binding Item.Info.ASW}" Value="0" />
+																					<Condition Binding="{Binding Item.ImprovementStats.ASW}" Value="0" />
+																				</MultiDataTrigger.Conditions>
+																				<MultiDataTrigger.Setters>
+																					<Setter Property="Visibility" Value="Collapsed" />
+																				</MultiDataTrigger.Setters>
+																			</MultiDataTrigger>
+																		</Style.Triggers>
+																	</Style>
+																</TextBlock.Style>
+															</TextBlock>
+															<TextBlock Margin="0,2,0,0">
+																<Run Text="대잠 명중:" />
+																<Run Foreground="#FF45A9A5"
+																	 Text="{Binding Item.ImprovementStats.ASWHit, Mode=OneWay, StringFormat={}+{0:N2}}" />
+
+																<TextBlock.Style>
+																	<Style TargetType="{x:Type TextBlock}">
+																		<Style.Triggers>
+																			<DataTrigger Binding="{Binding Item.ImprovementStats.ASWHit}" Value="0">
+																				<Setter Property="Visibility" Value="Collapsed" />
+																			</DataTrigger>
+																		</Style.Triggers>
+																	</Style>
+																</TextBlock.Style>
+															</TextBlock>
+
+															<TextBlock Margin="0,2,0,0">
+																<InlineUIContainer>
+																	<TextBlock>
+																		<TextBlock.Style>
+																			<Style TargetType="{x:Type TextBlock}">
+																				<Setter Property="Text" Value="명중:" />
+																				<Style.Triggers>
+																					<DataTrigger Binding="{Binding Item.Info.Type, Mode=OneWay}" Value="局地戦闘機">
+																						<Setter Property="Text" Value="대폭:" />
+																					</DataTrigger>
+																				</Style.Triggers>
+																			</Style>
+																		</TextBlock.Style>
+																	</TextBlock>
+																</InlineUIContainer>
+																<Run Text="{Binding Item.Info.Hit, Mode=OneWay}">
+																	<Run.Style>
+																		<Style TargetType="{x:Type Run}">
+																			<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																			<Style.Triggers>
+																				<DataTrigger Binding="{Binding Item.Info.Hit}" Value="0">
+																					<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																				</DataTrigger>
+																			</Style.Triggers>
+																		</Style>
+																	</Run.Style>
+																</Run>
+																<Run Foreground="#FF45A9A5">
+																	<Run.Style>
+																		<Style TargetType="{x:Type Run}">
+																			<Setter Property="Text" Value="{Binding Item.ImprovementStats.Hit, Mode=OneWay, StringFormat={}+{0:N2}}" />
+																			<Style.Triggers>
+																				<DataTrigger Binding="{Binding Item.ImprovementStats.Hit}" Value="0">
+																					<Setter Property="Text" Value="" />
+																				</DataTrigger>
+																			</Style.Triggers>
+																		</Style>
+																	</Run.Style>
+																</Run>
+
+																<TextBlock.Style>
+																	<Style TargetType="{x:Type TextBlock}">
+																		<Style.Triggers>
+																			<MultiDataTrigger>
+																				<MultiDataTrigger.Conditions>
+																					<Condition Binding="{Binding Item.Info.Hit}" Value="0" />
+																					<Condition Binding="{Binding Item.ImprovementStats.Hit}" Value="0" />
+																				</MultiDataTrigger.Conditions>
+																				<MultiDataTrigger.Setters>
+																					<Setter Property="Visibility" Value="Collapsed" />
+																				</MultiDataTrigger.Setters>
+																			</MultiDataTrigger>
+																		</Style.Triggers>
+																	</Style>
+																</TextBlock.Style>
+															</TextBlock>
+															<TextBlock Margin="0,2,0,0">
+																<InlineUIContainer>
+																	<TextBlock>
+																		<TextBlock.Style>
+																			<Style TargetType="{x:Type TextBlock}">
+																				<Setter Property="Text" Value="회피:" />
+																				<Style.Triggers>
+																					<DataTrigger Binding="{Binding Item.Info.Type, Mode=OneWay}" Value="局地戦闘機">
+																						<Setter Property="Text" Value="영격:" />
+																					</DataTrigger>
+																				</Style.Triggers>
+																			</Style>
+																		</TextBlock.Style>
+																	</TextBlock>
+																</InlineUIContainer>
+																<Run Text="{Binding Item.Info.Evade, Mode=OneWay}">
+																	<Run.Style>
+																		<Style TargetType="{x:Type Run}">
+																			<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																			<Style.Triggers>
+																				<DataTrigger Binding="{Binding Item.Info.Evade}" Value="0">
+																					<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																				</DataTrigger>
+																			</Style.Triggers>
+																		</Style>
+																	</Run.Style>
+																</Run>
+																<Run Foreground="#FF45A9A5">
+																	<Run.Style>
+																		<Style TargetType="{x:Type Run}">
+																			<Setter Property="Text" Value="{Binding Item.ImprovementStats.Evade, Mode=OneWay, StringFormat={}+{0:N2}}" />
+																			<Style.Triggers>
+																				<DataTrigger Binding="{Binding Item.ImprovementStats.Evade}" Value="0">
+																					<Setter Property="Text" Value="" />
+																				</DataTrigger>
+																			</Style.Triggers>
+																		</Style>
+																	</Run.Style>
+																</Run>
+
+																<TextBlock.Style>
+																	<Style TargetType="{x:Type TextBlock}">
+																		<Style.Triggers>
+																			<MultiDataTrigger>
+																				<MultiDataTrigger.Conditions>
+																					<Condition Binding="{Binding Item.Info.Evade}" Value="0" />
+																					<Condition Binding="{Binding Item.ImprovementStats.Evade}" Value="0" />
+																				</MultiDataTrigger.Conditions>
+																				<MultiDataTrigger.Setters>
+																					<Setter Property="Visibility" Value="Collapsed" />
+																				</MultiDataTrigger.Setters>
+																			</MultiDataTrigger>
+																		</Style.Triggers>
+																	</Style>
+																</TextBlock.Style>
+															</TextBlock>
+
+															<TextBlock Margin="0,2,0,0">
+																<Run Text="색적:" />
+																<Run Text="{Binding Item.Info.ViewRange, Mode=OneWay}">
+																	<Run.Style>
+																		<Style TargetType="{x:Type Run}">
+																			<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																			<Style.Triggers>
+																				<DataTrigger Binding="{Binding Item.Info.ViewRange}" Value="0">
+																					<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																				</DataTrigger>
+																			</Style.Triggers>
+																		</Style>
+																	</Run.Style>
+																</Run>
+																<Run Foreground="#FF45A9A5">
+																	<Run.Style>
+																		<Style TargetType="{x:Type Run}">
+																			<Setter Property="Text" Value="{Binding Item.ImprovementStats.LoS, Mode=OneWay, StringFormat={}+{0:N2}}" />
+																			<Style.Triggers>
+																				<DataTrigger Binding="{Binding Item.ImprovementStats.LoS}" Value="0">
+																					<Setter Property="Text" Value="" />
+																				</DataTrigger>
+																			</Style.Triggers>
+																		</Style>
+																	</Run.Style>
+																</Run>
+
+																<TextBlock.Style>
+																	<Style TargetType="{x:Type TextBlock}">
+																		<Style.Triggers>
+																			<MultiDataTrigger>
+																				<MultiDataTrigger.Conditions>
+																					<Condition Binding="{Binding Item.Info.ViewRange}" Value="0" />
+																					<Condition Binding="{Binding Item.ImprovementStats.LoS}" Value="0" />
+																				</MultiDataTrigger.Conditions>
+																				<MultiDataTrigger.Setters>
+																					<Setter Property="Visibility" Value="Collapsed" />
+																				</MultiDataTrigger.Setters>
+																			</MultiDataTrigger>
+																		</Style.Triggers>
+																	</Style>
+																</TextBlock.Style>
+															</TextBlock>
+
+															<TextBlock Margin="0,10,0,0">
+																<Run Text="원정 보너스: +" />
+																<Run Text="{Binding Item.Info.ExpeditionBonus, Mode=OneWay}">
+																	<Run.Style>
+																		<Style TargetType="{x:Type Run}">
+																			<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																			<Style.Triggers>
+																				<DataTrigger Binding="{Binding Item.Info.ExpeditionBonus}" Value="0">
+																					<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																				</DataTrigger>
+																			</Style.Triggers>
+																		</Style>
+																	</Run.Style>
+																</Run>
+																<Run Foreground="#FF45A9A5">
+																	<Run.Style>
+																		<Style TargetType="{x:Type Run}">
+																			<Setter Property="Text" Value="{Binding Item.ImprovementStats.ExpeditionBonus, Mode=OneWay, StringFormat={}+{0:N2}}" />
+																			<Style.Triggers>
+																				<DataTrigger Binding="{Binding Item.ImprovementStats.ExpeditionBonus}" Value="0">
+																					<Setter Property="Text" Value="" />
+																				</DataTrigger>
+																			</Style.Triggers>
+																		</Style>
+																	</Run.Style>
+																</Run>
+																<Run Text="%" />
+
+																<TextBlock.Style>
+																	<Style TargetType="{x:Type TextBlock}">
+																		<Style.Triggers>
+																			<MultiDataTrigger>
+																				<MultiDataTrigger.Conditions>
+																					<Condition Binding="{Binding Item.Info.ExpeditionBonus}" Value="0" />
+																					<Condition Binding="{Binding Item.ImprovementStats.ExpeditionBonus}" Value="0" />
+																				</MultiDataTrigger.Conditions>
+																				<MultiDataTrigger.Setters>
+																					<Setter Property="Visibility" Value="Collapsed" />
+																				</MultiDataTrigger.Setters>
+																			</MultiDataTrigger>
+																		</Style.Triggers>
+																	</Style>
+																</TextBlock.Style>
+															</TextBlock>
+															<TextBlock Margin="0,10,0,0">
+																<Run Text="포대형 특화 계수: 포격전 화력 x (" />
+																<Run Text="{Binding Item.Info.TurrentEfficacy, Mode=OneWay, StringFormat={}{0:N2}}">
+																	<Run.Style>
+																		<Style TargetType="{x:Type Run}">
+																			<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																			<Style.Triggers>
+																				<DataTrigger Binding="{Binding Item.Info.TurrentEfficacy}" Value="0">
+																					<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																				</DataTrigger>
+																			</Style.Triggers>
+																		</Style>
+																	</Run.Style>
+																</Run>
+																<Run Foreground="#FF45A9A5">
+																	<Run.Style>
+																		<Style TargetType="{x:Type Run}">
+																			<Setter Property="Text" Value="{Binding Item.ImprovementStats.TurrentEfficacy, Mode=OneWay, StringFormat={}+{0:N2}}" />
+																			<Style.Triggers>
+																				<DataTrigger Binding="{Binding Item.ImprovementStats.TurrentEfficacy}" Value="0">
+																					<Setter Property="Text" Value="" />
+																				</DataTrigger>
+																			</Style.Triggers>
+																		</Style>
+																	</Run.Style>
+																</Run>
+																<Run Text=")" />
+
+																<TextBlock.Style>
+																	<Style TargetType="{x:Type TextBlock}">
+																		<Style.Triggers>
+																			<MultiDataTrigger>
+																				<MultiDataTrigger.Conditions>
+																					<Condition Binding="{Binding Item.Info.TurrentEfficacy}" Value="0" />
+																					<Condition Binding="{Binding Item.ImprovementStats.TurrentEfficacy}" Value="0" />
+																				</MultiDataTrigger.Conditions>
+																				<MultiDataTrigger.Setters>
+																					<Setter Property="Visibility" Value="Collapsed" />
+																				</MultiDataTrigger.Setters>
+																			</MultiDataTrigger>
+																		</Style.Triggers>
+																	</Style>
+																</TextBlock.Style>
+															</TextBlock>
+
+															<TextBlock Margin="0,10,0,0">
+																<Run Text="항속거리:" />
+																<Run Text="{Binding Item.Info.Distance, Mode=OneWay}">
+																	<Run.Style>
+																		<Style TargetType="{x:Type Run}">
+																			<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																			<Style.Triggers>
+																				<DataTrigger Binding="{Binding Item.Info.Distance}" Value="0">
+																					<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																				</DataTrigger>
+																			</Style.Triggers>
+																		</Style>
+																	</Run.Style>
+																</Run>
+
+																<TextBlock.Style>
+																	<Style TargetType="{x:Type TextBlock}">
+																		<Style.Triggers>
+																			<DataTrigger Binding="{Binding Item.Info.IsNumerable}" Value="False">
+																				<Setter Property="Visibility" Value="Collapsed" />
+																			</DataTrigger>
+																		</Style.Triggers>
+																	</Style>
+																</TextBlock.Style>
+															</TextBlock>
+															<TextBlock Margin="0,2,0,0">
+																<Run Text="배치비용:" />
+																<Run Text="{Binding Item.Info.AirBaseCost, Mode=OneWay}">
+																	<Run.Style>
+																		<Style TargetType="{x:Type Run}">
+																			<Setter Property="Foreground" Value="{DynamicResource ActiveForegroundBrushKey}" />
+																			<Style.Triggers>
+																				<DataTrigger Binding="{Binding Item.Info.AirBaseCost}" Value="0">
+																					<Setter Property="Foreground" Value="{DynamicResource InactiveForegroundBrushKey}" />
+																				</DataTrigger>
+																			</Style.Triggers>
+																		</Style>
+																	</Run.Style>
+																</Run>
+
+																<TextBlock.Style>
+																	<Style TargetType="{x:Type TextBlock}">
+																		<Style.Triggers>
+																			<DataTrigger Binding="{Binding Item.Info.IsNumerable}" Value="False">
+																				<Setter Property="Visibility" Value="Collapsed" />
+																			</DataTrigger>
+																		</Style.Triggers>
+																	</Style>
+																</TextBlock.Style>
+															</TextBlock>
+														</StackPanel>
+													</Border.ToolTip>
 												</Border>
 											</DockPanel>
 										</DockPanel>

--- a/source/Grabacr07.KanColleViewer/Views/Contents/Expeditions.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Contents/Expeditions.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="Grabacr07.KanColleViewer.Views.Contents.Expeditions"
+<UserControl x:Class="Grabacr07.KanColleViewer.Views.Contents.Expeditions"
 			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 			 xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
@@ -175,12 +175,148 @@
 
 							<Border Grid.Row="2" Margin="0,5" Height=".99" Background="{DynamicResource BorderBrushKey}" />
 
-							<TextBlock x:Name="NotExcution"
-									   Grid.Row="3"
-									   Text="{Binding Resources.Expedition_OnHomeport, Source={x:Static models:ResourceService.Current}, Mode=OneWay}"
-									   Style="{DynamicResource EmphaticTextStyleKey}"
-									   HorizontalAlignment="Center"
-									   Visibility="Collapsed" />
+							<Grid x:Name="NotExcution"
+								  Grid.Row="3"
+								  Visibility="Collapsed">
+								<Grid.RowDefinitions>
+									<RowDefinition Height="Auto" />
+									<RowDefinition Height="Auto" />
+									<RowDefinition Height="*" />
+								</Grid.RowDefinitions>
+
+								<TextBlock Margin="10"
+										   Text="{Binding Resources.Expedition_OnHomeport, Source={x:Static models:ResourceService.Current}, Mode=OneWay}"
+										   Style="{DynamicResource EmphaticTextStyleKey}"
+										   HorizontalAlignment="Center" />
+
+								<Border Grid.Row="1"
+										Margin="0,5"
+										Height=".99"
+										Background="{DynamicResource BorderBrushKey}" />
+
+								<StackPanel Grid.Row="2">
+									<TextBlock Text="마지막 원정 결과"
+											   Style="{DynamicResource HeaderTextStyleKey}" />
+									<TextBlock TextAlignment="Center"
+											   Margin="0,10">
+										<TextBlock.Style>
+											<Style TargetType="{x:Type TextBlock}"
+												   BasedOn="{StaticResource _TextBaseStyleKey}">
+												<Setter Property="FontFamily" Value="{DynamicResource EmphaticFontFamilyKey}" />
+												<Setter Property="FontSize" Value="{DynamicResource EmphaticFontSizeKey}" />
+												<Setter Property="FontWeight" Value="SemiBold" />
+												<Setter Property="TextTrimming" Value="WordEllipsis" />
+												<Setter Property="TextWrapping" Value="Wrap" />
+												
+												<Setter Property="Foreground" Value="#80FFFFFF" />
+												<Setter Property="Text" Value="" />
+												
+												<Style.Triggers>
+													<DataTrigger Binding="{Binding Expedition.ExpeditionResult.Result}" Value="0">
+														<Setter Property="Foreground" Value="#FFE03020" />
+														<Setter Property="Text" Value="실패" />
+													</DataTrigger>
+													<DataTrigger Binding="{Binding Expedition.ExpeditionResult.Result}" Value="1">
+														<Setter Property="Foreground" Value="Gold" />
+														<Setter Property="Text" Value="성공" />
+													</DataTrigger>
+													<DataTrigger Binding="{Binding Expedition.ExpeditionResult.Result}" Value="2">
+														<Setter Property="Foreground" Value="#FFFFE558" />
+														<Setter Property="Text" Value="대성공" />
+													</DataTrigger>
+												</Style.Triggers>
+											</Style>
+										</TextBlock.Style>
+									</TextBlock>
+
+									<Grid Margin="8,0">
+										<Grid.ColumnDefinitions>
+											<ColumnDefinition Width="*" />
+											<ColumnDefinition Width="Auto" />
+											<ColumnDefinition Width="Auto" />
+											<ColumnDefinition Width="Auto" />
+										</Grid.ColumnDefinitions>
+
+										<TextBlock Text="{Binding Resources.Expedition_Expect_Fuel, Source={x:Static models:ResourceService.Current}, Mode=OneWay}"
+												   Style="{DynamicResource DefaultTextStyleKey}" />
+										<TextBlock Grid.Column="1"
+												   Text="{Binding Expedition.ExpeditionResult.Fuel, Mode=OneWay}"
+												   Style="{DynamicResource DefaultTextStyleKey}" />
+									</Grid>
+									<Grid Margin="8,0">
+										<Grid.ColumnDefinitions>
+											<ColumnDefinition Width="*" />
+											<ColumnDefinition Width="Auto" />
+											<ColumnDefinition Width="Auto" />
+											<ColumnDefinition Width="Auto" />
+										</Grid.ColumnDefinitions>
+
+										<TextBlock Grid.Row="1"
+												   Text="{Binding Resources.Expedition_Expect_Ammo, Source={x:Static models:ResourceService.Current}, Mode=OneWay}"
+												   Style="{DynamicResource DefaultTextStyleKey}" />
+										<TextBlock Grid.Row="1"
+												   Grid.Column="1"
+												   Text="{Binding Expedition.ExpeditionResult.Ammo, Mode=OneWay}"
+												   Style="{DynamicResource DefaultTextStyleKey}" />
+									</Grid>
+									<Grid Margin="8,0">
+										<Grid.ColumnDefinitions>
+											<ColumnDefinition Width="*" />
+											<ColumnDefinition Width="Auto" />
+											<ColumnDefinition Width="Auto" />
+											<ColumnDefinition Width="Auto" />
+										</Grid.ColumnDefinitions>
+
+										<TextBlock Grid.Row="2"
+												   Text="{Binding Resources.Expedition_Expect_Steel, Source={x:Static models:ResourceService.Current}, Mode=OneWay}"
+												   Style="{DynamicResource DefaultTextStyleKey}" />
+										<TextBlock Grid.Row="2"
+												   Grid.Column="1"
+												   Text="{Binding Expedition.ExpeditionResult.Steel, Mode=OneWay}"
+												   Style="{DynamicResource DefaultTextStyleKey}" />
+									</Grid>
+									<Grid Margin="8,0">
+										<Grid.ColumnDefinitions>
+											<ColumnDefinition Width="*" />
+											<ColumnDefinition Width="Auto" />
+											<ColumnDefinition Width="Auto" />
+											<ColumnDefinition Width="Auto" />
+										</Grid.ColumnDefinitions>
+
+										<TextBlock Grid.Row="3"
+												   Text="{Binding Resources.Expedition_Expect_Bauxite, Source={x:Static models:ResourceService.Current}, Mode=OneWay}"
+												   Style="{DynamicResource DefaultTextStyleKey}" />
+										<TextBlock Grid.Row="3"
+												   Grid.Column="1"
+												   Text="{Binding Expedition.ExpeditionResult.Bauxite, Mode=OneWay}"
+												   Style="{DynamicResource DefaultTextStyleKey}" />
+									</Grid>
+
+									<ItemsControl ItemsSource="{Binding Expedition.ExpeditionResult.Items}"
+												  Margin="0,10,0,0">
+										<ItemsControl.ItemTemplate>
+											<DataTemplate>
+												<Grid Margin="8,0">
+													<Grid.ColumnDefinitions>
+														<ColumnDefinition Width="*" />
+														<ColumnDefinition Width="Auto" />
+														<ColumnDefinition Width="Auto" />
+														<ColumnDefinition Width="Auto" />
+													</Grid.ColumnDefinitions>
+
+													<TextBlock Grid.Row="3"
+															   Text="{Binding Name, Mode=OneWay, StringFormat={}{0}:}"
+															   Style="{DynamicResource DefaultTextStyleKey}" />
+													<TextBlock Grid.Row="3"
+															   Grid.Column="1"
+															   Text="{Binding Count, Mode=OneWay}"
+															   Style="{DynamicResource DefaultTextStyleKey}" />
+												</Grid>
+											</DataTemplate>
+										</ItemsControl.ItemTemplate>
+									</ItemsControl>
+								</StackPanel>
+							</Grid>
 							<TextBlock x:Name="InSortie"
 									   Grid.Row="3"
 									   Text="{Binding Resources.Expedition_OnSortie, Source={x:Static models:ResourceService.Current}, Mode=OneWay}"
@@ -244,8 +380,8 @@
 									<Border Margin="0,8" Height=".99" Background="{DynamicResource BorderBrushKey}" />
 
 									<TextBlock Margin="0,0,0,4"
-													   Text="{Binding Resources.Expedition_Conditions, Source={x:Static models:ResourceService.Current}, Mode=OneWay}"
-													   Style="{DynamicResource HeaderTextStyleKey}" />
+											   Text="{Binding Resources.Expedition_Conditions, Source={x:Static models:ResourceService.Current}, Mode=OneWay}"
+											   Style="{DynamicResource HeaderTextStyleKey}" />
 
 									<ItemsControl ItemsSource="{Binding Ships}">
 										<ItemsControl.ItemsPanel>
@@ -256,12 +392,12 @@
 										<ItemsControl.ItemTemplate>
 											<DataTemplate>
 												<StackPanel Orientation="Horizontal"
-																	Margin="5,3">
+															Margin="5,3">
 													<kcvc:ConditionIcon ConditionType="{Binding Ship.ConditionType, Mode=OneWay}" />
 
 													<TextBlock Margin="4,0,0,0"
-																	   Text="{Binding Ship.Condition, Mode=OneWay}"
-																	   Style="{DynamicResource DefaultTextStyleKey}" />
+															   Text="{Binding Ship.Condition, Mode=OneWay}"
+															   Style="{DynamicResource DefaultTextStyleKey}" />
 												</StackPanel>
 											</DataTemplate>
 										</ItemsControl.ItemTemplate>
@@ -273,9 +409,9 @@
 									<Border Margin="0,8" Height=".99" Background="{DynamicResource BorderBrushKey}" />
 
 									<TextBlock Margin="0,0,0,4"
-													   Style="{DynamicResource HeaderTextStyleKey}">
-												<Run Text="{Binding Resources.Expedition_ExpectRes, Source={x:Static models:ResourceService.Current}, Mode=OneWay}" />
-												<Run Text="{Binding Resources.Expedition_ExpectResGreat, Source={x:Static models:ResourceService.Current}, Mode=OneWay}" Style="{DynamicResource EmphaticTextElementStyleKey}"/><Run Text=")" />
+											   Style="{DynamicResource HeaderTextStyleKey}">
+										<Run Text="{Binding Resources.Expedition_ExpectRes, Source={x:Static models:ResourceService.Current}, Mode=OneWay}" />
+										<Run Text="{Binding Resources.Expedition_ExpectResGreat, Source={x:Static models:ResourceService.Current}, Mode=OneWay}" Style="{DynamicResource EmphaticTextElementStyleKey}"/><Run Text=")" />
 									</TextBlock>
 
 									<Grid Margin="8,0">
@@ -287,17 +423,20 @@
 										</Grid.ColumnDefinitions>
 
 										<TextBlock Text="{Binding Resources.Expedition_Expect_Fuel, Source={x:Static models:ResourceService.Current}, Mode=OneWay}"
-														   Style="{DynamicResource DefaultTextStyleKey}" />
+												   VerticalAlignment="Bottom"
+												   Style="{DynamicResource DefaultTextStyleKey}" />
 										<TextBlock Grid.Column="1"
-														   Text="{Binding ResultData.ExpFuel, Mode=OneWay}"
-														   Style="{DynamicResource DefaultTextStyleKey}" />
+												   VerticalAlignment="Bottom"
+												   Text="{Binding ResultData.ExpFuel, Mode=OneWay}"
+												   Style="{DynamicResource DefaultTextStyleKey}" />
 										<TextBlock Grid.Column="2"
-														   Margin="4,0"
-														   Text="/"
-														   Style="{DynamicResource DefaultTextStyleKey}" />
+												   Margin="4,0"
+												   Text="/"
+												   VerticalAlignment="Bottom"
+												   Style="{DynamicResource DefaultTextStyleKey}" />
 										<TextBlock Grid.Column="3"
-														   Text="{Binding ResultData.ExpGreatFuel, Mode=OneWay}"
-														   Style="{DynamicResource EmphaticTextStyleKey}" />
+												   Text="{Binding ResultData.ExpGreatFuel, Mode=OneWay}"
+												   Style="{DynamicResource EmphaticTextStyleKey}" />
 									</Grid>
 									<Grid Margin="8,0">
 										<Grid.ColumnDefinitions>
@@ -308,21 +447,24 @@
 										</Grid.ColumnDefinitions>
 
 										<TextBlock Grid.Row="1"
-														   Text="{Binding Resources.Expedition_Expect_Ammo, Source={x:Static models:ResourceService.Current}, Mode=OneWay}"
-														   Style="{DynamicResource DefaultTextStyleKey}" />
+												   VerticalAlignment="Bottom"
+												   Text="{Binding Resources.Expedition_Expect_Ammo, Source={x:Static models:ResourceService.Current}, Mode=OneWay}"
+												   Style="{DynamicResource DefaultTextStyleKey}" />
 										<TextBlock Grid.Row="1"
-														   Grid.Column="1"
-														   Text="{Binding ResultData.ExpAmmo, Mode=OneWay}"
-														   Style="{DynamicResource DefaultTextStyleKey}" />
+												   Grid.Column="1"
+												   VerticalAlignment="Bottom"
+												   Text="{Binding ResultData.ExpAmmo, Mode=OneWay}"
+												   Style="{DynamicResource DefaultTextStyleKey}" />
 										<TextBlock Grid.Row="1"
-														   Grid.Column="2"
-														   Margin="4,0"
-														   Text="/"
-														   Style="{DynamicResource DefaultTextStyleKey}" />
+												   Grid.Column="2"
+												   Margin="4,0"
+												   Text="/"
+												   VerticalAlignment="Bottom"
+												   Style="{DynamicResource DefaultTextStyleKey}" />
 										<TextBlock Grid.Row="1"
-														   Grid.Column="3"
-														   Text="{Binding ResultData.ExpGreatAmmo, Mode=OneWay}"
-														   Style="{DynamicResource EmphaticTextStyleKey}" />
+												   Grid.Column="3"
+												   Text="{Binding ResultData.ExpGreatAmmo, Mode=OneWay}"
+												   Style="{DynamicResource EmphaticTextStyleKey}" />
 									</Grid>
 									<Grid Margin="8,0">
 										<Grid.ColumnDefinitions>
@@ -333,21 +475,24 @@
 										</Grid.ColumnDefinitions>
 
 										<TextBlock Grid.Row="2"
-														   Text="{Binding Resources.Expedition_Expect_Steel, Source={x:Static models:ResourceService.Current}, Mode=OneWay}"
-														   Style="{DynamicResource DefaultTextStyleKey}" />
+												   VerticalAlignment="Bottom"
+												   Text="{Binding Resources.Expedition_Expect_Steel, Source={x:Static models:ResourceService.Current}, Mode=OneWay}"
+												   Style="{DynamicResource DefaultTextStyleKey}" />
 										<TextBlock Grid.Row="2"
-														   Grid.Column="1"
-														   Text="{Binding ResultData.ExpSteel, Mode=OneWay}"
-														   Style="{DynamicResource DefaultTextStyleKey}" />
+												   Grid.Column="1"
+												   VerticalAlignment="Bottom"
+												   Text="{Binding ResultData.ExpSteel, Mode=OneWay}"
+												   Style="{DynamicResource DefaultTextStyleKey}" />
 										<TextBlock Grid.Row="2"
-														   Grid.Column="2"
-														   Margin="4,0"
-														   Text="/"
-														   Style="{DynamicResource DefaultTextStyleKey}" />
+												   Grid.Column="2"
+												   Margin="4,0"
+												   Text="/"
+												   VerticalAlignment="Bottom"
+												   Style="{DynamicResource DefaultTextStyleKey}" />
 										<TextBlock Grid.Row="2"
-														   Grid.Column="3"
-														   Text="{Binding ResultData.ExpGreatSteel, Mode=OneWay}"
-														   Style="{DynamicResource EmphaticTextStyleKey}" />
+												   Grid.Column="3"
+												   Text="{Binding ResultData.ExpGreatSteel, Mode=OneWay}"
+												   Style="{DynamicResource EmphaticTextStyleKey}" />
 									</Grid>
 									<Grid Margin="8,0">
 										<Grid.ColumnDefinitions>
@@ -358,21 +503,24 @@
 										</Grid.ColumnDefinitions>
 
 										<TextBlock Grid.Row="3"
-														   Text="{Binding Resources.Expedition_Expect_Bauxite, Source={x:Static models:ResourceService.Current}, Mode=OneWay}"
-														   Style="{DynamicResource DefaultTextStyleKey}" />
+												   VerticalAlignment="Bottom"
+												   Text="{Binding Resources.Expedition_Expect_Bauxite, Source={x:Static models:ResourceService.Current}, Mode=OneWay}"
+												   Style="{DynamicResource DefaultTextStyleKey}" />
 										<TextBlock Grid.Row="3"
-														   Grid.Column="1"
-														   Text="{Binding ResultData.ExpBauxite, Mode=OneWay}"
-														   Style="{DynamicResource DefaultTextStyleKey}" />
+												   Grid.Column="1"
+												   VerticalAlignment="Bottom"
+												   Text="{Binding ResultData.ExpBauxite, Mode=OneWay}"
+												   Style="{DynamicResource DefaultTextStyleKey}" />
 										<TextBlock Grid.Row="3"
-														   Grid.Column="2"
-														   Margin="4,0"
-														   Text="/"
-														   Style="{DynamicResource DefaultTextStyleKey}" />
+												   Grid.Column="2"
+												   Margin="4,0"
+												   Text="/"
+												   VerticalAlignment="Bottom"
+												   Style="{DynamicResource DefaultTextStyleKey}" />
 										<TextBlock Grid.Row="3"
-														   Grid.Column="3"
-														   Text="{Binding ResultData.ExpGreatBauxite, Mode=OneWay}"
-														   Style="{DynamicResource EmphaticTextStyleKey}" />
+												   Grid.Column="3"
+												   Text="{Binding ResultData.ExpGreatBauxite, Mode=OneWay}"
+												   Style="{DynamicResource EmphaticTextStyleKey}" />
 									</Grid>
 								</StackPanel>
 							</StackPanel>

--- a/source/Grabacr07.KanColleViewer/Views/Contents/Fleets.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Contents/Fleets.xaml
@@ -761,6 +761,7 @@
 								<Grid.RowDefinitions>
 									<RowDefinition Height="Auto" />
 									<RowDefinition Height="Auto" />
+									<RowDefinition Height="Auto" />
 								</Grid.RowDefinitions>
 
 								<TextBlock Grid.Column="0"

--- a/source/Grabacr07.KanColleViewer/Views/Controls/GraphControl.cs
+++ b/source/Grabacr07.KanColleViewer/Views/Controls/GraphControl.cs
@@ -167,16 +167,6 @@ namespace Grabacr07.KanColleViewer.Views.Controls
 			RenderHorizontalLine(g, sz, yList);
 			RenderVerticalLine(g, sz, xList);
 
-			if (GuideLine.HasValue)
-			{
-				var y = sz.Height - BottomMargin - 2 - (int)((float)(GuideLine.Value - YMin) / (YMax - YMin) * (sz.Height - BottomMargin - 2));
-				g.DrawLine(
-					new Pen(Color.FromArgb(0x40, 0x7E, 0x1D, 0xBF), 1.77f),
-					new System.Drawing.Point(LeftMargin, y),
-					new System.Drawing.Point(sz.Width, y)
-				);
-			}
-
 			foreach (var type in ElementToDraw)
 			{
 				var color = colorTable[type];
@@ -203,20 +193,10 @@ namespace Grabacr07.KanColleViewer.Views.Controls
 				path.AddLine(
 					new System.Drawing.Point(
 						pt.X,
-						pt.Y
-					),
-					new System.Drawing.Point(
-						pt.X + 5,
-						pt.Y
-					)
-				);
-				path.AddLine(
-					new System.Drawing.Point(
-						pt.X + 5,
 						sz.Height - BottomMargin + 4 - 1
 					),
 					new System.Drawing.Point(
-						pt.X + 5,
+						pt.X,
 						sz.Height - BottomMargin + 4 - 1
 					)
 				);
@@ -224,6 +204,17 @@ namespace Grabacr07.KanColleViewer.Views.Controls
 				g.FillPath(new SolidBrush(Color.FromArgb(51, color)), path);
 				g.DrawPath(new Pen(color, 2.15f), path);
 			}
+
+			if (GuideLine.HasValue)
+			{
+				var y = sz.Height - BottomMargin - 2 - (int)((float)(GuideLine.Value - YMin) / (YMax - YMin) * (sz.Height - BottomMargin - 2));
+				g.DrawLine(
+					new Pen(Color.FromArgb(0xC0, 0x7E, 0x1D, 0xBF), 1.77f),
+					new System.Drawing.Point(LeftMargin, y),
+					new System.Drawing.Point(sz.Width, y)
+				);
+			}
+
 			g.ResetClip();
 		}
 

--- a/source/Grabacr07.KanColleWrapper/KanColleWrapper.csproj
+++ b/source/Grabacr07.KanColleWrapper/KanColleWrapper.csproj
@@ -124,6 +124,7 @@
     <Compile Include="Models\ASWCalculator.cs" />
     <Compile Include="Models\CombinedFleet.cs" />
     <Compile Include="Models\CombinedFleetType.cs" />
+    <Compile Include="Models\ExpeditionResult.cs" />
     <Compile Include="Models\FleetSpeed.cs" />
     <Compile Include="Models\FleetState.cs" />
     <Compile Include="Models\LogDataList.cs" />

--- a/source/Grabacr07.KanColleWrapper/Logger.cs
+++ b/source/Grabacr07.KanColleWrapper/Logger.cs
@@ -246,15 +246,18 @@ namespace Grabacr07.KanColleWrapper
 			if (br.api_get_ship != null)
 				ShipName = KanColleClient.Current.Translations.GetTranslation(br.api_get_ship.api_ship_name, TranslationType.Ships, false, br);
 
-			if (br.api_get_useitem != null)
+			var _item = KanColleClient.Current.Master.UseItems
+				.SingleOrDefault(x => x.Value.Id == br.api_get_useitem?.api_useitem_id).Value
+				?.Name;
+			if (_item != null)
+			{
 				ItemName = KanColleClient.Current.Translations.GetTranslation(
-					KanColleClient.Current.Master.UseItems
-						.SingleOrDefault(x => x.Value.Id == br.api_get_useitem.api_useitem_id).Value
-						?.Name,
+					_item,
 					TranslationType.Useitems,
 					false,
 					br
 				);
+			}
 
 			MapType = KanColleClient.Current.Translations.GetTranslation(br.api_quest_name, TranslationType.OperationMaps, false, br);
 
@@ -264,7 +267,7 @@ namespace Grabacr07.KanColleWrapper
 			//날짜,해역이름,해역,보스,적 함대,랭크,드랍
 			Log(
 				LogType.ShipDrop,
-				"{0},{1},{2},{3},{4},{5},{6}",
+				"{0},{1},{2},{3},{4},{5},{6},{7}",
 				currentTime,
 				MapType,
 				$"{NodeData.SelectToken("world").ToString()}-{(int)NodeData.SelectToken("mapnum")}-{(int)NodeData.SelectToken("node")}",
@@ -329,21 +332,22 @@ namespace Grabacr07.KanColleWrapper
 				}
 				else if (Type == LogType.ShipDrop)
 				{
-					if (!System.IO.File.Exists(MainFolder + "\\DropLog2.csv"))
+					var csvPath = Path.Combine(MainFolder, "DropLog2.csv");
+
+					if (!System.IO.File.Exists(csvPath))
 					{
-						var csvPath = Path.Combine(MainFolder, "DropLog2.csv");
 						using (var fileStream = new FileStream(csvPath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
 						using (var writer = new BinaryWriter(fileStream))
 						{
 							writer.Write(utf8Bom);
 						}
-						using (StreamWriter w = File.AppendText(MainFolder + "\\DropLog2.csv"))
+						using (StreamWriter w = File.AppendText(csvPath))
 						{
 							w.WriteLine("날짜,해역이름,해역,보스,적 함대,랭크,드랍,아이템", args);
 						}
 					}
 
-					using (StreamWriter w = File.AppendText(MainFolder + "\\DropLog2.csv"))
+					using (StreamWriter w = File.AppendText(csvPath))
 					{
 						w.WriteLine(format, args);
 					}
@@ -445,6 +449,7 @@ namespace Grabacr07.KanColleWrapper
 				item.EnemyFleet = args[4].ToString();
 				item.Rank = args[5].ToString();
 				item.Drop = args[6].ToString();
+				item.ItemDrop = args[7].ToString();
 
 				using (var fileStream = new FileStream(binPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite))
 				using (var writer = new BinaryWriter(fileStream))
@@ -457,6 +462,7 @@ namespace Grabacr07.KanColleWrapper
 					writer.Write(item.EnemyFleet);
 					writer.Write(item.Rank);
 					writer.Write(item.Drop);
+					writer.Write(item.ItemDrop);
 
 					fileStream.Dispose();
 					fileStream.Close();

--- a/source/Grabacr07.KanColleWrapper/Logger.cs
+++ b/source/Grabacr07.KanColleWrapper/Logger.cs
@@ -240,25 +240,40 @@ namespace Grabacr07.KanColleWrapper
 		private void BattleResult(kcsapi_battle_result br)
 		{
 			string ShipName = "";
+			string ItemName = "";
 			string MapType = "";
+
 			if (br.api_get_ship != null)
-			{
 				ShipName = KanColleClient.Current.Translations.GetTranslation(br.api_get_ship.api_ship_name, TranslationType.Ships, false, br);
-			}
+
+			if (br.api_get_useitem != null)
+				ItemName = KanColleClient.Current.Translations.GetTranslation(
+					KanColleClient.Current.Master.UseItems
+						.SingleOrDefault(x => x.Value.Id == br.api_get_useitem.api_useitem_id).Value
+						?.Name,
+					TranslationType.Useitems,
+					false,
+					br
+				);
+
 			MapType = KanColleClient.Current.Translations.GetTranslation(br.api_quest_name, TranslationType.OperationMaps, false, br);
 
 			string currentTime = DateTime.Now.ToString("yyyy/MM/dd HH:mm:ss");
 
 			#region CSV파일 저장
 			//날짜,해역이름,해역,보스,적 함대,랭크,드랍
-			Log(LogType.ShipDrop, "{0},{1},{2},{3},{4},{5},{6}",
+			Log(
+				LogType.ShipDrop,
+				"{0},{1},{2},{3},{4},{5},{6}",
 				currentTime,
 				MapType,
 				$"{NodeData.SelectToken("world").ToString()}-{(int)NodeData.SelectToken("mapnum")}-{(int)NodeData.SelectToken("node")}",
 				IsBossCell ? "O" : "X",
 				KanColleClient.Current.Translations.GetTranslation(br.api_enemy_info.api_deck_name, TranslationType.OperationSortie, false, br, -1),
 				br.api_win_rank, 
-				ShipName);
+				ShipName,
+				ItemName
+			);
 			#endregion
 		}
 
@@ -324,7 +339,7 @@ namespace Grabacr07.KanColleWrapper
 						}
 						using (StreamWriter w = File.AppendText(MainFolder + "\\DropLog2.csv"))
 						{
-							w.WriteLine("날짜,해역이름,해역,보스,적 함대,랭크,드랍", args);
+							w.WriteLine("날짜,해역이름,해역,보스,적 함대,랭크,드랍,아이템", args);
 						}
 					}
 

--- a/source/Grabacr07.KanColleWrapper/Models/Expedition.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/Expedition.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Grabacr07.KanColleWrapper.Internal;
+using Grabacr07.KanColleWrapper.Models.Raw;
 
 namespace Grabacr07.KanColleWrapper.Models
 {
@@ -92,6 +93,24 @@ namespace Grabacr07.KanColleWrapper.Models
 
 		#endregion
 
+		#region ExpeditionResult 変更通知プロパティ
+
+		private ExpeditionResult _ExpeditionResult;
+		public ExpeditionResult ExpeditionResult
+		{
+			get { return this._ExpeditionResult; }
+			private set
+			{
+				if (this._ExpeditionResult != value)
+				{
+					this._ExpeditionResult = value;
+					this.RaisePropertyChanged();
+				}
+			}
+		}
+
+		#endregion
+
 		/// <summary>
 		/// 艦隊が遠征から帰ったときに発生します。
 		/// </summary>
@@ -119,6 +138,9 @@ namespace Grabacr07.KanColleWrapper.Models
 				this.UpdateCore();
 			}
 		}
+
+		internal void Done(kcsapi_mission_result mission)
+			=> this.ExpeditionResult = new ExpeditionResult(mission);
 
 		private void UpdateCore()
 		{

--- a/source/Grabacr07.KanColleWrapper/Models/ExpeditionResult.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/ExpeditionResult.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Livet;
+
+using Grabacr07.KanColleWrapper.Models.Raw;
+
+namespace Grabacr07.KanColleWrapper.Models
+{
+	public class ExpeditionResult : ViewModel
+	{
+		#region Result, ResultText
+		private int _Result { get; set; }
+		public int Result
+		{
+			get { return this._Result; }
+			set
+			{
+				if (this._Result != value)
+				{
+					this._Result = value;
+					this.RaisePropertyChanged();
+				}
+			}
+		}
+		#endregion
+
+		#region Fuel
+		private int _Fuel { get; set; }
+		public int Fuel
+		{
+			get { return this._Fuel; }
+			set
+			{
+				if (this._Fuel != value)
+				{
+					this._Fuel = value;
+					this.RaisePropertyChanged();
+				}
+			}
+		}
+		#endregion
+
+		#region Ammo
+		private int _Ammo { get; set; }
+		public int Ammo
+		{
+			get { return this._Ammo; }
+			set
+			{
+				if (this._Ammo != value)
+				{
+					this._Ammo = value;
+					this.RaisePropertyChanged();
+				}
+			}
+		}
+		#endregion
+
+		#region Steel
+		private int _Steel { get; set; }
+		public int Steel
+		{
+			get { return this._Steel; }
+			set
+			{
+				if (this._Steel != value)
+				{
+					this._Steel = value;
+					this.RaisePropertyChanged();
+				}
+			}
+		}
+		#endregion
+
+		#region Bauxite
+		private int _Bauxite { get; set; }
+		public int Bauxite
+		{
+			get { return this._Bauxite; }
+			set
+			{
+				if (this._Bauxite != value)
+				{
+					this._Bauxite = value;
+					this.RaisePropertyChanged();
+				}
+			}
+		}
+		#endregion
+
+		#region Items
+		private ExpeditionResultItem[] _Items { get; set; }
+		public ExpeditionResultItem[] Items
+		{
+			get { return this._Items; }
+			set
+			{
+				if (this._Items != value)
+				{
+					this._Items = value;
+					this.RaisePropertyChanged();
+				}
+			}
+		}
+		#endregion
+
+		public ExpeditionResult()
+		{
+		}
+
+		public ExpeditionResult(kcsapi_mission_result mission)
+			=> this.Update(mission);
+
+		public void Update(kcsapi_mission_result mission)
+		{
+			this.Result = mission.api_clear_result;
+
+			this.Fuel = mission.api_get_material[0];
+			this.Ammo = mission.api_get_material[1];
+			this.Steel = mission.api_get_material[2];
+			this.Bauxite = mission.api_get_material[3];
+
+			var list = new List<ExpeditionResultItem>();
+			if (mission.api_get_item1 != null) list.Add(new ExpeditionResultItem(mission.api_get_item1, mission.api_useitem_flag[0]));
+			if (mission.api_get_item2 != null) list.Add(new ExpeditionResultItem(mission.api_get_item1, mission.api_useitem_flag[1]));
+
+			this.Items = list.ToArray();
+
+			/*
+			 * mission.api_useitem_flag[i]
+			 * 1: Repair bucket
+			 * 2: Instant construction
+			 * 3: Development material
+			 * 4: BASED ON [id] property
+			 * 5: Furniture coin
+			 */
+		}
+	}
+
+	public class ExpeditionResultItem : ViewModel
+	{
+		private kcsapi_mission_result_item source { get; }
+		public int Kind { get; }
+
+		public int Id => this.source.api_useitem_id;
+		public string Name
+		{
+			get
+			{
+				switch (this.Kind)
+				{
+					case 1:
+						return "고속수복재";
+					case 2:
+						return "고속건조재";
+					case 3:
+						return "개발자재";
+					case 5:
+						return "가구코인";
+
+					case 4:
+						return KanColleClient.Current.Translations.GetTranslation(
+							KanColleClient.Current.Master.UseItems[this.Id]?.Name,
+							TranslationType.Useitems,
+							false
+						);
+
+					default:
+						return "???";
+				}
+			}
+		}
+		public int Count => this.source.api_useitem_count;
+
+		internal ExpeditionResultItem(kcsapi_mission_result_item item, int kind)
+		{
+			this.source = item;
+			this.Kind = kind;
+		}
+	}
+}

--- a/source/Grabacr07.KanColleWrapper/Models/Fleet.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/Fleet.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -228,9 +228,7 @@ namespace Grabacr07.KanColleWrapper.Models
 		}
 
 		internal void RaiseShipsUpdated()
-		{
-			this.RaisePropertyChanged(nameof(this.ShipsUpdated));
-		}
+			=> this.RaisePropertyChanged(nameof(this.ShipsUpdated));
 
 		public override string ToString()
 		{

--- a/source/Grabacr07.KanColleWrapper/Models/LogDataList.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/LogDataList.cs
@@ -1,4 +1,4 @@
-﻿
+
 namespace Grabacr07.KanColleWrapper.Models
 {
 	/// <summary>
@@ -13,6 +13,7 @@ namespace Grabacr07.KanColleWrapper.Models
 		public string EnemyFleet { get; set; }
 		public string Rank { get; set; }
 		public string Drop { get; set; }
+		public string ItemDrop { get; set; }
 	}
 	/// <summary>
 	/// 날짜,비서함,연료,탄,강재,보크사이트,결과

--- a/source/Grabacr07.KanColleWrapper/Models/Mission.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/Mission.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -12,16 +12,19 @@ namespace Grabacr07.KanColleWrapper.Models
 	{
 		public int Id { get; }
 
-		public string Title { get; }
+		public string JPTitle { get; }
+		public string JPDetail { get; }
 
-		public string Detail { get; }
+		public string Title => KanColleClient.Current.Translations.GetTranslation(this.JPTitle, TranslationType.ExpeditionTitle, false, this.RawData, this.Id);
+		public string Detail => KanColleClient.Current.Translations.GetTranslation(this.JPDetail, TranslationType.ExpeditionDetail, false, this.RawData, this.Id);
 
 		public Mission(kcsapi_mission mission)
 			: base(mission)
 		{
 			this.Id = mission.api_id;
-			this.Title = KanColleClient.Current.Translations.GetTranslation(mission.api_name, TranslationType.ExpeditionTitle, false, this.RawData, mission.api_id);
-			this.Detail = KanColleClient.Current.Translations.GetTranslation(mission.api_details, TranslationType.ExpeditionDetail, false, this.RawData, mission.api_id);
+
+			this.JPTitle = mission.api_name;
+			this.JPDetail = mission.api_details;
 		}
 	}
 }

--- a/source/Grabacr07.KanColleWrapper/Models/Raw/Battle/battle_result.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/Raw/Battle/battle_result.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -25,6 +25,7 @@ namespace Grabacr07.KanColleWrapper.Models.Raw
 		public int api_first_clear { get; set; }
 		public int[] api_get_flag { get; set; }
 		public kcsapi_battleresult_getship api_get_ship { get; set; }
+		public kcsapi_get_useitem api_get_useitem { get; set; }
 		public kcsapi_battleresult_geteventitem[] api_get_eventitem { get; set; }
 		public int api_get_eventflag { get; set; }
 		public int api_get_exmap_rate { get; set; }
@@ -45,6 +46,11 @@ namespace Grabacr07.KanColleWrapper.Models.Raw
 		public string api_ship_type { get; set; }
 		public string api_ship_name { get; set; }
 		public string api_ship_getmes { get; set; }
+	}
+	public class kcsapi_get_useitem
+	{
+		public int api_useitem_id { get; set; }
+		public int api_useitem_count { get; set; }
 	}
 
 	public class kcsapi_battleresult_geteventitem

--- a/source/Grabacr07.KanColleWrapper/Models/Raw/kcsapi_mission_result.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/Raw/kcsapi_mission_result.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -22,14 +22,16 @@ namespace Grabacr07.KanColleWrapper.Models.Raw
 		public int api_quest_level { get; set; }
 		public int[] api_get_material { get; set; }
 		public int[] api_useitem_flag { get; set; }
+
 		public kcsapi_mission_result_item api_get_item1 { get; set; }
+		public kcsapi_mission_result_item api_get_item2 { get; set; }
 	}
 
 
 	public class kcsapi_mission_result_item
 	{
 		public int api_useitem_id { get; set; }
-		public object api_useitem_name { get; set; }
+		public string api_useitem_name { get; set; }
 		public int api_useitem_count { get; set; }
 	}
 	// ReSharper restore InconsistentNaming

--- a/source/Grabacr07.KanColleWrapper/Models/ResourceModel.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/ResourceModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -19,6 +19,83 @@ namespace Grabacr07.KanColleWrapper.Models
 		public int InstantConstruction;
 		public int DevelopmentMaterial;
 		public int ImprovementMaterial;
+
+		public void Clear()
+		{
+			this.Fuel = this.Ammo = this.Steel = this.Bauxite = 0;
+			this.RepairBucket = this.InstantConstruction = this.DevelopmentMaterial = this.ImprovementMaterial = 0;
+		}
+
+		#region Operator overrides
+		public static ResourceModel operator +(ResourceModel r1, ResourceModel r2)
+		{
+			return new ResourceModel
+			{
+				Fuel = r1.Fuel+r2.Fuel,
+				Ammo = r1.Ammo+r2.Ammo,
+				Steel = r1.Steel+r2.Steel,
+				Bauxite = r1.Bauxite+r2.Bauxite,
+
+				RepairBucket = r1.RepairBucket + r2.RepairBucket,
+				InstantConstruction = r1.InstantConstruction + r2.InstantConstruction,
+				DevelopmentMaterial = r1.DevelopmentMaterial + r2.DevelopmentMaterial,
+				ImprovementMaterial = r1.ImprovementMaterial + r2.ImprovementMaterial,
+
+				Date = r1.Date>r2.Date?r1.Date:r2.Date
+			};
+		}
+		public static ResourceModel operator -(ResourceModel r1, ResourceModel r2)
+		{
+			return new ResourceModel
+			{
+				Fuel = r1.Fuel - r2.Fuel,
+				Ammo = r1.Ammo - r2.Ammo,
+				Steel = r1.Steel - r2.Steel,
+				Bauxite = r1.Bauxite - r2.Bauxite,
+
+				RepairBucket = r1.RepairBucket - r2.RepairBucket,
+				InstantConstruction = r1.InstantConstruction - r2.InstantConstruction,
+				DevelopmentMaterial = r1.DevelopmentMaterial - r2.DevelopmentMaterial,
+				ImprovementMaterial = r1.ImprovementMaterial - r2.ImprovementMaterial,
+
+				Date = r1.Date > r2.Date ? r1.Date : r2.Date
+			};
+		}
+		public static ResourceModel operator *(ResourceModel r, int m)
+		{
+			return new ResourceModel
+			{
+				Fuel = r.Fuel * m,
+				Ammo = r.Ammo * m,
+				Steel = r.Steel * m,
+				Bauxite = r.Bauxite * m,
+
+				RepairBucket = r.RepairBucket * m,
+				InstantConstruction = r.InstantConstruction * m,
+				DevelopmentMaterial = r.DevelopmentMaterial * m,
+				ImprovementMaterial = r.ImprovementMaterial * m,
+
+				Date = r.Date
+			};
+		}
+		public static ResourceModel operator /(ResourceModel r, int m)
+		{
+			return new ResourceModel
+			{
+				Fuel = r.Fuel / m,
+				Ammo = r.Ammo / m,
+				Steel = r.Steel / m,
+				Bauxite = r.Bauxite / m,
+
+				RepairBucket = r.RepairBucket / m,
+				InstantConstruction = r.InstantConstruction / m,
+				DevelopmentMaterial = r.DevelopmentMaterial / m,
+				ImprovementMaterial = r.ImprovementMaterial / m,
+
+				Date = r.Date
+			};
+		}
+		#endregion
 
 		public override string ToString()
 		{

--- a/source/Grabacr07.KanColleWrapper/Models/TranslationType.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/TranslationType.cs
@@ -1,4 +1,4 @@
-﻿
+
 namespace Grabacr07.KanColleWrapper.Models
 {
 	public enum TranslationType
@@ -67,6 +67,8 @@ namespace Grabacr07.KanColleWrapper.Models
 
 		RemodelSlots = 13,
 
-        EquipmentTypes = 14,
+		EquipmentTypes = 14,
+
+		Useitems = 15,
 	}
 }

--- a/source/Grabacr07.KanColleWrapper/Organization.cs
+++ b/source/Grabacr07.KanColleWrapper/Organization.cs
@@ -172,6 +172,23 @@ namespace Grabacr07.KanColleWrapper
 						this.CombinedType = (CombinedFleetType)type;
 				});
 
+			proxy.api_req_mission_result.TryParse<kcsapi_mission_result>()
+				.Subscribe(x => {
+					var mission = KanColleClient.Current.Master.Missions
+						.Select(y => y.Value)
+						.FirstOrDefault(y => y.JPTitle == x.Data.api_quest_name);
+
+					if (mission != null)
+					{
+						var fleet = this.Fleets
+							.Select(y => y.Value)
+							.FirstOrDefault(y => y.Expedition.Id == mission.Id);
+
+						if (fleet != null)
+							fleet.Expedition.Done(x.Data);
+					}
+				});
+
 			this.SubscribeSortieSessions(proxy);
 		}
 

--- a/source/Grabacr07.KanColleWrapper/Translations.cs
+++ b/source/Grabacr07.KanColleWrapper/Translations.cs
@@ -138,7 +138,7 @@ namespace Grabacr07.KanColleWrapper
 				EquipmentTypesVersion = "없음";
 
 			if (UseitemsXML != null)
-				if (UseitemsXML.Root.Attribute("Version") != null) EquipmentTypesVersion = UseitemsXML.Root.Attribute("Version").Value;
+				if (UseitemsXML.Root.Attribute("Version") != null) UseitemsVersion = UseitemsXML.Root.Attribute("Version").Value;
 				else UseitemsVersion = "알 수 없음";
 			else
 				UseitemsVersion = "없음";

--- a/source/Grabacr07.KanColleWrapper/Translations.cs
+++ b/source/Grabacr07.KanColleWrapper/Translations.cs
@@ -21,7 +21,8 @@ namespace Grabacr07.KanColleWrapper
 		private XDocument QuestsXML;//4
 		private XDocument ExpeditionXML;//5
 		private XDocument RemodelXml;//6
-        private XDocument EquipmentTypesXML;//7
+		private XDocument EquipmentTypesXML;//7
+		private XDocument UseitemsXML;//8
 		string MainFolder = Path.GetDirectoryName(System.Reflection.Assembly.GetEntryAssembly().Location);
 
 		public bool EnableTranslations { get; set; }
@@ -34,7 +35,8 @@ namespace Grabacr07.KanColleWrapper
 		public string ShipsVersion { get; set; }
 		public string ShipTypesVersion { get; set; }
 		public string RemodelSlotsVersion { get; set; }
-        public string EquipmentTypesVersion { get; set; }
+		public string EquipmentTypesVersion { get; set; }
+		public string UseitemsVersion { get; set; }
 		private void SaveXmls(int idx)
 		{
 			switch (idx)
@@ -57,12 +59,14 @@ namespace Grabacr07.KanColleWrapper
 				case 5:
 					ExpeditionXML.Save(Path.Combine(MainFolder, "Translations", "Expeditions.xml"));
 					break;
-				case 6://리모델링은 세이브가 없다
+				case 6: // 개수공창 정보는 번역하여 저장하지 않음
 					break;
-                case 7:
-                    EquipmentTypesXML.Save(Path.Combine(MainFolder, "Translations", "EquipmentTypes.xml"));
-                    break;
-            }
+				case 7:
+					EquipmentTypesXML.Save(Path.Combine(MainFolder, "Translations", "EquipmentTypes.xml"));
+					break;
+				case 8: // Useitems 정보는 번역하여 저장하지 않음
+					break;
+			}
 			LoadXmls();
 		}
 		private void LoadXmls()
@@ -74,10 +78,10 @@ namespace Grabacr07.KanColleWrapper
 			if (File.Exists(Path.Combine(MainFolder, "Translations", "Quests.xml"))) QuestsXML = XDocument.Load(Path.Combine(MainFolder, "Translations", "Quests.xml"));
 			if (File.Exists(Path.Combine(MainFolder, "Translations", "Expeditions.xml"))) ExpeditionXML = XDocument.Load(Path.Combine(MainFolder, "Translations", "Expeditions.xml"));
 			if (File.Exists(Path.Combine(MainFolder, "Translations", "RemodelSlots.xml"))) RemodelXml = XDocument.Load(Path.Combine(MainFolder, "Translations", "RemodelSlots.xml"));
-            if (File.Exists(Path.Combine(MainFolder, "Translations", "EquipmentTypes.xml"))) EquipmentTypesXML = XDocument.Load(Path.Combine(MainFolder, "Translations", "EquipmentTypes.xml"));
-
-        }
-        internal Translations()
+			if (File.Exists(Path.Combine(MainFolder, "Translations", "EquipmentTypes.xml"))) EquipmentTypesXML = XDocument.Load(Path.Combine(MainFolder, "Translations", "EquipmentTypes.xml"));
+			if (File.Exists(Path.Combine(MainFolder, "Translations", "Useitems.xml"))) UseitemsXML = XDocument.Load(Path.Combine(MainFolder, "Translations", "Useitems.xml"));
+		}
+		internal Translations()
 		{
 			try
 			{
@@ -93,21 +97,25 @@ namespace Grabacr07.KanColleWrapper
 				else ShipsVersion = "알 수 없음";
 			else
 				ShipsVersion = "없음";
+
 			if (ShipTypesXML != null)
 				if (ShipTypesXML.Root.Attribute("Version") != null) ShipTypesVersion = ShipTypesXML.Root.Attribute("Version").Value;
 				else ShipTypesVersion = "알 수 없음";
 			else
 				ShipTypesVersion = "없음";
+
 			if (EquipmentXML != null)
 				if (EquipmentXML.Root.Attribute("Version") != null) EquipmentVersion = EquipmentXML.Root.Attribute("Version").Value;
 				else EquipmentVersion = "알 수 없음";
 			else
 				EquipmentVersion = "없음";
+
 			if (OperationsXML != null)
 				if (OperationsXML.Root.Attribute("Version") != null) OperationsVersion = OperationsXML.Root.Attribute("Version").Value;
 				else OperationsVersion = "알 수 없음";
 			else
 				OperationsVersion = "없음";
+
 			if (QuestsXML != null)
 				if (QuestsXML.Root.Attribute("Version") != null) QuestsVersion = QuestsXML.Root.Attribute("Version").Value;
 				else QuestsVersion = "알 수 없음";
@@ -116,16 +124,24 @@ namespace Grabacr07.KanColleWrapper
 				else ExpeditionsVersion = "알 수 없음";
 			else
 				QuestsVersion = "없음";
+
 			if (RemodelXml != null)
 				if (RemodelXml.Root.Attribute("Version") != null) RemodelSlotsVersion = RemodelXml.Root.Attribute("Version").Value;
 				else RemodelSlotsVersion = "알 수 없음";
 			else
 				RemodelSlotsVersion = "없음";
-            if (EquipmentTypesXML != null)
-                if (EquipmentTypesXML.Root.Attribute("Version") != null) EquipmentTypesVersion = EquipmentTypesXML.Root.Attribute("Version").Value;
-                else EquipmentTypesVersion = "알 수 없음";
-            else
-                EquipmentTypesVersion = "없음";
+
+			if (EquipmentTypesXML != null)
+				if (EquipmentTypesXML.Root.Attribute("Version") != null) EquipmentTypesVersion = EquipmentTypesXML.Root.Attribute("Version").Value;
+				else EquipmentTypesVersion = "알 수 없음";
+			else
+				EquipmentTypesVersion = "없음";
+
+			if (UseitemsXML != null)
+				if (UseitemsXML.Root.Attribute("Version") != null) EquipmentTypesVersion = UseitemsXML.Root.Attribute("Version").Value;
+				else UseitemsVersion = "알 수 없음";
+			else
+				UseitemsVersion = "없음";
 		}
 
 		private IEnumerable<XElement> GetTranslationList(TranslationType Type)
@@ -165,17 +181,17 @@ namespace Grabacr07.KanColleWrapper
 						return EquipmentXML.Descendants("Item");
 					}
 					break;
-                case TranslationType.EquipmentTypes:
-                    if (EquipmentTypesXML != null)
-                    {
-                        if (KanColleClient.Current.Updater.EquipTypesUpdate)
-                        {
-                            this.EquipmentTypesXML = XDocument.Load(Path.Combine(MainFolder, "Translations", "EquipmentTypes.xml"));
-                            KanColleClient.Current.Updater.EquipTypesUpdate = false;
-                        }
-                        return EquipmentTypesXML.Descendants("Item");
-                    }
-                    break;
+				case TranslationType.EquipmentTypes:
+					if (EquipmentTypesXML != null)
+					{
+						if (KanColleClient.Current.Updater.EquipTypesUpdate)
+						{
+							this.EquipmentTypesXML = XDocument.Load(Path.Combine(MainFolder, "Translations", "EquipmentTypes.xml"));
+							KanColleClient.Current.Updater.EquipTypesUpdate = false;
+						}
+						return EquipmentTypesXML.Descendants("Item");
+					}
+					break;
 				case TranslationType.OperationMaps:
 					if (OperationsXML != null)
 					{
@@ -222,6 +238,17 @@ namespace Grabacr07.KanColleWrapper
 							KanColleClient.Current.Updater.ExpeditionUpdate = false;
 						}
 						return ExpeditionXML.Descendants("Expedition");
+					}
+					break;
+				case TranslationType.Useitems:
+					if (UseitemsXML != null)
+					{
+						if (KanColleClient.Current.Updater.UseitemsUpdate)
+						{
+							this.UseitemsXML = XDocument.Load(Path.Combine(MainFolder, "Translations", "Useitems.xml"));
+							KanColleClient.Current.Updater.UseitemsUpdate = false;
+						}
+						return UseitemsXML.Descendants("Useitem");
 					}
 					break;
 			}

--- a/source/Grabacr07.KanColleWrapper/Translations.cs
+++ b/source/Grabacr07.KanColleWrapper/Translations.cs
@@ -294,7 +294,7 @@ namespace Grabacr07.KanColleWrapper
 				if (TranslationList == null && RawData != null)
 				{
 					if (!IsLogReader) AddTranslation(RawData, Type);
-					if (ID < 0 && !IsLogReader) return "[" + ID.ToString() + "] " + JPString;
+					if (ID > 0 && !IsLogReader) return "[" + ID.ToString() + "] " + JPString;
 					else return JPString;
 				}
 

--- a/source/Grabacr07.KanColleWrapper/Updater.cs
+++ b/source/Grabacr07.KanColleWrapper/Updater.cs
@@ -18,6 +18,7 @@ namespace Grabacr07.KanColleWrapper
 		public bool ExpeditionUpdate { get; set; }
 		public bool RemodelUpdate { get; set; }
 		public bool EquipTypesUpdate { get; set; }
+		public bool UseitemsUpdate { get; set; }
 
 		/// <summary>
 		/// 업데이트 상태를 구별한다.
@@ -55,6 +56,9 @@ namespace Grabacr07.KanColleWrapper
 						break;
 					case TranslationType.EquipmentTypes:
 						this.EquipTypesUpdate = true;
+						break;
+					case TranslationType.Useitems:
+						this.UseitemsUpdate = true;
 						break;
 				}
 			}
@@ -167,11 +171,16 @@ namespace Grabacr07.KanColleWrapper
 						Client.DownloadFile(BaseTranslationURL + "RemodelSlots.xml", Path.Combine(MainFolder, "Translations", "tmp", "RemodelSlots.xml"));
 						ReturnValue = XmlFileWizard(MainFolder, "RemodelSlots.xml", TranslationType.RemodelSlots);
 					}
-                    if (IsOnlineVersionGreater(TranslationType.EquipmentTypes, TranslationsRef.EquipmentTypesVersion))
-                    {
-                        Client.DownloadFile(BaseTranslationURL + "EquipmentTypes.xml", Path.Combine(MainFolder, "Translations", "tmp", "EquipmentTypes.xml"));
-                        ReturnValue = XmlFileWizard(MainFolder, "EquipmentTypes.xml", TranslationType.EquipmentTypes);
-                    }
+					if (IsOnlineVersionGreater(TranslationType.EquipmentTypes, TranslationsRef.EquipmentTypesVersion))
+					{
+						Client.DownloadFile(BaseTranslationURL + "EquipmentTypes.xml", Path.Combine(MainFolder, "Translations", "tmp", "EquipmentTypes.xml"));
+						ReturnValue = XmlFileWizard(MainFolder, "EquipmentTypes.xml", TranslationType.EquipmentTypes);
+					}
+					if (IsOnlineVersionGreater(TranslationType.Useitems, TranslationsRef.UseitemsVersion))
+					{
+						Client.DownloadFile(BaseTranslationURL + "Useitems.xml", Path.Combine(MainFolder, "Translations", "tmp", "Useitems.xml"));
+						ReturnValue = XmlFileWizard(MainFolder, "Useitems.xml", TranslationType.Useitems);
+					}
 
 				}
 				catch
@@ -224,8 +233,10 @@ namespace Grabacr07.KanColleWrapper
 					return Versions.Where(x => x.Element("Name").Value.Equals("ShipTypes")).FirstOrDefault().Element(ElementName).Value;
 				case TranslationType.RemodelSlots:
 					return Versions.Where(x => x.Element("Name").Value.Equals("RemodelSlots")).FirstOrDefault().Element(ElementName).Value;
-                case TranslationType.EquipmentTypes:
-                    return Versions.Where(x => x.Element("Name").Value.Equals("EquipmentTypes")).FirstOrDefault().Element(ElementName).Value;
+				case TranslationType.EquipmentTypes:
+					return Versions.Where(x => x.Element("Name").Value.Equals("EquipmentTypes")).FirstOrDefault().Element(ElementName).Value;
+				case TranslationType.Useitems:
+					return Versions.Where(x => x.Element("Name").Value.Equals("Useitems")).FirstOrDefault().Element(ElementName).Value;
 			}
 			return "";
 		}
@@ -272,8 +283,10 @@ namespace Grabacr07.KanColleWrapper
 					return LocalVersion.CompareTo(new Version(Versions.Where(x => x.Element("Name").Value.Equals("ShipTypes")).FirstOrDefault().Element(ElementName).Value)) < 0;
 				case TranslationType.RemodelSlots:
 					return LocalVersion.CompareTo(new Version(Versions.Where(x => x.Element("Name").Value.Equals("RemodelSlots")).FirstOrDefault().Element(ElementName).Value)) < 0;
-                case TranslationType.EquipmentTypes:
-                    return LocalVersion.CompareTo(new Version(Versions.Where(x => x.Element("Name").Value.Equals("EquipmentTypes")).FirstOrDefault().Element(ElementName).Value)) < 0;
+				case TranslationType.EquipmentTypes:
+					return LocalVersion.CompareTo(new Version(Versions.Where(x => x.Element("Name").Value.Equals("EquipmentTypes")).FirstOrDefault().Element(ElementName).Value)) < 0;
+				case TranslationType.Useitems:
+					return LocalVersion.CompareTo(new Version(Versions.Where(x => x.Element("Name").Value.Equals("Useitems")).FirstOrDefault().Element(ElementName).Value)) < 0;
 			}
 
 			return false;


### PR DESCRIPTION
### ↯ 다운로드
- GitHub [다운로드](https://github.com/CirnoV/KanColleViewer/releases/download/v4.2.12r3/KanColleViewer-KR.4.2.12.r3.zip)
- MEGA [다운로드](https://mega.nz/#!GoQ3Qa7L!IqhkqkTPQ-GIB2Fds0Ql0sWKn4j9aiFUjEs2LcfuTXQ)

### 🔗 외부 링크
- VirusTotal [검사 결과](https://www.virustotal.com/ko/file/8a47d75979bed106954a0d7239264d245dff2e0008a1b5874c16e19dc3fda081/analysis/1528918263/)
- ~~OpenDB Project Website ([http://swaytwig.com/opendb/](http://swaytwig.com/opendb/))~~ 공사중입니다.
- 업데이트 페이지 [http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html](http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html)

질문 및 건의사항은 [wolfgangkurzdev@gmail.com](mailto:wolfgangkurzdev@gmail.com) 으로 메일 부탁드립니다.
뷰어 사용중 오류가 발생하는 경우, error.log 혹은 battleinfo_error.log 를 첨부하여 메일로 제보해주시면 해결에 도움이 됩니다.

뷰어를 완전히 삭제하신 후 재설치를 해보시는 것도 방법이 될 수 있습니다.
뷰어의 각종 로그, 함대 프리셋, 전과 데이터 등을 백업하시려면, **뷰어 폴더 내의 csv 파일들과 Record 폴더를 백업**하면 됩니다.

```diff
- 갑자기 혹은 장비목록을 열 때 프로그램이 종료되면, 뷰어 폴더의 KanColleWrapper.dll 을 삭제하시기 바랍니다.
- (lib 폴더 내부에 있는 파일은 삭제하지 마세요)
- 파일이 없거나 삭제 후에도 동일한 증상이 나타난다면 메일로 문의 바랍니다.
```

----
### 💬 함선 탭
- 자원량 툴팁 문제를 수정했습니다.
  * 탄약과 보크사이트 표시가 겹치는 문제를 수정했습니다.

### 💬 원정 탭
- 마지막 원정 결과 표시를 추가했습니다.
  * 원정을 마치고 모항에 있을 때, 해당 함대가 마지막으로 수행했던 원정의 성공 여부 및 획득 자원, 아이템을 표시합니다.
  * 다시 원정을 가거나 출격 상태인 경우에는 표시되지 않습니다.

### 💬 함선 목록 창
- 함선이 장비중인 장비의 툴팁을 수정했습니다.
  * 함대 탭의 장비 툴팁과 동일한 툴팁이 표시되도록 수정했습니다.

### 💬 자원 기록 그래프
- 그래프 표시를 수정했습니다.
  * 고속수복재, 고속건조재, 개발자재, 개수자재 그래프의 가로축이 지나치게 크게 표시되는 문제를 수정했습니다.
  * 현재 접속중인 계정의 자연 회복 상한치 표시를 추가했습니다. 보라색 가로선으로 표시합니다.
- 데이터 최적화를 추가했습니다.
  * 뷰어 실행 시 기존 자원 기록 데이터를 최적화합니다.
  * 최적화되어 줄어드는 용량은 기록된 데이터에 따라 다릅니다.
- 그래프 표시 최적화를 수행했습니다.
  * 자원 기록 그래프 창의 속도가 매우 빨라졌습니다.
  * ![-](https://user-images.githubusercontent.com/20940566/41373982-e20227a4-6f8c-11e8-812c-7c18003683a7.gif)

### 💬 BattleInfoPlugin
- 아이템 드랍 표시가 추가되었습니다.
  * 함선 드랍 표시 옆에 하늘색으로 표시됩니다.
  * 드랍 기록에도 동일하게 기록됩니다.
  * ![-](https://user-images.githubusercontent.com/20940566/41373958-cc42c428-6f8c-11e8-960b-7b0443dc074c.png)

### 💬 기록 열람 프로그램
- 아이템 드랍 열을 추가했습니다.
  * 기존 기록과 충돌이 일어날 수 있습니다.
  * 불러오기에 실패하여 프로그램이 종료하는 경우, "csv를 bin으로 변환하기"를 한 후에 불러와보시기 바랍니다.
- 드랍 해역의 표시를 수정했습니다.
  * 노드 번호가 아닌 알파벳으로 표시되도록 수정했습니다.
- 드랍 기록의 해역 필터를 알파벳으로도 검색할 수 있도록 수정했습니다.
  * "4-2-D" 와 같이 검색할 수 있습니다.
- 보스방 표시를 수정했습니다.
  * O, X 가 아닌 보스방 아이콘으로 대체했습니다.
- 결과 랭크에 색상을 추가했습니다.
  * 랭크별로 색상으로 표시됩니다. (S승 금색, A승 빨간색 등)
- 페이지 당 결과 개수 입력 칸을 추가했습니다.
  * 기본 값은 기존과 같은 20 입니다.
- 페이지 번호 입력 칸이 4자리일 때 내용이 잘려보이던 문제를 수정했습니다.

### 💬 번역
- 일부 함선의 번역을 추가했습니다.
  * 이세改2
  * 쿠로시오改2
- 일부 장비의 번역을 추가했습니다.
  * 35.6cm 삼연장포改(다즐미채 사양)
  * 41cm 삼연장포改2
  * 스이세이 22형(634 해군항공대)
  * 스이세이 22형(634 해군항공대/숙련)
