### PR TITLE
v4.2.12 rev4

### DIFF
--- a/source/Grabacr07.KanColleViewer/Models/Migration/_KanColleClientSettings.cs
+++ b/source/Grabacr07.KanColleViewer/Models/Migration/_KanColleClientSettings.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -23,7 +23,7 @@ namespace Grabacr07.KanColleViewer.Models.Migration
 		public bool IsViewRangeCalcIncludeSecondFleet { get; set; }
 		public bool AutoTranslateEnable { get; set; }
 		public bool CheckFlagshipIsRepairShip { get; set; }
-		public bool QuestOnAllTabs { get; set; }
+		public bool QuestOnAnyTabs { get; set; }
 
 		event PropertyChangedEventHandler INotifyPropertyChanged.PropertyChanged
 		{

--- a/source/Grabacr07.KanColleViewer/Models/Migration/_Settings.cs
+++ b/source/Grabacr07.KanColleViewer/Models/Migration/_Settings.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
@@ -65,7 +65,7 @@ namespace Grabacr07.KanColleViewer.Models.Migration
 				KanColleSettings.NotificationShorteningTime.Value = Current.KanColleClientSettings.NotificationShorteningTime;
 				KanColleSettings.ReSortieCondition.Value = Current.KanColleClientSettings.ReSortieCondition;
 				KanColleSettings.AutoTranslateEnable.Value = Current.KanColleClientSettings.AutoTranslateEnable;
-				KanColleSettings.QuestOnAllTabs.Value = Current.KanColleClientSettings.QuestOnAllTabs;
+				KanColleSettings.QuestOnAnyTabs.Value = Current.KanColleClientSettings.QuestOnAnyTabs;
 			}
 
 			if (Current.ProxySettings != null)

--- a/source/Grabacr07.KanColleViewer/Models/Settings/KanColleSettings.cs
+++ b/source/Grabacr07.KanColleViewer/Models/Settings/KanColleSettings.cs
@@ -277,7 +277,7 @@ namespace Grabacr07.KanColleViewer.Models.Settings
 		/// <summary>
 		/// 전체 탭이 아닌 일간, 주간 등의 탭에서도 갱신되도록 합니다.
 		/// </summary>
-		public static SerializableProperty<bool> QuestOnAllTabs { get; }
+		public static SerializableProperty<bool> QuestOnAnyTabs { get; }
 			= new SerializableProperty<bool>(GetKey(), Providers.Viewer, false);
 
 		/// <summary>
@@ -329,7 +329,7 @@ namespace Grabacr07.KanColleViewer.Models.Settings
 
 		bool IKanColleClientSettings.CheckFlagshipIsRepairShip => CheckFlagshipIsNotRepairShip.Value;
 
-		bool IKanColleClientSettings.QuestOnAllTabs => QuestOnAllTabs.Value;
+		bool IKanColleClientSettings.QuestOnAnyTabs => QuestOnAnyTabs.Value;
 
 		#endregion
 

--- a/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
@@ -15,4 +15,4 @@ using System.Windows;
 	ResourceDictionaryLocation.None,
 	ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("4.2.12.3")]
+[assembly: AssemblyVersion("4.2.12.4")]

