### PR TITLE
v4.5.0 rev3

### DIFF
--- a/source/Grabacr07.KanColleViewer/App.config
+++ b/source/Grabacr07.KanColleViewer/App.config
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <configSections>
         <sectionGroup name="applicationSettings" type="System.Configuration.ApplicationSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-            <section name="Grabacr07.KanColleViewer.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
+            <section name="Grabacr07.KanColleViewer.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
         </sectionGroup>
         <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-            <section name="Grabacr07.KanColleViewer.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false"/>
+            <section name="Grabacr07.KanColleViewer.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
         </sectionGroup>
     </configSections>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
     </startup>
     <applicationSettings>
         <Grabacr07.KanColleViewer.Properties.Settings>
@@ -55,25 +55,25 @@
     </applicationSettings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<probing privatePath="lib"/>
+			<probing privatePath="lib" />
 			<dependentAssembly>
-        <assemblyIdentity name="System.Reactive.Core" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.2.4.0" newVersion="2.2.4.0"/>
+        <assemblyIdentity name="System.Reactive.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.4.0" newVersion="2.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reactive.Interfaces" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.2.4.0" newVersion="2.2.4.0"/>
+        <assemblyIdentity name="System.Reactive.Interfaces" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.4.0" newVersion="2.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reactive.Linq" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.2.4.0" newVersion="2.2.4.0"/>
+        <assemblyIdentity name="System.Reactive.Linq" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.4.0" newVersion="2.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Livet" publicKeyToken="b0b1d3f711ef38cb" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0"/>
+        <assemblyIdentity name="Livet" publicKeyToken="b0b1d3f711ef38cb" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
       </dependentAssembly>
     </assemblyBinding>
-		<loadFromRemoteSources enabled="true"/>
+		<loadFromRemoteSources enabled="true" />
 	</runtime>
   <userSettings>
     <Grabacr07.KanColleViewer.Properties.Settings>

--- a/source/Grabacr07.KanColleViewer/Application.Static.cs
+++ b/source/Grabacr07.KanColleViewer/Application.Static.cs
@@ -48,11 +48,16 @@ namespace Grabacr07.KanColleViewer
 			cefSettings.CefCommandLineArgs.Add("proxy-server", Models.Settings.NetworkSettings.LocalProxySettingsString);
 			cefSettings.BrowserSubprocessPath = @"lib\CefSharp.BrowserSubprocess.exe";
 			cefSettings.Locale = "ko-KR";
-			//cefSettings.CefCommandLineArgs.Add("disable-webgl", "1");
+			// cefSettings.LogSeverity = LogSeverity.Verbose;
+			// cefSettings.CefCommandLineArgs.Add("disable-webgl", "1");
+			// cefSettings.CefCommandLineArgs.Add("disable-gpu", "1");
+			// cefSettings.CefCommandLineArgs.Add("disable-gpu-vsync", "1");
+			// cefSettings.CefCommandLineArgs.Add("disable-gpu-compositing", "1");
+			// cefSettings.SetOffScreenRenderingBestPerformanceArgs();
 			CefSharpSettings.SubprocessExitIfParentProcessClosed = true;
 
 			Cef.EnableHighDPISupport();
-			Cef.Initialize(cefSettings);
+			Cef.Initialize(cefSettings, performDependencyCheck: false, browserProcessHandler: null);
 		}
 
 		/// <summary>

--- a/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
@@ -15,5 +15,5 @@ using System.Windows;
 	ResourceDictionaryLocation.None,
 	ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("4.5.0.2")]
+[assembly: AssemblyVersion("4.5.0.3")]
 // CefSharp needs https://www.microsoft.com/en-us/download/details.aspx?id=48145

--- a/source/Grabacr07.KanColleViewer/Views/Catalogs/ShipCatalogWindow.xaml
+++ b/source/Grabacr07.KanColleViewer/Views/Catalogs/ShipCatalogWindow.xaml
@@ -92,6 +92,7 @@
 			<Grid.RowDefinitions>
 				<RowDefinition Height="Auto" />
 				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" />
 				<RowDefinition />
 			</Grid.RowDefinitions>
 
