### PR TITLE
v4.2.12 rev7

### DIFF
--- a/source/Grabacr07.KanColleViewer/Models/Migration/_KanColleClientSettings.cs
+++ b/source/Grabacr07.KanColleViewer/Models/Migration/_KanColleClientSettings.cs
@@ -24,6 +24,7 @@ namespace Grabacr07.KanColleViewer.Models.Migration
 		public bool AutoTranslateEnable { get; set; }
 		public bool CheckFlagshipIsRepairShip { get; set; }
 		public bool QuestOnAnyTabs { get; set; }
+		public bool QuestNoTakeOnTab { get; set; }
 
 		event PropertyChangedEventHandler INotifyPropertyChanged.PropertyChanged
 		{

--- a/source/Grabacr07.KanColleViewer/Models/Migration/_Settings.cs
+++ b/source/Grabacr07.KanColleViewer/Models/Migration/_Settings.cs
@@ -66,6 +66,7 @@ namespace Grabacr07.KanColleViewer.Models.Migration
 				KanColleSettings.ReSortieCondition.Value = Current.KanColleClientSettings.ReSortieCondition;
 				KanColleSettings.AutoTranslateEnable.Value = Current.KanColleClientSettings.AutoTranslateEnable;
 				KanColleSettings.QuestOnAnyTabs.Value = Current.KanColleClientSettings.QuestOnAnyTabs;
+				KanColleSettings.QuestNoTakeOnTab.Value = Current.KanColleClientSettings.QuestNoTakeOnTab;
 			}
 
 			if (Current.ProxySettings != null)

--- a/source/Grabacr07.KanColleViewer/Models/Settings/KanColleSettings.cs
+++ b/source/Grabacr07.KanColleViewer/Models/Settings/KanColleSettings.cs
@@ -281,6 +281,12 @@ namespace Grabacr07.KanColleViewer.Models.Settings
 			= new SerializableProperty<bool>(GetKey(), Providers.Viewer, false);
 
 		/// <summary>
+		/// 위 설정을 사용중일 때, 진행중 탭의 내용을 다른 탭에서 가져오도록 합니다.
+		/// </summary>
+		public static SerializableProperty<bool> QuestNoTakeOnTab { get; }
+			= new SerializableProperty<bool>(GetKey(), Providers.Viewer, false);
+
+		/// <summary>
 		/// 모항 정보에 원정 진행바를 표시할지를 설정합니다.
 		/// </summary>
 		public static SerializableProperty<bool> AdmiralExpeditionBars { get; }
@@ -330,6 +336,8 @@ namespace Grabacr07.KanColleViewer.Models.Settings
 		bool IKanColleClientSettings.CheckFlagshipIsRepairShip => CheckFlagshipIsNotRepairShip.Value;
 
 		bool IKanColleClientSettings.QuestOnAnyTabs => QuestOnAnyTabs.Value;
+
+		bool IKanColleClientSettings.QuestNoTakeOnTab => QuestNoTakeOnTab.Value;
 
 		#endregion
 

--- a/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
@@ -15,4 +15,4 @@ using System.Windows;
 	ResourceDictionaryLocation.None,
 	ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("4.2.12.6")]
+[assembly: AssemblyVersion("4.2.12.7")]

--- a/source/Grabacr07.KanColleViewer/ViewModels/Contents/QuestsViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/Contents/QuestsViewModel.cs
@@ -236,7 +236,15 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents
 			{
 				{ nameof(quests.All), (sender, args) => this.UpdateQuest(quests) },
 			});
-			
+
+			KanColleSettings.QuestOnAnyTabs.Subscribe(x =>
+			{
+				this.RaisePropertyChanged(nameof(this.Quests));
+				this.RaisePropertyChanged(nameof(this.Current));
+				this.RaisePropertyChanged(nameof(this.IsEmpty));
+				this.RaisePropertyChanged(nameof(this.IsUntaken));
+			});
+
 			// set Quest Tarcker
 			questTracker = new TrackManager();
 			questTracker.QuestsEventChanged += (s, e) => this.UpdateQuest(quests);
@@ -290,11 +298,12 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents
 				questTracker.AllQuests
 					.ForEach(x =>
 					{
-						var y = viewList.FirstOrDefault(z => z.Id == x.Id);
-						if (y == null) return;
-
-						y.QuestProgressValue = x.GetProgress();
-						y.QuestProgressText = x.GetProgressText();
+						var y = viewList.Where(z => z.Id == x.Id);
+						foreach (var z in y)
+						{
+							z.QuestProgressValue = x.GetProgress();
+							z.QuestProgressText = x.GetProgressText();
+						}
 					});
 			}
 			catch { }
@@ -307,8 +316,13 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents
 			this.IsUntakenTable = quests.IsUntaken;
 
 			// Quests 멤버는 필터 적용된걸 get으로 반환해서 문제가 있음
-			_badge = OriginalQuests.Count(x => x.QuestProgressValue == 100);
+			_badge = OriginalQuests
+				.Where(x => x.QuestProgressValue == 100)
+				.Distinct(x => x.Id)
+				.Count();
+
 			this.UpdateBadge();
