### PR TITLE
v4.5.0 rev4

### DIFF
--- a/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
+++ b/source/Grabacr07.KanColleViewer/Properties/AssemblyInfo.cs
@@ -15,5 +15,5 @@ using System.Windows;
 	ResourceDictionaryLocation.None,
 	ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("4.5.0.3")]
+[assembly: AssemblyVersion("4.5.0.4")]
 // CefSharp needs https://www.microsoft.com/en-us/download/details.aspx?id=48145

--- a/source/Grabacr07.KanColleViewer/ViewModels/NavigatorViewModel.cs
+++ b/source/Grabacr07.KanColleViewer/ViewModels/NavigatorViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -159,7 +159,7 @@ namespace Grabacr07.KanColleViewer.ViewModels
 		public void GoKanColle()
 		{
 			Uri uri;
-			string SauceCookie = "javascript:void(eval(\"document.cookie = 'cklg=ja;expires=Sun, 09 Feb 2019 09:00:09 GMT;domain=dmm.com;path=/';document.cookie = 'ckcy=1;expires=Sun, 09 Feb 2019 09:00:09 GMT;domain=osapi.dmm.com;path=/';document.cookie = 'ckcy=1;expires=Sun, 09 Feb 2019 09:00:09 GMT;domain=203.104.209.7;path=/';document.cookie = 'ckcy=1;expires=Sun, 09 Feb 2019 09:00:09 GMT;domain=www.dmm.com;path=/netgame/';\"));location.href=\"http://www.dmm.com/netgame/social/-/gadgets/=/app_id=854854/\";";
+			string SauceCookie = "javascript:void(eval(\"document.cookie = 'cklg=ja;expires=Sun, 09 Feb 2100 09:00:09 GMT;domain=dmm.com;path=/';document.cookie = 'ckcy=1;expires=Sun, 09 Feb 2100 09:00:09 GMT;domain=osapi.dmm.com;path=/';document.cookie = 'ckcy=1;expires=Sun, 09 Feb 2100 09:00:09 GMT;domain=203.104.209.7;path=/';document.cookie = 'ckcy=1;expires=Sun, 09 Feb 2100 09:00:09 GMT;domain=www.dmm.com;path=/netgame/';\"));location.href=\"http://www.dmm.com/netgame/social/-/gadgets/=/app_id=854854/\";";
 			if (this.UriRequested != null && Uri.TryCreate(SauceCookie, UriKind.Absolute, out uri))
 			{
 				this.UriRequested(this, uri);


### PR DESCRIPTION
### ↯ 다운로드
- GitHub [다운로드](https://github.com/CirnoV/KanColleViewer/releases/download/v4.5.0r4/KanColleViewer-KR.4.5.0.r4.zip)
- MEGA [다운로드](https://mega.nz/#!DwoyUYbA!qiGQ_CJeKFeBa-rl8SP53-sV-FHmhuOq1ZBtD3KCujE)

### 🔗 외부 링크
- VirusTotal [검사 결과](https://www.virustotal.com/ko/file/a6d2daa991181390ce3dba4cfbd4c1683ccaa4b31095a6bf7d8a929284eec1f9/analysis/1550650765/)
- OpenDB Project Website: ([http://opendb.swaytwig.com/](http://opendb.swaytwig.com/))
- 업데이트 페이지: [http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html](http://wolfgangkurz.github.io/KanColleAssets/kcvkr.html)

질문 및 건의사항은 [wolfgangkurzdev@gmail.com](mailto:wolfgangkurzdev@gmail.com) 으로 메일 부탁드립니다.
뷰어 사용중 오류가 발생하는 경우, ErrorReports 폴더 내의 로그 파일 혹은 battleinfo_error.log 를 첨부하여 메일로 제보해주시면 해결에 도움이 됩니다.

뷰어를 완전히 삭제하신 후 재설치를 해보시는 것도 방법이 될 수 있습니다.
뷰어의 각종 로그, 함대 프리셋, 전과 데이터 등을 백업하시려면, **뷰어 폴더 내의 csv 파일들과 Record 폴더를 백업**하면 됩니다.

```diff
- 갑자기 혹은 장비목록을 열 때 프로그램이 종료되면, 뷰어 폴더의 KanColleWrapper.dll 을 삭제하시기 바랍니다.
- (lib 폴더 내부에 있는 파일은 삭제하지 마세요)
- 파일이 없거나 삭제 후에도 동일한 증상이 나타난다면 메일로 문의 바랍니다.
```

> 프로그램이 시작되지 않는 경우, 설치/업데이트 이후 뷰어 폴더 내에 추가된 "Visual Studio 2015용 Visual C++ 재배포 가능 패키지 (x86 설치)" 링크를 따라 설치해보시기 바랍니다.
> 또는 다음 링크를 따라 설치하시기 바랍니다. (x86 버전을 설치해야 합니다)
> https://www.microsoft.com/ko-kr/download/details.aspx?id=48145

----
### 💬 공통
- 쿠키 만료 기한을 2100년으로 변경했습니다.