--- a/source/Grabacr07.KanColleViewer/ViewModels/Contents/QuestViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/Contents/QuestViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -21,6 +21,24 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents
 				if (this._Id != value)
 				{
 					this._Id = value;
+					this.RaisePropertyChanged();
+				}
+			}
+		}
+
+		#endregion
+
+		#region Tab 변경통지 프로퍼티
+
+		private int _Tab;
+		public int Tab
+		{
+			get { return this._Tab; }
+			set
+			{
+				if (this._Tab != value)
+				{
+					this._Tab = value;
 					this.RaisePropertyChanged();
 				}
 			}
@@ -239,6 +257,8 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents
 				? QuestNameTable.IdNameTable[this.Id]
 				: string.Format("[{0}]", this.Id);
 
+		public string TabId => string.Format("{0}-{1}", this.Tab, this.Id);
+
 		#region Page 변경통지 프로퍼티
 
 		private int _Page { get; set; }
@@ -327,6 +347,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents
 			else
 			{
 				this.Id = quest.Id;
+				this.Tab = quest.Tab;
 				this.IsUntaken = false;
 
 				this.Type = quest.Type;

--- a/source/Grabacr07.KanColleViewer/Views/Contents/Quests.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Contents/Quests.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="Grabacr07.KanColleViewer.Views.Contents.Quests"
+<UserControl x:Class="Grabacr07.KanColleViewer.Views.Contents.Quests"
 			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 			 xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
@@ -336,8 +336,6 @@
 				   Style="{DynamicResource DetailTextStyleKey}"
 				   Margin="5">
 			<Run Text="※진행상태 (50 %, 80 %) 는 게임내의 표시와 동일합니다." />
-			<LineBreak />
-			<Run Text="※게임 내의 All 탭에서만 갱신할 수 있습니다." />
 		</TextBlock>
 
 		<TextBlock Grid.Row="1"

--- a/source/Grabacr07.KanColleViewer/Views/Settings/Operation.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Settings/Operation.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="Grabacr07.KanColleViewer.Views.Settings.Operation"
+<UserControl x:Class="Grabacr07.KanColleViewer.Views.Settings.Operation"
 			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -166,7 +166,7 @@
 
 				<Border Height="8" />
 				<CheckBox Content="전체 탭만이 아닌 모든 탭에서 임무를 갱신"
-						  IsChecked="{Binding Source={x:Static ms:KanColleSettings.QuestOnAllTabs}, Path=Value}" />
+						  IsChecked="{Binding Source={x:Static ms:KanColleSettings.QuestOnAnyTabs}, Path=Value}" />
 			</StackPanel>
 
 			<Rectangle Style="{DynamicResource SeparatorStyleKey}" />

--- a/source/Grabacr07.KanColleWrapper/IKanColleClientSettings.cs
+++ b/source/Grabacr07.KanColleWrapper/IKanColleClientSettings.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -31,6 +31,6 @@ namespace Grabacr07.KanColleWrapper
 		/// </summary>
 		bool CheckFlagshipIsRepairShip { get; }
 
-		bool QuestOnAllTabs { get; }
+		bool QuestOnAnyTabs { get; }
 	}
 }

--- a/source/Grabacr07.KanColleWrapper/Models/Quest.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/Quest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -50,6 +50,18 @@ namespace Grabacr07.KanColleWrapper.Models
 		/// 任務の詳細を取得します。
 		/// </summary>
 		public string DetailJP => RawData.api_detail;
+
+		/// <summary>
+		/// 임무 화면에서의 탭 번호
+		/// </summary>
+		/// 0 - 전체
+		/// 9 - 진행중
+		/// 1 - 일간
+		/// 2 - 주간
+		/// 3 - 월간
+		/// 4 - 일회성
+		/// 5 - 그 외
+		public int Tab { get; set; }
 
 		/// <summary>
 		/// 임무 화면에서의 페이지 번호

--- a/source/Grabacr07.KanColleWrapper/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleWrapper/Properties/AssemblyInfo.cs
@@ -10,5 +10,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("8C42F9E0-E2C9-4741-8F98-653A4D275798")]
 
-[assembly: AssemblyVersion("1.7.20")]
-[assembly: AssemblyInformationalVersion("1.7.20")]
+[assembly: AssemblyVersion("1.7.21")]
+[assembly: AssemblyInformationalVersion("1.7.21")]

