### PR TITLE
v4.2.12 rev9

### DIFF
--- a/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
@@ -15,4 +15,4 @@ using System.Windows;
 	ResourceDictionaryLocation.None,
 	ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("4.2.12.8")]
+[assembly: AssemblyVersion("4.2.12.9")]

--- a/source/Grabacr07.KanColleWrapper/Models/Quest.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/Quest.cs
@@ -70,6 +70,11 @@ namespace Grabacr07.KanColleWrapper.Models
 
 		public Quest(kcsapi_quest rawData) : base(rawData) { }
 
+		public void Stop()
+		{
+			this.RawData.api_state = 1;
+			this.RaisePropertyChanged(nameof(this.State));
+		}
 
 		public override string ToString()
 		{

--- a/source/Grabacr07.KanColleWrapper/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleWrapper/Properties/AssemblyInfo.cs
@@ -10,5 +10,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("8C42F9E0-E2C9-4741-8F98-653A4D275798")]
 
-[assembly: AssemblyVersion("1.7.23")]
-[assembly: AssemblyInformationalVersion("1.7.23")]
+[assembly: AssemblyVersion("1.7.24")]
+[assembly: AssemblyInformationalVersion("1.7.24")]

--- a/source/Grabacr07.KanColleWrapper/Quests.cs
+++ b/source/Grabacr07.KanColleWrapper/Quests.cs
@@ -195,10 +195,15 @@ namespace Grabacr07.KanColleWrapper
 		{
 			Quest temp;
 
-			foreach(var tab in this.questPages)
+			foreach (var tab in this.questPages)
 			{
-				foreach (var page in tab.Value) {
-					foreach(var key in page.Keys)
+				if (tab.Value == null) continue;
+
+				foreach (var page in tab.Value)
+				{
+					if (page == null) continue;
+
+					foreach (var key in page.Keys)
 					{
 						if (page[key] == null) continue;
 						if (page[key].Id == q_id)

--- a/source/Grabacr07.KanColleWrapper/Quests.cs
+++ b/source/Grabacr07.KanColleWrapper/Quests.cs
@@ -135,6 +135,18 @@ namespace Grabacr07.KanColleWrapper
 
 					ClearQuest(q_id);
 				});
+
+			proxy.ApiSessionSource
+				.Where(x => x.Request.PathAndQuery == "/kcsapi/api_req_quest/stop")
+				.TryParse()
+				.Where(x => x.IsSuccess)
+				.Subscribe(x =>
+				{
+					int q_id;
+					if (!int.TryParse(x.Request["api_quest_id"], out q_id)) return;
+
+					StopQuest(q_id);
+				});
 		}
 
 		private static kcsapi_questlist Serialize(Session session)
@@ -208,6 +220,34 @@ namespace Grabacr07.KanColleWrapper
 						if (page[key] == null) continue;
 						if (page[key].Id == q_id)
 							page.TryRemove(key, out temp);
+					}
+				}
+			}
+
+			this.All = this.questPages
+				.SelectMany(y =>
+					y.Value.Where(x => x != null)
+						.SelectMany(x => x.Select(kvp => kvp.Value))
+						.Distinct(x => x.Id)
+						.OrderBy(x => x.Id)
+				)
+				.ToList();
+		}
+		private void StopQuest(int q_id)
+		{
+			foreach (var tab in this.questPages)
+			{
+				if (tab.Value == null) continue;
+
+				foreach (var page in tab.Value)
+				{
+					if (page == null) continue;
+
+					foreach (var key in page.Keys)
+					{
+						if (page[key] == null) continue;
+						if (page[key].Id == q_id)
+							page[key].Stop();
 					}
 				}
 			}


### PR DESCRIPTION
### ↯ 다운로드
- GitHub [다운로드](https://github.com/CirnoV/KanColleViewer/releases/download/v4.2.12r9/KanColleViewer-KR.4.2.12.r9.zip)
- MEGA [다운로드](https://mega.nz/#!fhgB3IrZ!X5KdxjgY-0TgejTXYq7lnDbeyon-dmThf0AVcao-ylg)

### 🔗 외부 링크
- VirusTotal [검사 결과](https://www.virustotal.com/ko/file/06759631821f5cd399f6e395b135974843f94709de62f8983b05aeda3594867f/analysis/1530301047/)
- ~~OpenDB Project Website ([http://swaytwig.com/opendb/](http://swaytwig.com/opendb/))~~ 공사중입니다.
- 업데이트 페이지 [http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html](http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html)

질문 및 건의사항은 [wolfgangkurzdev@gmail.com](mailto:wolfgangkurzdev@gmail.com) 으로 메일 부탁드립니다.
뷰어 사용중 오류가 발생하는 경우, error.log 혹은 battleinfo_error.log 를 첨부하여 메일로 제보해주시면 해결에 도움이 됩니다.

뷰어를 완전히 삭제하신 후 재설치를 해보시는 것도 방법이 될 수 있습니다.
뷰어의 각종 로그, 함대 프리셋, 전과 데이터 등을 백업하시려면, **뷰어 폴더 내의 csv 파일들과 Record 폴더를 백업**하면 됩니다.

```diff
- 갑자기 혹은 장비목록을 열 때 프로그램이 종료되면, 뷰어 폴더의 KanColleWrapper.dll 을 삭제하시기 바랍니다.
- (lib 폴더 내부에 있는 파일은 삭제하지 마세요)
- 파일이 없거나 삭제 후에도 동일한 증상이 나타난다면 메일로 문의 바랍니다.
```

----
### 💬 임무 탭
- 뷰어 업데이트 후 발생한 임무 관련한 문제들을 수정했습니다.
  * 임무를 완료했을 때 목록에서 사라지지 않던 문제를 수정했습니다.
  * 임무를 취소했을 때 목록에서 사라지지 않던 문제를 수정했습니다.

### 💬 기타
- 사용하지 않는 파일 일부를 삭제하여 용량을 줄였습니다.
  * lib 폴더 내의 Microsoft.CodeAnalysis 로 시작하는 dll 파일을 삭제하면 됩니다.