@@ -656,6 +657,47 @@
 			</Expander>
 
 			<Border Grid.Row="2"
+					BorderThickness=".99"
+					BorderBrush="{DynamicResource BorderBrushKey}"
+					Padding="5"
+					Margin="8">
+
+				<Grid>
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="Auto" />
+						<ColumnDefinition Width="*" />
+					</Grid.ColumnDefinitions>
+					<Grid.RowDefinitions>
+						<RowDefinition Height="Auto" />
+						<RowDefinition Height="Auto" />
+					</Grid.RowDefinitions>
+
+					<TextBlock Grid.Column="0"
+							   Margin="0,0,5,0"
+							   VerticalAlignment="Center"
+							   Text="함대표시 코드:" />
+					<metro:PromptTextBox Grid.Column="1"
+										 VerticalAlignment="Center"
+										 IsReadOnly="True"
+										 Prompt="함대표시 코드"
+										 Text="{Binding FleetDisplayData, Mode=OneWay}" />
+
+					<TextBlock Grid.Row="1"
+							   Grid.ColumnSpan="2"
+							   Margin="0,2,0,0"
+							   FontSize="11"
+							   Opacity="0.66">
+					<Run Text="* 함대표시 코드는 보유중인 함선 목록을 각종 사이트/프로그램에 사용할 수 있도록 가공한 형태입니다." />
+					<LineBreak/>
+					<Run Text="* 이벤트에 사용되는 함선 목록 정보:" />
+					<metro2:HyperlinkEx Uri="https://flatisjustice.moe/eventlist">
+						<Run Text="https://flatisjustice.moe/eventlist" />
+					</metro2:HyperlinkEx>
+					</TextBlock>
+				</Grid>
+			</Border>
+
+			<Border Grid.Row="3"
 					BorderBrush="{DynamicResource BorderBrushKey}"
 					BorderThickness=".99"
 					Margin="8">
@@ -2451,7 +2493,7 @@
 				</ListView>
 			</Border>
 
-			<Border Grid.Row="2"
+			<Border Grid.Row="3"
 					Background="{DynamicResource ThemeBrushKey}"
 					BorderBrush="{DynamicResource BorderBrushKey}"
 					BorderThickness=".99"

--- a/source/Grabacr07.KanColleViewer/packages.config
+++ b/source/Grabacr07.KanColleViewer/packages.config
@@ -2,8 +2,8 @@
 <packages>
   <package id="cef.redist.x64" version="3.3396.1786" targetFramework="net46" />
   <package id="cef.redist.x86" version="3.3396.1786" targetFramework="net46" />
-  <package id="CefSharp.Common" version="67.0.0-pre01" targetFramework="net46" />
-  <package id="CefSharp.Wpf" version="67.0.0-pre01" targetFramework="net46" />
+  <package id="CefSharp.Common" version="67.0.0-pre01" targetFramework="net462" />
+  <package id="CefSharp.Wpf" version="67.0.0-pre01" targetFramework="net462" />
   <package id="LivetCask" version="1.3.1.0" targetFramework="net45" />
   <package id="LivetExtensions" version="1.1.0.0" targetFramework="net45" />
   <package id="log4net" version="2.0.3" targetFramework="net45" />

--- a/source/Grabacr07.KanColleWrapper/KanColleWrapper.csproj
+++ b/source/Grabacr07.KanColleWrapper/KanColleWrapper.csproj
@@ -185,6 +185,7 @@
     <Compile Include="Models\SlotItemEquipType.cs" />
     <Compile Include="Models\SlotItemStat.cs" />
     <Compile Include="Models\SlotItemType.cs" />
+    <Compile Include="Models\TranslationRequest.cs" />
     <Compile Include="Models\TranslationType.cs" />
     <Compile Include="Models\ViewRange.cs" />
     <Compile Include="Models\WebTranslator.cs" />