+			this.RaisePropertyChanged(nameof(this.Quests));
 		}
 		private QuestViewModel[] ComputeQuestPage(QuestViewModel[] inp)
 		{

--- a/source/Grabacr07.KanColleViewer/ViewModels/Contents/QuestsViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/Contents/QuestsViewModel.cs
@@ -95,7 +95,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents
 
 				if (!onAnyTabs) tabId = 0;
 
-				if (tabId == 9 && IsNoTakeOnTab)
+				if (tabId == 9 && IsOnAnyTab && IsNoTakeOnTab)
 				{
 					temp = temp
 						.Where(x => x.Tab != 9)
@@ -125,7 +125,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents
 			get
 			{
 				var tab = !IsOnAnyTab ? 0 : CurrentTab;
-				if (CurrentTab == 9 && IsNoTakeOnTab)
+				if (CurrentTab == 9 && IsOnAnyTab && IsNoTakeOnTab)
 					return this.IsUntakenTable == null
 						? true
 						: this.IsUntakenTable.Any(x => x.Value);
@@ -146,7 +146,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents
 			get
 			{
 				var tab = !IsOnAnyTab ? 0 : CurrentTab;
-				if (CurrentTab == 9 && IsNoTakeOnTab)
+				if (CurrentTab == 9 && IsOnAnyTab && IsNoTakeOnTab)
 					return this.IsEmptyTable == null
 						? false
 						: this.IsEmptyTable.All(x => x.Value);
@@ -370,7 +370,7 @@ namespace Grabacr07.KanColleViewer.ViewModels.Contents
 				.Distinct()
 				.ToArray();
 
-			if (CurrentTab != 9 || !IsNoTakeOnTab)
+			if (!(CurrentTab == 9 && IsOnAnyTab && IsNoTakeOnTab))
 			{
 				foreach (var page in pages)
 					inp.Where(x => x.Page == page)

--- a/source/Grabacr07.KanColleViewer/Views/Settings/Operation.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Settings/Operation.xaml
@@ -167,6 +167,11 @@
 				<Border Height="8" />
 				<CheckBox Content="전체 탭만이 아닌 모든 탭에서 임무를 갱신"
 						  IsChecked="{Binding Source={x:Static ms:KanColleSettings.QuestOnAnyTabs}, Path=Value}" />
+
+				<Border Height="8" />
+				<CheckBox Margin="20,0,0,0"
+						  Content="위 설정을 사용중일 때, 진행중 탭의 내용을 다른 탭에서 가져옴"
+						  IsChecked="{Binding Source={x:Static ms:KanColleSettings.QuestNoTakeOnTab}, Path=Value}" />
 			</StackPanel>
 
 			<Rectangle Style="{DynamicResource SeparatorStyleKey}" />

--- a/source/Grabacr07.KanColleWrapper/IKanColleClientSettings.cs
+++ b/source/Grabacr07.KanColleWrapper/IKanColleClientSettings.cs
@@ -32,5 +32,6 @@ namespace Grabacr07.KanColleWrapper
 		bool CheckFlagshipIsRepairShip { get; }
 
 		bool QuestOnAnyTabs { get; }
+		bool QuestNoTakeOnTab { get; }
 	}
 }


### PR DESCRIPTION
### ↯ 다운로드
- GitHub [다운로드](https://github.com/CirnoV/KanColleViewer/releases/download/v4.2.12r7/KanColleViewer-KR.4.2.12.r7.zip)
- MEGA [다운로드](https://mega.nz/#!GgpxyKYQ!h74B9RqViH9dexhpjWKvHcvgVsbEBCJG5ZhMKUoBiXQ)

### 🔗 외부 링크
- VirusTotal [검사 결과](https://www.virustotal.com/ko/file/0dfd64d96a1ccc9f84bc3ad545445bd35773d85f8a62321f7e386762ba60e667/analysis/1530256299/)
- ~~OpenDB Project Website ([http://swaytwig.com/opendb/](http://swaytwig.com/opendb/))~~ 공사중입니다.
- 업데이트 페이지 [http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html](http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html)

질문 및 건의사항은 [wolfgangkurzdev@gmail.com](mailto:wolfgangkurzdev@gmail.com) 으로 메일 부탁드립니다.
뷰어 사용중 오류가 발생하는 경우, error.log 혹은 battleinfo_error.log 를 첨부하여 메일로 제보해주시면 해결에 도움이 됩니다.

뷰어를 완전히 삭제하신 후 재설치를 해보시는 것도 방법이 될 수 있습니다.
뷰어의 각종 로그, 함대 프리셋, 전과 데이터 등을 백업하시려면, **뷰어 폴더 내의 csv 파일들과 Record 폴더를 백업**하면 됩니다.

```diff
- 갑자기 혹은 장비목록을 열 때 프로그램이 종료되면, 뷰어 폴더의 KanColleWrapper.dll 을 삭제하시기 바랍니다.
- (lib 폴더 내부에 있는 파일은 삭제하지 마세요)
- 파일이 없거나 삭제 후에도 동일한 증상이 나타난다면 메일로 문의 바랍니다.
```

----
### 💬 임무 탭
- 뷰어 업데이트 후 발생한 임무 관련한 문제들을 수정했습니다.
  * 게임의 임무 탭을 변경해도 임무 목록에 바로 반영되지 않던 문제를 수정했습니다.
  * 임무를 달성해도 목록에 임무가 남아있던 문제를 수정했습니다.
  * 종합 탭에서 임무가 중복되어 표시되던 문제를 수정했습니다.
  * 설정에 따라서 "게임안에서 [임무(퀘스트)] 화면을 열어서, 임무 목록을 갱신 해 주십시오." 메시지가 사라지지 않던 문제를 수정했습니다.
  * 임무 탭 뱃지의 갯수가 중복되어 계산되던 것을 수정했습니다.
  * 임무 추적기가 특정 탭에서만 표시되던 문제를 수정했습니다.
  * "위 설정을 사용중일 때, 진행중 탭의 내용을 다른 탭에서 가져옴" 옵션이 추가되었습니다.
    a. 이 옵션은 "전체 탭만이 아닌 모든 탭에서 임무를 갱신" 옵션을 사용중일 때에만 작동합니다.
    b. 임무 탭의 "진행중"의 목록을 게임의 "진행중" 탭이 아닌 다른 탭에서 확인한 임무 중 진행중인 임무를 가져오도록 합니다.