--- a/source/Grabacr07.KanColleWrapper/Quests.cs
+++ b/source/Grabacr07.KanColleWrapper/Quests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -20,14 +20,20 @@ namespace Grabacr07.KanColleWrapper
 {
 	public class Quests : Notifier
 	{
-		private readonly List<ConcurrentDictionary<int, Quest>> questPages;
-		private int last_tab_id = -1;
+		private struct TabPage
+		{
+			public int Tab { get; set; }
+			public int Page { get; set; }
+		}
+
+		// questPages[tab][page] = Quest
+		private readonly Dictionary<int, List<ConcurrentDictionary<int, Quest>>> questPages;
 		private static int cur_tab_id = -1;
+		private static int last_exec_count = 0;
 
 		#region All 変更通知プロパティ
 
 		private IReadOnlyCollection<Quest> _All;
-
 		public IReadOnlyCollection<Quest> All
 		{
 			get { return this._All; }
@@ -37,6 +43,7 @@ namespace Grabacr07.KanColleWrapper
 				{
 					this._All = value;
 					this.RaisePropertyChanged();
+					this.RaisePropertyChanged(nameof(this.Current));
 				}
 			}
 		}
@@ -45,21 +52,21 @@ namespace Grabacr07.KanColleWrapper
 
 		#region Current 変更通知プロパティ
 
-		private IReadOnlyCollection<Quest> _Current;
-
 		/// <summary>
 		/// 現在遂行中の任務のリストを取得します。未取得の任務がある場合、リスト内に null が含まれることに注意してください。
 		/// </summary>
 		public IReadOnlyCollection<Quest> Current
 		{
-			get { return this._Current; }
-			set
+			get
 			{
-				if (!Equals(this._Current, value))
-				{
-					this._Current = value;
-					this.RaisePropertyChanged();
-				}
+				var list = this.All
+					.Where(x => x.State != QuestState.None)
+					.OrderBy(x => x.Id);
+				var placeholder = new Quest[Math.Max(0, list.Count() - last_exec_count)];
+
+				return list
+					.Concat(placeholder)
+					.ToList();
 			}
 		}
 
@@ -67,9 +74,9 @@ namespace Grabacr07.KanColleWrapper
 
 		#region IsUntaken 変更通知プロパティ
 
-		private bool _IsUntaken;
-
-		public bool IsUntaken
+		// 한 번도 퀘스트 화면에 진입하지 않은 경우
+		private Dictionary<int, bool> _IsUntaken;
+		public Dictionary<int, bool> IsUntaken
 		{
 			get { return this._IsUntaken; }
 			set
@@ -86,9 +93,9 @@ namespace Grabacr07.KanColleWrapper
 
 		#region IsEmpty 変更通知プロパティ
 
-		private bool _IsEmpty;
-
-		public bool IsEmpty
+		// 퀘스트가 하나도 없는 경우
+		private Dictionary<int, bool> _IsEmpty;
+		public Dictionary<int, bool> IsEmpty
 		{
 			get { return this._IsEmpty; }
 			set
@@ -106,9 +113,10 @@ namespace Grabacr07.KanColleWrapper
 
 		internal Quests(KanColleProxy proxy)
 		{
-			this.questPages = new List<ConcurrentDictionary<int, Quest>>();
-			this.IsUntaken = true;
-			this.All = this.Current = new List<Quest>();
+			this.questPages = new Dictionary<int, List<ConcurrentDictionary<int, Quest>>>();
+			this.IsUntaken = new Dictionary<int, bool>();
+			this.IsEmpty = new Dictionary<int, bool>();
+			this.All = new List<Quest>();
 
 			proxy.api_get_member_questlist
 				// .Where(x => HttpUtility.ParseQueryString(x.Request.BodyAsString)["api_tab_id"] == "0")
@@ -124,8 +132,10 @@ namespace Grabacr07.KanColleWrapper
 
 			if (!int.TryParse(s_tab_id, out tab_id)) return null;
 
-			if (!KanColleClient.Current.Settings.QuestOnAllTabs && tab_id != 0)
+			/*
+			if (!KanColleClient.Current.Settings.QuestOnAnyTabs && tab_id != 0)
 				return null;
+			*/
 
 			Quests.cur_tab_id = tab_id;
 
@@ -171,59 +181,54 @@ namespace Grabacr07.KanColleWrapper
 
 		private void Update(kcsapi_questlist questlist)
 		{
-			this.IsUntaken = false;
+			var tab = Quests.cur_tab_id;
+			this.IsUntaken[tab] = false;
+			Quests.last_exec_count = questlist.api_exec_count;
 
+			/*
 			if(this.last_tab_id != Quests.cur_tab_id)
 				this.questPages.Clear();
-
-			this.last_tab_id = Quests.cur_tab_id;
+			*/
+			if (!this.questPages.ContainsKey(tab))
+				this.questPages[tab] = new List<ConcurrentDictionary<int, Quest>>();
 
 			// キャッシュしてるページの数が、取得したページ数 (api_page_count) より大きいとき
 			// 取得したページ数と同じ数になるようにキャッシュしてるページを減らす
-			if (this.questPages.Count > questlist.api_page_count)
-			{
-				while (this.questPages.Count > questlist.api_page_count) this.questPages.RemoveAt(this.questPages.Count - 1);
-			}
+			while (this.questPages[tab].Count > questlist.api_page_count)
+				this.questPages[tab].RemoveAt(this.questPages.Count - 1);
 
 			// 小さいときは、キャッシュしたページ数と同じ数になるようにページを増やす
-			else if (this.questPages.Count < questlist.api_page_count)
-			{
-				while (this.questPages.Count < questlist.api_page_count) this.questPages.Add(null);
-			}
+			while (this.questPages[tab].Count < questlist.api_page_count)
+				this.questPages[tab].Add(null);
 
 			if (questlist.api_list == null)
 			{
-				this.IsEmpty = true;
-				this.All = this.Current = new List<Quest>();
+				this.IsEmpty[tab] = true;
 			}
 			else
 			{
 				var page = questlist.api_disp_page - 1;
-				if (page >= this.questPages.Count) page = this.questPages.Count - 1;
+				if (page >= this.questPages[tab].Count) page = this.questPages[tab].Count - 1;
 
-				this.questPages[page] = new ConcurrentDictionary<int, Quest>();
+				this.questPages[tab][page] = new ConcurrentDictionary<int, Quest>();
 
-				this.IsEmpty = false;
+				this.IsEmpty[tab] = false;
 
 				foreach (var quest in questlist.api_list.Select(x => new Quest(x)))
 				{
 					quest.Page = page;
-					this.questPages[page].AddOrUpdate(quest.Id, quest, (_, __) => quest);
+					quest.Tab = tab;
+					this.questPages[tab][page].AddOrUpdate(quest.Id, quest, (_, __) => quest);
 				}
 
-				this.All = this.questPages.Where(x => x != null)
-					.SelectMany(x => x.Select(kvp => kvp.Value))
-					.Distinct(x => x.Id)
-					.OrderBy(x => x.Id)
+				this.All = this.questPages
+					.SelectMany(y =>
+						y.Value.Where(x => x != null)
+							.SelectMany(x => x.Select(kvp => kvp.Value))
+							.Distinct(x => x.Id)
+							.OrderBy(x => x.Id)
+					)
 					.ToList();
-
-				var current = this.All.Where(x => x.State == QuestState.TakeOn || x.State == QuestState.Accomplished)
-					.OrderBy(x => x.Id)
-					.ToList();
-
-				// 遂行中の任務数に満たない場合、未取得分として null で埋める
-				while (current.Count < questlist.api_exec_count) current.Add(null);
-				this.Current = current;
 			}
 		}
 	}

--- a/source/Plugins/TaskbarProgress/ExpeditionProgress.cs
+++ b/source/Plugins/TaskbarProgress/ExpeditionProgress.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
@@ -105,7 +105,7 @@ namespace Grabacr07.KanColleViewer.Plugins
 		{
 			if (!this.initialized) return;
 
-			if (this.wrappers.Length == 0)
+			if (this.wrappers == null || this.wrappers.Length == 0)
 			{
 				this.State = TaskbarItemProgressState.None;
 				this.Value = .0;

--- a/source/Plugins/TaskbarProgress/Properties/AssemblyInfo.cs
+++ b/source/Plugins/TaskbarProgress/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Windows;
 
@@ -15,4 +15,4 @@ using System.Windows;
 	ResourceDictionaryLocation.None,
 	ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("1.2.0")]
+[assembly: AssemblyVersion("1.2.1")]


### PR DESCRIPTION
### ↯ 다운로드
- GitHub [다운로드](https://github.com/CirnoV/KanColleViewer/releases/download/v4.2.12r4/KanColleViewer-KR.4.2.12.r4.zip)
- MEGA [다운로드](https://mega.nz/#!7loRTSbJ!7mQ8tlFA1AWX2ywaah3Rx23TAGRPvDL7BIwKyd3qLPA)

### 🔗 외부 링크
- VirusTotal [검사 결과](https://www.virustotal.com/ko/file/bcb6d41b6b19d388fecf4315b3f050c544385077769af372486678d6ea87f62f/analysis/1530187849/)
- ~~OpenDB Project Website ([http://swaytwig.com/opendb/](http://swaytwig.com/opendb/))~~ 공사중입니다.
- 업데이트 페이지 [http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html](http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html)

질문 및 건의사항은 [wolfgangkurzdev@gmail.com](mailto:wolfgangkurzdev@gmail.com) 으로 메일 부탁드립니다.
뷰어 사용중 오류가 발생하는 경우, error.log 혹은 battleinfo_error.log 를 첨부하여 메일로 제보해주시면 해결에 도움이 됩니다.

뷰어를 완전히 삭제하신 후 재설치를 해보시는 것도 방법이 될 수 있습니다.
뷰어의 각종 로그, 함대 프리셋, 전과 데이터 등을 백업하시려면, **뷰어 폴더 내의 csv 파일들과 Record 폴더를 백업**하면 됩니다.

```diff
- 갑자기 혹은 장비목록을 열 때 프로그램이 종료되면, 뷰어 폴더의 KanColleWrapper.dll 을 삭제하시기 바랍니다.
- (lib 폴더 내부에 있는 파일은 삭제하지 마세요)
- 파일이 없거나 삭제 후에도 동일한 증상이 나타난다면 메일로 문의 바랍니다.
```

----
### 💬 임무 탭
- 임무 목록에 표시하는 기준이 변경되었습니다.
- 동작 설정의 "전체 탭만이 아닌 모든 탭에서 임무를 갱신" 옵션이 정확하게 작동합니다.
  * 옵션을 사용하지 않는 경우는 다음과 같이 작동합니다.
    1. 임무 탭의 모든 탭은 게임 내 임무 화면의 "전체" 탭에서 확인한 임무만 표시됩니다.
    2. 게임 내의 진행중, 일간 탭에서 확인해도 임무 탭의 목록은 갱신/추가되지 않습니다.
  * 옵션을 사용하는 경우는 다음과 같이 작동합니다.
    1. 임무 탭의 모든 탭은 게임 내 임무 화면의 각 탭에서 확인한 임무만 표시됩니다.
    2. "진행중" 탭은 게임 내의 진행중 탭에서 확인한 임무만 표시됩니다.
    3. "일일" 탭은 게임 내의 일간 탭에서 확인한 임무만 표시됩니다.

### 💬 기록 열람 프로그램
- "csvtobin" 을 한 후 일부 필터를 적용하면 프로그램이 종료되는 문제를 수정했습니다.
  * 업데이트 후 다시 한 번 csvtobin 을 실행하셔야 정상적으로 작동됩니다.

### 💬 번역
- 일부 함선의 번역을 수정했습니다.
  * 사무엘 B. 로버츠
  * 사무엘 B. 로버츠改