--- a/source/Grabacr07.KanColleWrapper/Models/TranslationRequest.cs
+++ b/source/Grabacr07.KanColleWrapper/Models/TranslationRequest.cs
@@ -1,0 +1,54 @@
+using Grabacr07.KanColleWrapper.Models;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Grabacr07.KanColleWrapper
+{
+	public partial class Translations
+	{
+		private const string RequestTranslationURL = "http://swaytwig.com/kcvkr/request.php";
+
+		private void RequestTranslation(TranslationType Type, string Source)
+		{
+			HttpWebRequest request = HttpWebRequest.Create(RequestTranslationURL) as HttpWebRequest;
+			WebResponse response;
+			Stream writer;
+
+			try
+			{
+				var postBytes = Encoding.UTF8.GetBytes($"type={(int)Type}&source={WebUtility.UrlEncode(Source)}");
+				request.Method = "POST";
+				request.ServicePoint.Expect100Continue = false;
+				request.ContentType = "application/x-www-form-urlencoded";
+
+				writer = request.GetRequestStream();
+				writer.Write(postBytes, 0, postBytes.Length);
+				writer.Flush();
+				writer.Close();
+
+				request.BeginGetResponse(new AsyncCallback((x) =>
+				{
+					response = request.EndGetResponse(x);
+
+#if DEBUG
+					try {
+						var resp = response.GetResponseStream();
+						Debug.WriteLine($"Translate requested: {Source}");
+						Debug.WriteLine("Translate request result: " + new StreamReader(resp).ReadToEnd());
+					}
+					catch  { }
+#endif
+
+					response.Close();
+				}), null);
+			}
+			catch { }
+		}
+	}
+}

--- a/source/Grabacr07.KanColleWrapper/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleWrapper/Properties/AssemblyInfo.cs
@@ -11,4 +11,4 @@ using System.Runtime.InteropServices;
 [assembly: Guid("8C42F9E0-E2C9-4741-8F98-653A4D275798")]
 
 [assembly: AssemblyVersion("1.7.27")]
-[assembly: AssemblyInformationalVersion("1.7.27")]
+[assembly: AssemblyInformationalVersion("1.7.28")]

--- a/source/Grabacr07.KanColleWrapper/Translations.cs
+++ b/source/Grabacr07.KanColleWrapper/Translations.cs
@@ -12,7 +12,7 @@ using System.Xml.Linq;
 
 namespace Grabacr07.KanColleWrapper
 {
-	public class Translations
+	public partial class Translations
 	{
 		private XDocument ShipsXML;//0
 		private XDocument ShipTypesXML;//1
@@ -119,11 +119,14 @@ namespace Grabacr07.KanColleWrapper
 			if (QuestsXML != null)
 				if (QuestsXML.Root.Attribute("Version") != null) QuestsVersion = QuestsXML.Root.Attribute("Version").Value;
 				else QuestsVersion = "알 수 없음";
+			else
+				QuestsVersion = "없음";
+
 			if (ExpeditionXML != null)
 				if (ExpeditionXML.Root.Attribute("Version") != null) ExpeditionsVersion = ExpeditionXML.Root.Attribute("Version").Value;
 				else ExpeditionsVersion = "알 수 없음";
 			else
-				QuestsVersion = "없음";
+				ExpeditionsVersion = "없음";
 
 			if (RemodelXml != null)
 				if (RemodelXml.Root.Attribute("Version") != null) RemodelSlotsVersion = RemodelXml.Root.Attribute("Version").Value;
@@ -142,6 +145,16 @@ namespace Grabacr07.KanColleWrapper
 				else UseitemsVersion = "알 수 없음";
 			else
 				UseitemsVersion = "없음";
+		}
+
+		public void Reload()
+		{
+			try
+			{
+				LoadXmls();
+				GetVersions();
+			}
+			catch { }
 		}
 
 		private IEnumerable<XElement> GetTranslationList(TranslationType Type)
@@ -385,6 +398,7 @@ namespace Grabacr07.KanColleWrapper
 							new XElement("JP-Name", ShipData.api_name),
 							new XElement("TR-Name", KanColleClient.Current.WebTranslator.RawTranslate(ShipData.api_name))
 						));
