### PR TITLE
v4.2.12 rev10 / rev11

### DIFF
--- a/source/Grabacr07.KanColleViewer/Models/HQRecord.cs
+++ b/source/Grabacr07.KanColleViewer/Models/HQRecord.cs
@@ -1,4 +1,4 @@
-﻿using Grabacr07.KanColleWrapper;
+using Grabacr07.KanColleWrapper;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -10,6 +10,10 @@ namespace Grabacr07.KanColleViewer.Models
 {
 	public class HQRecord
 	{
+		// 로컬 타임과 무관하게 항상 UTC+9 타임존의 Now (Asia/Tokyo)
+		private static DateTime UTC9Now
+			=> DateTime.UtcNow.AddHours(9);
+
 		public class HQRecordElement
 		{
 			/// <summary>
@@ -29,7 +33,7 @@ namespace Grabacr07.KanColleViewer.Models
 
 			public HQRecordElement()
 			{
-				Date = DateTime.Now;
+				Date = UTC9Now;
 			}
 
 			public HQRecordElement(DateTime time, int level, int exp) : this()
@@ -54,7 +58,7 @@ namespace Grabacr07.KanColleViewer.Models
 		public HQRecord()
 		{
 			Record = new List<HQRecordElement>();
-			_prevTime = DateTime.Now;
+			_prevTime = UTC9Now;
 			_initialFlag = true;
 		}
 
@@ -62,7 +66,7 @@ namespace Grabacr07.KanColleViewer.Models
 		{
 			if (_initialFlag || IsCrossedHour(_prevTime))
 			{
-				_prevTime = DateTime.Now;
+				_prevTime = UTC9Now;
 				_initialFlag = false;
 
 				var admiral = KanColleClient.Current.Homeport.Admiral;
@@ -173,7 +177,7 @@ namespace Grabacr07.KanColleViewer.Models
 		/// </summary>
 		public HQRecordElement GetRecordPrevious()
 		{
-			DateTime now = DateTime.Now;
+			DateTime now = UTC9Now;
 			DateTime target;
 
 			if (now.TimeOfDay.Hours < 2)
@@ -191,7 +195,7 @@ namespace Grabacr07.KanColleViewer.Models
 		/// </summary>
 		public HQRecordElement GetRecordDay()
 		{
-			DateTime now = DateTime.Now;
+			DateTime now = UTC9Now;
 			DateTime target;
 			if (now.TimeOfDay.Hours < 2)
 				target = new DateTime(now.Year, now.Month, now.Day, 2, 0, 0).Subtract(TimeSpan.FromDays(1));
@@ -206,7 +210,7 @@ namespace Grabacr07.KanColleViewer.Models
 		/// </summary>
 		public HQRecordElement GetRecordMonth()
 		{
-			DateTime now = DateTime.Now;
+			DateTime now = UTC9Now;
 			return GetRecord(new DateTime(now.Year, now.Month, 1));
 		}
 
@@ -218,7 +222,7 @@ namespace Grabacr07.KanColleViewer.Models
 		public static bool IsCrossedHour(DateTime prev)
 		{
 			DateTime nexthour = prev.Date.AddHours(prev.Hour + 1);
-			return nexthour <= DateTime.Now;
+			return nexthour <= UTC9Now;
 		}
 
 		public static string TimeToCSVString(DateTime time)

--- a/source/Grabacr07.KanColleViewer/Models/Helper.cs
+++ b/source/Grabacr07.KanColleViewer/Models/Helper.cs
@@ -43,12 +43,12 @@ namespace Grabacr07.KanColleViewer.Models
 			var filePath = Environment.GetFolderPath(Environment.SpecialFolder.MyPictures);
 
 			if (!defaultPath)
-			{
-				filePath = Path.Combine(
-					Settings.ScreenshotSettings.Destination,
-					$"KanColle-{DateTimeOffset.Now.LocalDateTime.ToString("yyMMdd-HHmmssff")}"
-				);
-			}
+				filePath = Settings.ScreenshotSettings.Destination;
+
+			filePath = Path.Combine(
+				filePath,
+				$"KanColle-{DateTimeOffset.Now.LocalDateTime.ToString("yyMMdd-HHmmssff")}"
+			);
 
 			filePath = Path.ChangeExtension(
 				filePath,

--- a/source/Grabacr07.KanColleViewer/Models/Helper.cs
+++ b/source/Grabacr07.KanColleViewer/Models/Helper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -38,15 +38,22 @@ namespace Grabacr07.KanColleViewer.Models
 		public static bool IsInDesignMode => DesignerProperties.GetIsInDesignMode(new DependencyObject());
 
 
-		public static string CreateScreenshotFilePath()
+		public static string CreateScreenshotFilePath(bool defaultPath = false)
 		{
-			var filePath = Path.Combine(
-				Settings.ScreenshotSettings.Destination,
-				$"KanColle-{DateTimeOffset.Now.LocalDateTime.ToString("yyMMdd-HHmmssff")}");
+			var filePath = Environment.GetFolderPath(Environment.SpecialFolder.MyPictures);
+
+			if (!defaultPath)
+			{
+				filePath = Path.Combine(
+					Settings.ScreenshotSettings.Destination,
+					$"KanColle-{DateTimeOffset.Now.LocalDateTime.ToString("yyMMdd-HHmmssff")}"
+				);
+			}
 
 			filePath = Path.ChangeExtension(
 				filePath,
-				Settings.ScreenshotSettings.Format == SupportedImageFormat.Png ? ".png" : ".jpg");
+				Settings.ScreenshotSettings.Format == SupportedImageFormat.Png ? ".png" : ".jpg"
+			);
 
 			return filePath;
 		}

--- a/source/Grabacr07.KanColleViewer/Models/Helper.cs
+++ b/source/Grabacr07.KanColleViewer/Models/Helper.cs
@@ -40,13 +40,15 @@ namespace Grabacr07.KanColleViewer.Models
 
 		public static string CreateScreenshotFilePath(bool defaultPath = false)
 		{
-			var filePath = Environment.GetFolderPath(Environment.SpecialFolder.MyPictures);
+			var directory = "";
 
 			if (!defaultPath)
-				filePath = Settings.ScreenshotSettings.Destination;
+				directory = Settings.ScreenshotSettings.Destination;
+			else
+				directory= Environment.GetFolderPath(Environment.SpecialFolder.MyPictures); ;
 
-			filePath = Path.Combine(
-				filePath,
+			var filePath = Path.Combine(
+				directory,
 				$"KanColle-{DateTimeOffset.Now.LocalDateTime.ToString("yyMMdd-HHmmssff")}"
 			);
 

--- a/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
@@ -15,4 +15,4 @@ using System.Windows;
 	ResourceDictionaryLocation.None,
 	ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("4.2.12.9")]
+[assembly: AssemblyVersion("4.2.12.10")]

--- a/source/Grabacr07.KanColleViewer/ViewModels/KanColleWindowViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/KanColleWindowViewModel.cs
@@ -236,7 +236,11 @@ namespace Grabacr07.KanColleViewer.ViewModels
 			}
 		}
 
-		public void TakeScreenshot() => TakeScreenshot(false);
+		public void TakeScreenshot()
+		{
+			TakeScreenshot(false);
+		}
+
 		public void TakeScreenshot(bool defaultPath)
 		{
 			var path = Helper.CreateScreenshotFilePath(defaultPath);

--- a/source/Grabacr07.KanColleViewer/ViewModels/KanColleWindowViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/KanColleWindowViewModel.cs
@@ -236,7 +236,8 @@ namespace Grabacr07.KanColleViewer.ViewModels
 			}
 		}
 
-		public void TakeScreenshot(bool defaultPath = false)
+		public void TakeScreenshot() => TakeScreenshot(false);
+		public void TakeScreenshot(bool defaultPath)
 		{
 			var path = Helper.CreateScreenshotFilePath(defaultPath);
 			var message = new ScreenshotMessage("Screenshot.Save") { Path = path, };

--- a/source/Grabacr07.KanColleViewer/ViewModels/KanColleWindowViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/KanColleWindowViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -236,17 +236,30 @@ namespace Grabacr07.KanColleViewer.ViewModels
 			}
 		}
 
-		public void TakeScreenshot()
+		public void TakeScreenshot(bool defaultPath = false)
 		{
-			var path = Helper.CreateScreenshotFilePath();
+			var path = Helper.CreateScreenshotFilePath(defaultPath);
 			var message = new ScreenshotMessage("Screenshot.Save") { Path = path, };
 
 			this.Messenger.Raise(message);
 
-			var notify = message.Response.IsSuccess
-				? Resources.Screenshot_Saved + Path.GetFileName(path)
-				: Resources.Screenshot_Failed + message.Response.Exception.Message;
-			StatusService.Current.Notify(notify);
+			if (message.Response.IsSuccess)
+			{
+				// Succeeded
+				var notify = Resources.Screenshot_Saved + Path.GetFileName(path);
+				StatusService.Current.Notify(notify);
+			}
+			else if (!defaultPath)
+			{
+				// Retry with default directory (MyPictures)
+				TakeScreenshot(true);
+			}
+			else
+			{
+				// Failed even with default directory
+				var notify = Resources.Screenshot_Failed + message.Response.Exception.Message;
+				StatusService.Current.Notify(notify);
+			}
 		}
 
 

--- a/source/Grabacr07.KanColleViewer/Views/Controls/GraphControl.cs
+++ b/source/Grabacr07.KanColleViewer/Views/Controls/GraphControl.cs
@@ -201,8 +201,8 @@ namespace Grabacr07.KanColleViewer.Views.Controls
 					)
 				);
 
-				g.FillPath(new SolidBrush(Color.FromArgb(51, color)), path);
-				g.DrawPath(new Pen(color, 2.15f), path);
+				// g.FillPath(new SolidBrush(Color.FromArgb(51, color)), path);
+				g.DrawPath(new Pen(color, 2f), path);
 			}
 
 			if (GuideLine.HasValue)


### PR DESCRIPTION
### ↯ 다운로드
- GitHub [다운로드](https://github.com/CirnoV/KanColleViewer/releases/download/v4.2.12r11/KanColleViewer-KR.4.2.12.r11.zip)
- MEGA [다운로드](https://mega.nz/#!a4xUwCBT!n3NpkcpuSlT_sJsUyqVhHYhgrlmnZrF6pJ_RuJXWLMY)

### 🔗 외부 링크
- VirusTotal [검사 결과](https://www.virustotal.com/ko/file/8294f1e7db8c8d10f4e05bd214209b116980f3baeebd74d374b562e175816ea9/analysis/1531238912/)
- OpenDB Project Website: ([http://opendb.swaytwig.com/](http://opendb.swaytwig.com/))
- 업데이트 페이지: [http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html](http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html)

질문 및 건의사항은 [wolfgangkurzdev@gmail.com](mailto:wolfgangkurzdev@gmail.com) 으로 메일 부탁드립니다.
뷰어 사용중 오류가 발생하는 경우, error.log 혹은 battleinfo_error.log 를 첨부하여 메일로 제보해주시면 해결에 도움이 됩니다.

뷰어를 완전히 삭제하신 후 재설치를 해보시는 것도 방법이 될 수 있습니다.
뷰어의 각종 로그, 함대 프리셋, 전과 데이터 등을 백업하시려면, **뷰어 폴더 내의 csv 파일들과 Record 폴더를 백업**하면 됩니다.

```diff
- 갑자기 혹은 장비목록을 열 때 프로그램이 종료되면, 뷰어 폴더의 KanColleWrapper.dll 을 삭제하시기 바랍니다.
- (lib 폴더 내부에 있는 파일은 삭제하지 마세요)
- 파일이 없거나 삭제 후에도 동일한 증상이 나타난다면 메일로 문의 바랍니다.
```

----
### 💬 공통
- 스크린샷 문제를 수정했습니다.
  * 설정에 지정된 스크린샷 저장 폴더가 존재하지 않거나 엑세스 할 수 없는 경우, 대체 폴더인 "내 사진" 폴더에 저장되도록 하였습니다.
- 전과 기록 동작을 일부 수정했습니다.
  * 컴퓨터의 Timezone에 영향받지 않고 기록되도록 수정했습니다.
  * 기준 시각은 UTC+9, Asia/Tokyo 입니다.
  * 기존 데이터는 변경되지 않습니다.

### 💬 자원 기록 그래프
- 그래프 표시를 수정했습니다.
  * 그래프의 배경이 칠해지지 않도록 수정했습니다.

### 💬 KanColle OpenDB Plugin
- KanColle OpenDB API 의 Endpoint 가 변경에 대응했습니다.

### 💬 번역
- 전체 장비 번역을 재작성했습니다.
  * KanColle OpenDB의 장비 번역을 기준으로 재작성했습니다.
