### PR TITLE
v4.2.12 rev6

### DIFF
--- a/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
@@ -15,4 +15,4 @@ using System.Windows;
 	ResourceDictionaryLocation.None,
 	ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("4.2.12.5")]
+[assembly: AssemblyVersion("4.2.12.6")]

--- a/source/Grabacr07.KanColleViewer/ViewModels/Contents/QuestsViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/Contents/QuestsViewModel.cs
@@ -110,7 +110,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents
 		{
 			get
 			{
-				var tab = IsOnAnyTab ? 0 : CurrentTab;
+				var tab = !IsOnAnyTab ? 0 : CurrentTab;
 				return this.IsUntakenTable == null
 					? true
 					: !this.IsUntakenTable.ContainsKey(tab) || this.IsUntakenTable[tab];
@@ -126,7 +126,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents
 		{
 			get
 			{
-				var tab = IsOnAnyTab ? 0 : CurrentTab;
+				var tab = !IsOnAnyTab ? 0 : CurrentTab;
 				return this.IsEmptyTable == null
 					? false
 					: this.IsEmptyTable.ContainsKey(tab) && this.IsEmptyTable[tab];


### PR DESCRIPTION
### ↯ 다운로드
- GitHub [다운로드](https://github.com/CirnoV/KanColleViewer/releases/download/v4.2.12r6/KanColleViewer-KR.4.2.12.r6.zip)
- MEGA [다운로드](https://mega.nz/#!H1oBHSKI!-6RiWkZgnoc4ssxrDVpdyIxUkcFdh3erCjm0C8DkPiw)

### 🔗 외부 링크
- VirusTotal [검사 결과](https://www.virustotal.com/ko/file/f43f0fdc80dc16fdad0723ec01335b367368050180a6973ea1574156063a447b/analysis/1530196025/)
- ~~OpenDB Project Website ([http://swaytwig.com/opendb/](http://swaytwig.com/opendb/))~~ 공사중입니다.
- 업데이트 페이지 [http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html](http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html)

질문 및 건의사항은 [wolfgangkurzdev@gmail.com](mailto:wolfgangkurzdev@gmail.com) 으로 메일 부탁드립니다.
뷰어 사용중 오류가 발생하는 경우, error.log 혹은 battleinfo_error.log 를 첨부하여 메일로 제보해주시면 해결에 도움이 됩니다.

뷰어를 완전히 삭제하신 후 재설치를 해보시는 것도 방법이 될 수 있습니다.
뷰어의 각종 로그, 함대 프리셋, 전과 데이터 등을 백업하시려면, **뷰어 폴더 내의 csv 파일들과 Record 폴더를 백업**하면 됩니다.

```diff
- 갑자기 혹은 장비목록을 열 때 프로그램이 종료되면, 뷰어 폴더의 KanColleWrapper.dll 을 삭제하시기 바랍니다.
- (lib 폴더 내부에 있는 파일은 삭제하지 마세요)
- 파일이 없거나 삭제 후에도 동일한 증상이 나타난다면 메일로 문의 바랍니다.
```

----
### 💬 임무 탭
- 임무 목록에 표시하는 기준이 변경되었습니다.
- 동작 설정의 "전체 탭만이 아닌 모든 탭에서 임무를 갱신" 옵션이 정확하게 작동합니다.
  * 옵션을 사용하지 않는 경우는 다음과 같이 작동합니다.
    1. 임무 탭의 모든 탭은 게임 내 임무 화면의 "전체" 탭에서 확인한 임무만 표시됩니다.
    2. 게임 내의 진행중, 일간 탭에서 확인해도 임무 탭의 목록은 갱신/추가되지 않습니다.
  * 옵션을 사용하는 경우는 다음과 같이 작동합니다.
    1. 임무 탭의 모든 탭은 게임 내 임무 화면의 각 탭에서 확인한 임무만 표시됩니다.
    2. "진행중" 탭은 게임 내의 진행중 탭에서 확인한 임무만 표시됩니다.
    3. "일일" 탭은 게임 내의 일간 탭에서 확인한 임무만 표시됩니다.
  * 옵션을 사용하지 않는 경우, 임무 탭의 "임무 목록을 갱신해 주십시오" 메시지가 사라지지 않던 문제를 수정했습니다.

### 💬 기록 열람 프로그램
- "csvtobin" 을 한 후 일부 필터를 적용하면 프로그램이 종료되는 문제를 수정했습니다.
  * 업데이트 후 다시 한 번 csvtobin 을 실행하셔야 정상적으로 작동됩니다.

### 💬 번역
- 일부 함선의 번역을 수정했습니다.
  * 사무엘 B. 로버츠
  * 사무엘 B. 로버츠改