+						RequestTranslation(Type, ShipData.api_name);
 
 						SaveXmls(0);
 						break;
@@ -405,7 +419,8 @@ namespace Grabacr07.KanColleWrapper
 							new XElement("ID", TypeData.api_id),
 							new XElement("JP-Name", TypeData.api_name),
 							new XElement("TR-Name", KanColleClient.Current.WebTranslator.RawTranslate(TypeData.api_name))
-							));
+						));
+						RequestTranslation(Type, TypeData.api_name);
 
 						SaveXmls(1);
 						break;
@@ -425,31 +440,33 @@ namespace Grabacr07.KanColleWrapper
 						EquipmentXML.Root.Add(new XElement("Item",
 							new XElement("JP-Name", EqiupData.api_name),
 							new XElement("TR-Name", KanColleClient.Current.WebTranslator.RawTranslate(EqiupData.api_name))
-							));
+						));
+						RequestTranslation(Type, EqiupData.api_name);
 
 						SaveXmls(2);
 						break;
-                    case TranslationType.EquipmentTypes:
-                        if (EquipmentTypesXML == null)
-                        {
-                            EquipmentTypesXML = new XDocument();
-                            EquipmentTypesXML.Add(new XElement("EquipmentTypes"));
-                        }
+					case TranslationType.EquipmentTypes:
+						if (EquipmentTypesXML == null)
+						{
+							EquipmentTypesXML = new XDocument();
+							EquipmentTypesXML.Add(new XElement("EquipmentTypes"));
+						}
 
-                        kcsapi_mst_slotitem_equiptype EqiupTypeData = RawData as kcsapi_mst_slotitem_equiptype;
+						kcsapi_mst_slotitem_equiptype EqiupTypeData = RawData as kcsapi_mst_slotitem_equiptype;
 
-                        if (EqiupTypeData == null)
-                            return;
+						if (EqiupTypeData == null)
+							return;
 
-                        EquipmentTypesXML.Root.Add(new XElement("Item",
-                            new XElement("JP-Name", EqiupTypeData.api_name),
-                            new XElement("TR-Name", KanColleClient.Current.WebTranslator.RawTranslate(EqiupTypeData.api_name))
-                            ));
+						EquipmentTypesXML.Root.Add(new XElement("Item",
+							new XElement("JP-Name", EqiupTypeData.api_name),
+							new XElement("TR-Name", KanColleClient.Current.WebTranslator.RawTranslate(EqiupTypeData.api_name))
+						));
+						RequestTranslation(Type, EqiupTypeData.api_name);
 
-                        SaveXmls(7);
-                        break;
+						SaveXmls(7);
+						break;
 
-                    case TranslationType.OperationMaps:
+					case TranslationType.OperationMaps:
 					case TranslationType.OperationSortie:
 						if (OperationsXML == null)
 						{
@@ -467,14 +484,16 @@ namespace Grabacr07.KanColleWrapper
 							OperationsXML.Root.Add(new XElement("Map",
 								new XElement("JP-Name", OperationsData.api_quest_name),
 								new XElement("TR-Name", KanColleClient.Current.WebTranslator.RawTranslate(OperationsData.api_quest_name))
-								));
+							));
+							RequestTranslation(Type, OperationsData.api_quest_name);
 						}
 						else
 						{
 							OperationsXML.Root.Add(new XElement("Sortie",
 								new XElement("JP-Name", OperationsData.api_enemy_info.api_deck_name),
 								new XElement("TR-Name", KanColleClient.Current.WebTranslator.RawTranslate(OperationsData.api_enemy_info.api_deck_name))
-								));
+							));
+							RequestTranslation(Type, OperationsData.api_enemy_info.api_deck_name);
 						}
 
 						SaveXmls(3);
