### PR TITLE
v4.5.0 rev2

### DIFF
--- a/source/Grabacr07.KanColleViewer/Models/Helper.cs
+++ b/source/Grabacr07.KanColleViewer/Models/Helper.cs
@@ -35,14 +35,9 @@ namespace Grabacr07.KanColleViewer.Models
 		public static bool IsInDesignMode => DesignerProperties.GetIsInDesignMode(new DependencyObject());
 
 
-		public static string CreateScreenshotFilePath(SupportedImageFormat format, bool defaultPath = false)
+		public static string CreateScreenshotFilePath(SupportedImageFormat format)
 		{
-			var directory = "";
-
-			if (!defaultPath)
-				directory = Settings.ScreenshotSettings.Destination;
-			else
-				directory= Environment.GetFolderPath(Environment.SpecialFolder.MyPictures);
+			var directory = Settings.ScreenshotSettings.Destination;
 
 			var filePath = Path.Combine(
 				directory,

--- a/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
@@ -15,4 +15,5 @@ using System.Windows;
 	ResourceDictionaryLocation.None,
 	ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("4.5.0.1")]
+[assembly: AssemblyVersion("4.5.0.2")]
+// CefSharp needs https://www.microsoft.com/en-us/download/details.aspx?id=48145

--- a/source/Grabacr07.KanColleViewer/ViewModels/KanColleWindowViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/KanColleWindowViewModel.cs
@@ -238,11 +238,6 @@ namespace Grabacr07.KanColleViewer.ViewModels
 
 		public void TakeScreenshot()
 		{
-			TakeScreenshot(false);
-		}
-
-		public void TakeScreenshot(bool defaultPath)
-		{
 			var format = ScreenshotSettings.Format.Value;
 			var path = Helper.CreateScreenshotFilePath(format);
 
@@ -252,24 +247,6 @@ namespace Grabacr07.KanColleViewer.ViewModels
 				Format = format,
 			};
 			this.Messenger.Raise(message);
-
-			if (message.Response.IsSuccess)
-			{
-				// Succeeded
-				var notify = Resources.Screenshot_Saved + Path.GetFileName(path);
-				StatusService.Current.Notify(notify);
-			}
-			else if (!defaultPath)
-			{
-				// Retry with default directory (MyPictures)
-				TakeScreenshot(true);
-			}
-			else
-			{
-				// Failed even with default directory
-				var notify = Resources.Screenshot_Failed + message.Response.Exception.Message;
-				StatusService.Current.Notify(notify);
-			}
 		}
 
 

--- a/source/Grabacr07.KanColleViewer/ViewModels/Messages/ScreenshotMessage.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/Messages/ScreenshotMessage.cs
@@ -8,7 +8,7 @@ using Livet.Messaging;
 
 namespace Grabacr07.KanColleViewer.ViewModels.Messages
 {
-	internal class ScreenshotMessage : ResponsiveInteractionMessage<Processing>
+	internal class ScreenshotMessage : InteractionMessage
 	{
 		public ScreenshotMessage() { }
 		public ScreenshotMessage(string messageKey) : base(messageKey) { }
@@ -24,7 +24,6 @@ namespace Grabacr07.KanColleViewer.ViewModels.Messages
 				MessageKey = this.MessageKey,
 				Path = this.Path,
 				Format = this.Format,
-				Response = this.Response,
 			};
 		}
 	}

--- a/source/Grabacr07.KanColleViewer/Views/Behaviors/ScreenshotAction.cs
+++ b/source/Grabacr07.KanColleViewer/Views/Behaviors/ScreenshotAction.cs
@@ -29,15 +29,31 @@ namespace Grabacr07.KanColleViewer.Views.Behaviors
 				try
 				{
 					await this.TakeScreenshot(screenshotMessage.Path, screenshotMessage.Format);
-					screenshotMessage.Response = new Processing();
 					StatusService.Current.Notify(Resources.Screenshot_Saved + Path.GetFileName(screenshotMessage.Path));
 				}
 				catch (Exception ex)
 				{
-					screenshotMessage.Response = new Processing(ex);
 					StatusService.Current.Notify(Resources.Screenshot_Failed + ex.Message);
 					Application.TelemetryClient.TrackException(ex);
+
+					try
+					{
+						var dir = Environment.GetFolderPath(Environment.SpecialFolder.MyPictures);
+						var path = Path.Combine(
+							dir,
+							Path.GetFileName(screenshotMessage.Path)
+						);
+
+						await this.TakeScreenshot(path, screenshotMessage.Format);
+						StatusService.Current.Notify(Resources.Screenshot_Saved + Path.GetFileName(screenshotMessage.Path));
+					}
+					catch (Exception ex2)
+					{
+						StatusService.Current.Notify(Resources.Screenshot_Failed + ex2.Message);
+						Application.TelemetryClient.TrackException(ex2);
+					}
 				}
+				message = screenshotMessage as InteractionMessage;
 			}
 		}
 


### PR DESCRIPTION
### ↯ 다운로드
- GitHub [다운로드](https://github.com/CirnoV/KanColleViewer/releases/download/v4.5.0r2/KanColleViewer-KR.4.5.0.r2.zip)
- MEGA [다운로드](https://mega.nz/#!K1pEVIzA!A8m2O79PKKKUYkoc8eScLtPfUPVxjE8zzBXttf9KvHI)

### 🔗 외부 링크
- VirusTotal [검사 결과](https://www.virustotal.com/ko/file/e392026ce1e0a67c517cffdedad0f36485cf5156f485b4bede99e38876703f04/analysis/1536487824/)
- OpenDB Project Website: ([http://opendb.swaytwig.com/](http://opendb.swaytwig.com/))
- 업데이트 페이지: [http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html](http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html)

질문 및 건의사항은 [wolfgangkurzdev@gmail.com](mailto:wolfgangkurzdev@gmail.com) 으로 메일 부탁드립니다.
뷰어 사용중 오류가 발생하는 경우, ErrorReports 폴더 내의 로그 파일 혹은 battleinfo_error.log 를 첨부하여 메일로 제보해주시면 해결에 도움이 됩니다.

뷰어를 완전히 삭제하신 후 재설치를 해보시는 것도 방법이 될 수 있습니다.
뷰어의 각종 로그, 함대 프리셋, 전과 데이터 등을 백업하시려면, **뷰어 폴더 내의 csv 파일들과 Record 폴더를 백업**하면 됩니다.

```diff
- 갑자기 혹은 장비목록을 열 때 프로그램이 종료되면, 뷰어 폴더의 KanColleWrapper.dll 을 삭제하시기 바랍니다.
- (lib 폴더 내부에 있는 파일은 삭제하지 마세요)
- 파일이 없거나 삭제 후에도 동일한 증상이 나타난다면 메일로 문의 바랍니다.
```

> 프로그램이 시작되지 않는 경우, 설치/업데이트 이후 뷰어 폴더 내에 추가된 "Visual Studio 2015용 Visual C++ 재배포 가능 패키지 (x86 설치)" 링크를 따라 설치해보시기 바랍니다.
> 또는 다음 링크를 따라 설치하시기 바랍니다. (x86 버전을 설치해야 합니다)
> https://www.microsoft.com/ko-kr/download/details.aspx?id=48145

----
### 💬 공통
- 스크린샷 버튼을 누를 시 프로그램이 비정상적으로 종료되던 문제를 수정했습니다.