@@ -511,7 +530,8 @@ namespace Grabacr07.KanColleWrapper
 								new XElement("TR-Name", "[" + QuestData.api_no.ToString() + "]" + KanColleClient.Current.WebTranslator.RawTranslate(QuestData.api_title)),
 								new XElement("JP-Detail", QuestData.api_detail),
 								new XElement("TR-Detail", "[" + QuestData.api_no.ToString() + "]" + KanColleClient.Current.WebTranslator.RawTranslate(QuestData.api_detail))
-								));
+							));
+							RequestTranslation(Type, $"{QuestData.api_no}::{QuestData.api_title}::{QuestData.api_detail}");
 						}
 
 						SaveXmls(4);
@@ -541,12 +561,13 @@ namespace Grabacr07.KanColleWrapper
 						{
 							// The quest doesn't exist at all. Add it.
 							ExpeditionXML.Root.Add(new XElement("Expedition",
-							new XElement("ID", MissionData.api_id),
-							new XElement("JP-Name", MissionData.api_name),
-							new XElement("TR-Name", "[" + MissionData.api_id.ToString() + "]" + KanColleClient.Current.WebTranslator.RawTranslate(MissionData.api_name)),
-							new XElement("JP-Detail", MissionData.api_details),
-							new XElement("TR-Detail", "[" + MissionData.api_id.ToString() + "]" + KanColleClient.Current.WebTranslator.RawTranslate(MissionData.api_details))
+								new XElement("ID", MissionData.api_id),
+								new XElement("JP-Name", MissionData.api_name),
+								new XElement("TR-Name", "[" + MissionData.api_id.ToString() + "]" + KanColleClient.Current.WebTranslator.RawTranslate(MissionData.api_name)),
+								new XElement("JP-Detail", MissionData.api_details),
+								new XElement("TR-Detail", "[" + MissionData.api_id.ToString() + "]" + KanColleClient.Current.WebTranslator.RawTranslate(MissionData.api_details))
 							));
+							RequestTranslation(Type, $"{MissionData.api_id}::{MissionData.api_name}::{MissionData.api_details}");
 						}
 
 						SaveXmls(5);
@@ -555,6 +576,5 @@ namespace Grabacr07.KanColleWrapper
 			}
 			catch { }
 		}
-
 	}
 }

--- a/source/Grabacr07.KanColleWrapper/Updater.cs
+++ b/source/Grabacr07.KanColleWrapper/Updater.cs
@@ -181,7 +181,6 @@ namespace Grabacr07.KanColleWrapper
 						Client.DownloadFile(BaseTranslationURL + "Useitems.xml", Path.Combine(MainFolder, "Translations", "tmp", "Useitems.xml"));
 						ReturnValue = XmlFileWizard(MainFolder, "Useitems.xml", TranslationType.Useitems);
 					}
-
 				}
 				catch
 				{
@@ -190,6 +189,8 @@ namespace Grabacr07.KanColleWrapper
 				}
 				if (Directory.Exists(Path.Combine(MainFolder, "Translations", "tmp")))
 					Directory.Delete(Path.Combine(MainFolder, "Translations", "tmp"), true);
+
+				KanColleClient.Current.Translations.Reload();
 
 				return ReturnValue;
 			}
@@ -255,7 +256,7 @@ namespace Grabacr07.KanColleWrapper
 			IEnumerable<XElement> Versions = VersionXML.Root.Descendants("Item");
 			string ElementName = "Version";
 			if (LocalVersionString == "알 수 없음") return false;
-			else if (LocalVersionString == "없음") return false;
+			else if (LocalVersionString == "없음") return true;
 			Version LocalVersion = new Version(LocalVersionString);
 
 

--- a/source/Plugins/WindowsNotifier/app.config
+++ b/source/Plugins/WindowsNotifier/app.config
@@ -1,31 +1,31 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
     <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-      <section name="Grabacr07.KanColleViewer.Plugins.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false"/>
+      <section name="Grabacr07.KanColleViewer.Plugins.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
     </sectionGroup>
   </configSections>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Reactive.Interfaces" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.2.4.0" newVersion="2.2.4.0"/>
+        <assemblyIdentity name="System.Reactive.Interfaces" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.4.0" newVersion="2.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reactive.Core" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.2.4.0" newVersion="2.2.4.0"/>
+        <assemblyIdentity name="System.Reactive.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.4.0" newVersion="2.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reactive.Linq" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.2.4.0" newVersion="2.2.4.0"/>
+        <assemblyIdentity name="System.Reactive.Linq" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.4.0" newVersion="2.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Livet" publicKeyToken="b0b1d3f711ef38cb" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0"/>
+        <assemblyIdentity name="Livet" publicKeyToken="b0b1d3f711ef38cb" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/></startup><userSettings>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" /></startup><userSettings>
     <Grabacr07.KanColleViewer.Plugins.Properties.Settings>
       <setting name="CustomVolume" serializeAs="String">
         <value>99</value>


### PR DESCRIPTION
### ↯ 다운로드
- GitHub [다운로드](https://github.com/CirnoV/KanColleViewer/releases/download/v4.5.0r3/KanColleViewer-KR.4.5.0.r3.zip)
- MEGA [다운로드](https://mega.nz/#!qwYwiIBb!ic_X-7f9uKAEDNwT5jTMQXDqGTSgyfqcrZJfdB9M05Y)

### 🔗 외부 링크
- VirusTotal [검사 결과](https://www.virustotal.com/ko/file/204fd56383a9feae7f1a5993d8051c1f1136fda32463e3a8e59fe447b66ed2c0/analysis/1545764740/)
- OpenDB Project Website: ([http://opendb.swaytwig.com/](http://opendb.swaytwig.com/))
- 업데이트 페이지: [http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html](http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html)

질문 및 건의사항은 [wolfgangkurzdev@gmail.com](mailto:wolfgangkurzdev@gmail.com) 으로 메일 부탁드립니다.
뷰어 사용중 오류가 발생하는 경우, ErrorReports 폴더 내의 로그 파일 혹은 battleinfo_error.log 를 첨부하여 메일로 제보해주시면 해결에 도움이 됩니다.

뷰어를 완전히 삭제하신 후 재설치를 해보시는 것도 방법이 될 수 있습니다.
뷰어의 각종 로그, 함대 프리셋, 전과 데이터 등을 백업하시려면, **뷰어 폴더 내의 csv 파일들과 Record 폴더를 백업**하면 됩니다.

```diff
- 갑자기 혹은 장비목록을 열 때 프로그램이 종료되면, 뷰어 폴더의 KanColleWrapper.dll 을 삭제하시기 바랍니다.
- (lib 폴더 내부에 있는 파일은 삭제하지 마세요)
- 파일이 없거나 삭제 후에도 동일한 증상이 나타난다면 메일로 문의 바랍니다.
```

> 프로그램이 시작되지 않는 경우, 설치/업데이트 이후 뷰어 폴더 내에 추가된 "Visual Studio 2015용 Visual C++ 재배포 가능 패키지 (x86 설치)" 링크를 따라 설치해보시기 바랍니다.
> 또는 다음 링크를 따라 설치하시기 바랍니다. (x86 버전을 설치해야 합니다)
> https://www.microsoft.com/ko-kr/download/details.aspx?id=48145

----
### 💬 공통
- 번역 파일 업데이트 기능의 문제를 수정했습니다.
  * 번역 파일이 없을 때, 번역 업데이트가 제대로 이루어지지 않는 문제가 수정되었습니다.
  * 번역 파일 업데이트 후, 해당 번역이 제대로 반영되지 않는 문제를 수정했습니다.
- 번역되지 않은 텍스트의 보고 기능이 추가되었습니다.
  * 신규/누락 텍스트의 번역을 원활하게 할 수 있도록 추가된 기능입니다.
  * 번역되지 않은 원본 텍스트를 제외한 정보는 전송되지 않습니다.

### 💬 함선 목록 창
- 함대 표시 코드가 추가되었습니다.
  * 함대표시 코드는 보유중인 함선 목록을 각종 사이트/프로그램에 사용할 수 있도록 가공한 형태입니다.
  * 이벤트에 사용되는 함선 목록 정보: https://flatisjustice.moe/eventlist
